### PR TITLE
no http block in conf → no tracing

### DIFF
--- a/bin/release.py
+++ b/bin/release.py
@@ -283,7 +283,8 @@ def prepare_release_artifact(build_job_number, work_dir):
             f"Job number {build_job_number} doesn't have an 'ngx_http_datadog_module.so' build artifact."
         )
 
-    nginx_version_info = urllib.request.urlopen(nginx_version_info_url).read().decode('utf8')
+    nginx_version_info = urllib.request.urlopen(
+        nginx_version_info_url).read().decode('utf8')
     module_path = work_dir / 'ngx_http_datadog_module.so'
     download_file(module_url, module_path)
 

--- a/src/datadog_directive.cpp
+++ b/src/datadog_directive.cpp
@@ -73,6 +73,11 @@ char *set_tracer(const ngx_command_t *command, ngx_conf_t *conf, string_view tra
   auto main_conf = static_cast<datadog_main_conf_t *>(
       ngx_http_conf_get_module_main_conf(conf, ngx_http_datadog_module));
 
+  if (main_conf == nullptr) {
+    // no config, no behavior
+    return static_cast<char *>(NGX_CONF_OK);
+  }
+
   main_conf->is_tracer_configured = true;
   main_conf->tracer_conf = to_ngx_str(conf->pool, tracer_conf);
   main_conf->tracer_conf_source_location =
@@ -175,6 +180,11 @@ char *propagate_datadog_context(ngx_conf_t *cf, ngx_command_t *command, void *co
   auto main_conf = static_cast<datadog_main_conf_t *>(
       ngx_http_conf_get_module_main_conf(cf, ngx_http_datadog_module));
 
+  if (main_conf == nullptr) {
+    // no config, no behavior
+    return static_cast<char *>(NGX_CONF_OK);
+  }
+
   if (!main_conf->is_tracer_configured) {
     if (auto rcode = set_tracer(command, cf, TRACER_CONF_DEFAULT)) {
       return rcode;
@@ -255,6 +265,12 @@ char *propagate_fastcgi_datadog_context(ngx_conf_t *cf, ngx_command_t *command,
                                         void *conf) noexcept try {
   auto main_conf = static_cast<datadog_main_conf_t *>(
       ngx_http_conf_get_module_main_conf(cf, ngx_http_datadog_module));
+
+  if (main_conf == nullptr) {
+    // no config, no behavior
+    return static_cast<char *>(NGX_CONF_OK);
+  }
+
   if (!main_conf->is_tracer_configured) {
     if (auto rcode = set_tracer(command, cf, TRACER_CONF_DEFAULT)) {
       return rcode;
@@ -300,6 +316,12 @@ char *propagate_grpc_datadog_context(ngx_conf_t *cf, ngx_command_t *command, voi
     try {
   auto main_conf = static_cast<datadog_main_conf_t *>(
       ngx_http_conf_get_module_main_conf(cf, ngx_http_datadog_module));
+
+  if (main_conf == nullptr) {
+    // no config, no behavior
+    return static_cast<char *>(NGX_CONF_OK);
+  }
+
   if (!main_conf->is_tracer_configured) {
     if (auto rcode = set_tracer(command, cf, TRACER_CONF_DEFAULT)) {
       return rcode;
@@ -453,6 +475,11 @@ char *configure_tracer(ngx_conf_t *cf, ngx_command_t *command, void *conf) noexc
 
   const auto main_conf = static_cast<datadog_main_conf_t *>(
       ngx_http_conf_get_module_main_conf(cf, ngx_http_datadog_module));
+
+  if (main_conf == nullptr) {
+    // no config, no behavior
+    return static_cast<char *>(NGX_CONF_OK);
+  }
 
   // If the tracer has already been configured, then either there are two
   // "datadog { ... }" blocks, or, more likely, another directive like

--- a/src/datadog_directive.cpp
+++ b/src/datadog_directive.cpp
@@ -73,10 +73,11 @@ char *set_tracer(const ngx_command_t *command, ngx_conf_t *conf, string_view tra
   auto main_conf = static_cast<datadog_main_conf_t *>(
       ngx_http_conf_get_module_main_conf(conf, ngx_http_datadog_module));
 
-  if (main_conf == nullptr) {
-    // no config, no behavior
-    return static_cast<char *>(NGX_CONF_OK);
-  }
+  // The only way that `main_conf` could be `nullptr` is if there's no `http`
+  // block in the nginx configuration.  In that case, this function
+  // (`set_tracer`) would never get called, because it's called only from
+  // configuration directives that live inside the `http` block.
+  assert(main_conf != nullptr);
 
   main_conf->is_tracer_configured = true;
   main_conf->tracer_conf = to_ngx_str(conf->pool, tracer_conf);
@@ -180,10 +181,11 @@ char *propagate_datadog_context(ngx_conf_t *cf, ngx_command_t *command, void *co
   auto main_conf = static_cast<datadog_main_conf_t *>(
       ngx_http_conf_get_module_main_conf(cf, ngx_http_datadog_module));
 
-  if (main_conf == nullptr) {
-    // no config, no behavior
-    return static_cast<char *>(NGX_CONF_OK);
-  }
+  // The only way that `main_conf` could be `nullptr` is if there's no `http`
+  // block in the nginx configuration.  In that case, this function would never
+  // get called, because it's called only from configuration directives that
+  // live inside the `http` block.
+  assert(main_conf != nullptr);
 
   if (!main_conf->is_tracer_configured) {
     if (auto rcode = set_tracer(command, cf, TRACER_CONF_DEFAULT)) {
@@ -266,10 +268,11 @@ char *propagate_fastcgi_datadog_context(ngx_conf_t *cf, ngx_command_t *command,
   auto main_conf = static_cast<datadog_main_conf_t *>(
       ngx_http_conf_get_module_main_conf(cf, ngx_http_datadog_module));
 
-  if (main_conf == nullptr) {
-    // no config, no behavior
-    return static_cast<char *>(NGX_CONF_OK);
-  }
+  // The only way that `main_conf` could be `nullptr` is if there's no `http`
+  // block in the nginx configuration.  In that case, this function would never
+  // get called, because it's called only from configuration directives that
+  // live inside the `http` block.
+  assert(main_conf != nullptr);
 
   if (!main_conf->is_tracer_configured) {
     if (auto rcode = set_tracer(command, cf, TRACER_CONF_DEFAULT)) {
@@ -317,10 +320,11 @@ char *propagate_grpc_datadog_context(ngx_conf_t *cf, ngx_command_t *command, voi
   auto main_conf = static_cast<datadog_main_conf_t *>(
       ngx_http_conf_get_module_main_conf(cf, ngx_http_datadog_module));
 
-  if (main_conf == nullptr) {
-    // no config, no behavior
-    return static_cast<char *>(NGX_CONF_OK);
-  }
+  // The only way that `main_conf` could be `nullptr` is if there's no `http`
+  // block in the nginx configuration.  In that case, this function would never
+  // get called, because it's called only from configuration directives that
+  // live inside the `http` block.
+  assert(main_conf != nullptr);
 
   if (!main_conf->is_tracer_configured) {
     if (auto rcode = set_tracer(command, cf, TRACER_CONF_DEFAULT)) {
@@ -430,7 +434,7 @@ char *set_datadog_tag(ngx_conf_t *cf, ngx_command_t *command, void *conf) noexce
   return add_datadog_tag(cf, loc_conf->tags, values[1], values[2]);
 }
 
-char *configure_tracer(ngx_conf_t *cf, ngx_command_t *command, void *conf) noexcept {
+char *configure_tracer(ngx_conf_t *cf, ngx_command_t *command, void * /*conf*/) noexcept {
   const ngx_uint_t starting_line = cf->conf_file->line;
   NgxFileBuf buffer(*cf->conf_file->buffer, cf->conf_file->file, "", &cf->conf_file->line);
   std::istream input(&buffer);
@@ -476,10 +480,11 @@ char *configure_tracer(ngx_conf_t *cf, ngx_command_t *command, void *conf) noexc
   const auto main_conf = static_cast<datadog_main_conf_t *>(
       ngx_http_conf_get_module_main_conf(cf, ngx_http_datadog_module));
 
-  if (main_conf == nullptr) {
-    // no config, no behavior
-    return static_cast<char *>(NGX_CONF_OK);
-  }
+  // The only way that `main_conf` could be `nullptr` is if there's no `http`
+  // block in the nginx configuration.  In that case, this function would never
+  // get called, because it's called only from configuration directives that
+  // live inside the `http` block.
+  assert(main_conf != nullptr);
 
   // If the tracer has already been configured, then either there are two
   // "datadog { ... }" blocks, or, more likely, another directive like

--- a/src/log_conf.cpp
+++ b/src/log_conf.cpp
@@ -19,6 +19,11 @@ ngx_int_t inject_datadog_log_formats(ngx_conf_t *conf) {
   auto main_conf = static_cast<datadog_main_conf_t *>(
       ngx_http_conf_get_module_main_conf(conf, ngx_http_datadog_module));
 
+  if (main_conf == nullptr) {
+    // no config, no behavior
+    return NGX_OK;
+  }
+
   // If the log formats are already defined, don't bother.
   if (main_conf->are_log_formats_defined) {
     return NGX_OK;

--- a/src/log_conf.cpp
+++ b/src/log_conf.cpp
@@ -19,10 +19,7 @@ ngx_int_t inject_datadog_log_formats(ngx_conf_t *conf) {
   auto main_conf = static_cast<datadog_main_conf_t *>(
       ngx_http_conf_get_module_main_conf(conf, ngx_http_datadog_module));
 
-  if (main_conf == nullptr) {
-    // no config, no behavior
-    return NGX_OK;
-  }
+  assert(main_conf != nullptr);
 
   // If the log formats are already defined, don't bother.
   if (main_conf->are_log_formats_defined) {

--- a/src/ngx_http_datadog_module.cpp
+++ b/src/ngx_http_datadog_module.cpp
@@ -207,7 +207,7 @@ static ngx_command_t datadog_commands[] = {
       NGX_HTTP_LOC_CONF_OFFSET,
       0,
       nullptr),
-    
+
     { ngx_string("datadog_load_tracer"),
        NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_CONF_TAKE2,
        plugin_loading_deprecated,
@@ -228,7 +228,7 @@ static ngx_command_t datadog_commands[] = {
       NGX_HTTP_LOC_CONF_OFFSET,
       0,
       nullptr},
-  
+
     ngx_null_command
 };
 
@@ -269,6 +269,12 @@ static ngx_int_t datadog_master_process_post_config(ngx_cycle_t *cycle) noexcept
   // `proxy_pass`.
   const auto main_conf = static_cast<datadog_main_conf_t *>(
       ngx_http_cycle_get_module_main_conf(cycle, ngx_http_datadog_module));
+
+  if (main_conf == nullptr) {
+    // no config, no behavior
+    return NGX_OK;
+  }
+
   if (!main_conf->is_tracer_configured) {
     main_conf->is_tracer_configured = true;
     main_conf->tracer_conf = ngx_string("");  // default config
@@ -292,6 +298,11 @@ static ngx_int_t datadog_module_init(ngx_conf_t *cf) noexcept {
       ngx_http_conf_get_module_main_conf(cf, ngx_http_core_module));
   auto main_conf = static_cast<datadog_main_conf_t *>(
       ngx_http_conf_get_module_main_conf(cf, ngx_http_datadog_module));
+
+  if (main_conf == nullptr) {
+    // no config, no behavior
+    return NGX_OK;
+  }
 
   // Add handlers to create tracing data.
   auto handler = static_cast<ngx_http_handler_pt *>(

--- a/src/request_tracing.cpp
+++ b/src/request_tracing.cpp
@@ -1,5 +1,6 @@
 #include "request_tracing.h"
 
+#include <cassert>
 #include <chrono>
 #include <ctime>
 #include <sstream>
@@ -101,6 +102,11 @@ RequestTracing::RequestTracing(ngx_http_request_t *request,
           ngx_http_get_module_main_conf(request_, ngx_http_datadog_module))},
       core_loc_conf_{core_loc_conf},
       loc_conf_{loc_conf} {
+  // `main_conf_` would be null when no `http` block appears in the nginx
+  // config.  If that happens, then no handlers are installed by this module,
+  // and so no `RequestTracing` objects are ever instantiated.
+  assert(main_conf_);
+
   auto tracer = ot::Tracer::Global();
   if (!tracer) throw std::runtime_error{"no global tracer set"};
 

--- a/test/cases/orchestration.py
+++ b/test/cases/orchestration.py
@@ -323,7 +323,8 @@ class Orchestration:
     """
 
     def __init__(self):
-        print('The test runner is running in the following environment:', os.environ)
+        print('The test runner is running in the following environment:',
+              os.environ)
 
     # Properties (all private)
     # - `up_thread` is the `threading.Thread` running `docker-compose up`.

--- a/test/cases/smoke/conf/minimal.conf
+++ b/test/cases/smoke/conf/minimal.conf
@@ -1,0 +1,7 @@
+load_module modules/ngx_http_datadog_module.so;
+
+worker_processes 0;
+
+events {
+    worker_connections  1024;
+}

--- a/test/cases/smoke/test_smoke.py
+++ b/test/cases/smoke/test_smoke.py
@@ -11,3 +11,14 @@ class TestSmoke(case.TestCase):
         status, log_lines = self.orch.nginx_replace_config(
             conf_text, conf_path.name)
         self.assertEqual(status, 0, log_lines)
+
+    def test_minimal_config(self):
+        """Verify that an nginx configuration without an "http" configuration
+        does not crash on module load, per the bug reported in
+        <https://github.com/DataDog/nginx-datadog/pull/17>.
+        """
+        conf_path = Path(__file__).parent / './conf/minimal.conf'
+        conf_text = conf_path.read_text()
+        status, log_lines = self.orch.nginx_replace_config(
+            conf_text, conf_path.name)
+        self.assertEqual(status, 0, log_lines)


### PR DESCRIPTION
This addresses the crash for which a fix is proposed in <https://github.com/DataDog/nginx-datadog/pull/17>, but in a different way.

Currently, if the `http` block is missing from nginx's configuration, our module crashes on load.

Andrew's patch instead returns an error on load.

This patch instead puts the module into a no-op mode. I like this solution better, because the absence of an `http` block means that there is no behavior for us to alter (nginx-datadog is an _http_ module).