### PR TITLE
make builds compatible with MacOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ clobber: clean
 
 .PHONY: build-in-docker
 build-in-docker: sources
-	bin/run_in_build_image.sh $(MAKE) BUILD_DIR=.docker-build build
+	bin/run_in_build_image.sh make BUILD_DIR=.docker-build build
 
 .PHONY: test
 test: build-in-docker

--- a/Makefile
+++ b/Makefile
@@ -70,8 +70,9 @@ clean:
 .PHONY: clobber
 clobber: clean
 	rm -rf \
-	    nginx \
-		dd-opentracing-cpp/deps
+		nginx \
+		dd-opentracing-cpp/deps \
+		dd-opentracing-cpp/CMakeFiles
 
 .PHONY: build-in-docker
 build-in-docker: sources

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ specified as `BASE_IMAGE` in the `./nginx-version-info` file, (e.g.
 `nginx:1.19.1-alpine`) and with the nginx source version specified as
 `NGINX_VERSION` in the `./nginx-version-info` file (e.g. `1.19.1`).  The
 appropriate build image must be created first using the
-[bin/docker-build.sh](bin/docker-build.sh) script if it does not exist already.
+[bin/docker_build.sh](bin/docker_build.sh) script if it does not exist already.
 Once the image is built, `make build-in-docker` produces the nginx module as
 `.docker-build/libngx_http_datadog_module.so`.
 

--- a/bin/nginx_release_downloads.sh
+++ b/bin/nginx_release_downloads.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Print lines:
 #
@@ -14,7 +14,7 @@
 
 downloads=https://nginx.org/download
 
-if [[ "$OSTYPE" == "darwin"* ]]; then
+if [ "$(uname)" = 'Darwin' ]; then
   SED='gsed'
 else
   SED='sed'

--- a/bin/nginx_release_downloads.sh
+++ b/bin/nginx_release_downloads.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Print lines:
 #
@@ -14,6 +14,12 @@
 
 downloads=https://nginx.org/download
 
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  SED='gsed'
+else
+  SED='sed'
+fi
+
 if [ $# -gt 1 ]; then
     >&2 printf 'At most one argument supported, but %d were specified.\n' $#
     exit 1
@@ -21,15 +27,15 @@ fi
 
 filter() {
     if [ $# -eq 1 ]; then
-        grep "^$(echo "$1" | sed 's/\./\\./g')[. ]" | tail -1 | awk '{print $2}'
+        grep "^$(echo "$1" | $SED 's/\./\\./g')[. ]" | tail -1 | awk '{print $2}'
     else
         cat
     fi
 }
 
 curl -s -S -L "$downloads" | \
-    sed -n 's/^.*href="\([^"]\+\)".*$/\1/p' | \
+    $SED -n 's/^.*href="\([^"]\+\)".*$/\1/p' | \
     grep '^nginx-.*\.tar\.gz$' | \
-    sed "s,^nginx-\(.*\)\.tar\.gz,\1 $downloads/\0," | \
+    $SED "s,^nginx-\(.*\)\.tar\.gz,\1 $downloads/\0," | \
     sort --version-sort | \
     filter "$@"

--- a/bin/run_in_build_image.sh
+++ b/bin/run_in_build_image.sh
@@ -7,7 +7,7 @@ built_image="nginx-datadog-build-$base_image_without_colons"
 BUILD_IMAGE="${BUILD_IMAGE:-$built_image}"
 
 interactive_flags=''
-if tty --silent; then
+if tty -s; then
   interactive_flags='--interactive --tty'
 fi
 


### PR DESCRIPTION
There are currently a couple issues with running `make build-in-docker` on MacOS:

* passing `$(MAKE)` into `run_in_build_image.sh` ends up trying to run `/Library/Developer/CommandLineTools/usr/bin/make` in a Linux image, which fails
* the `sed` commands in `bin/nginx_release_downloads.sh` don't work with BSD sed, so we call GNU sed
* MacOS `tty` has `-s` but not `--silent`

This PR addresses those issues while (I think) maintaining Linux compatibility.