### PR TITLE
add new nginx versions to CircleCI builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,6 +84,34 @@ workflows:
   build-and-test-all:
     jobs:
     - build:
+        name: "build 1.23.2-alpine"
+        build-image: "datadog/docker-library:nginx-datadog-build-1.23.2-alpine"
+        nginx-tag: "1.23.2-alpine"
+        filters:
+          tags:
+            only: /^v[0-9]+\.[0-9]+\.[0-9]+/
+    - test:
+        name: "test 1.23.2-alpine"
+        requires:
+        - "build 1.23.2-alpine"
+        filters:
+          tags:
+            only: /^v[0-9]+\.[0-9]+\.[0-9]+/
+    - build:
+        name: "build 1.23.2"
+        build-image: "datadog/docker-library:nginx-datadog-build-1.23.2"
+        nginx-tag: "1.23.2"
+        filters:
+          tags:
+            only: /^v[0-9]+\.[0-9]+\.[0-9]+/
+    - test:
+        name: "test 1.23.2"
+        requires:
+        - "build 1.23.2"
+        filters:
+          tags:
+            only: /^v[0-9]+\.[0-9]+\.[0-9]+/
+    - build:
         name: "build 1.23.1-alpine"
         build-image: "datadog/docker-library:nginx-datadog-build-1.23.1-alpine"
         nginx-tag: "1.23.1-alpine"
@@ -136,6 +164,34 @@ workflows:
         name: "test 1.23.0"
         requires:
         - "build 1.23.0"
+        filters:
+          tags:
+            only: /^v[0-9]+\.[0-9]+\.[0-9]+/
+    - build:
+        name: "build 1.22.1-alpine"
+        build-image: "datadog/docker-library:nginx-datadog-build-1.22.1-alpine"
+        nginx-tag: "1.22.1-alpine"
+        filters:
+          tags:
+            only: /^v[0-9]+\.[0-9]+\.[0-9]+/
+    - test:
+        name: "test 1.22.1-alpine"
+        requires:
+        - "build 1.22.1-alpine"
+        filters:
+          tags:
+            only: /^v[0-9]+\.[0-9]+\.[0-9]+/
+    - build:
+        name: "build 1.22.1"
+        build-image: "datadog/docker-library:nginx-datadog-build-1.22.1"
+        nginx-tag: "1.22.1"
+        filters:
+          tags:
+            only: /^v[0-9]+\.[0-9]+\.[0-9]+/
+    - test:
+        name: "test 1.22.1"
+        requires:
+        - "build 1.22.1"
         filters:
           tags:
             only: /^v[0-9]+\.[0-9]+\.[0-9]+/

--- a/bin/generate_jobs_yaml.sh
+++ b/bin/generate_jobs_yaml.sh
@@ -14,10 +14,14 @@ cd "$REPO"
 # Here are the supported nginx tags.
 supported_nginx_tags=$(mktemp)
 >"$supported_nginx_tags" cat <<END_NGINX_TAGS
+1.23.2-alpine
+1.23.2
 1.23.1-alpine
 1.23.1
 1.23.0-alpine
 1.23.0
+1.22.1-alpine
+1.22.1
 1.22.0-alpine
 1.22.0
 1.21.6-alpine


### PR DESCRIPTION
Support nginx versions 1.23.2 and 1.22.1. See "19 Oct 2022" in <http://nginx.org/en/CHANGES>.