### PR TITLE
increase portability of tests

### DIFF
--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,3 +1,2 @@
 __pycache__/
-docker-compose-verbose.log
 test.times

--- a/test/README.md
+++ b/test/README.md
@@ -1,7 +1,7 @@
 Tests
 =====
 These are integration tests.  They're written in python, and use
-`docker-compose` to orchestrate an instance of nginx containing the module
+`docker compose` to orchestrate an instance of nginx containing the module
 under test, and other services reverse proxied by nginx.
 
 See the readme file in [cases/](cases/) for usage information.
@@ -11,8 +11,8 @@ Files
 - [bin/](bin/) contains scripts for running and developing the tests.  Notably,
   [bin/run](bin/run) runs the tests.
 - [cases/](cases/) contains the actual python test cases that run tests against
-  the `docker-compose` setup.
-- [services/](services/) contains the dockerfiles for the `docker-compose`
+  the `docker compose` setup.
+- [services/](services/) contains the dockerfiles for the `docker compose`
   services, and other data relevant to the services.
 - [docker-compose.yaml](docker-compose.yml) defines the services used by the
   tests.

--- a/test/bin/README.md
+++ b/test/bin/README.md
@@ -8,4 +8,4 @@ These are scripts that are useful when working with the integration tests.
   unittest`, so for example you can run a subset of tests, or increase the
   verbosity of logging.
 - [run_parallel](run_parallel) is a wrapper around [run](run) that executes
-  each test Python module in its own docker-compose "project," all in parallel.
+  each test Python module in its own docker compose "project," all in parallel.

--- a/test/bin/run
+++ b/test/bin/run
@@ -9,5 +9,5 @@ export BASE_IMAGE
 export NGINX_MODULES_PATH="${NGINX_MODULES_PATH:-/usr/lib/nginx/modules}"
 export NGINX_CONF_PATH="${NGINX_CONF_PATH:-/etc/nginx/nginx.conf}"
 
-docker-compose build --parallel
+docker compose build --parallel
 python3 -m unittest "$@"

--- a/test/bin/run_parallel
+++ b/test/bin/run_parallel
@@ -9,7 +9,7 @@ if [ "$BASE_IMAGE" = '' ]; then
 fi
 
 export NGINX_MODULES_PATH="${NGINX_MODULES_PATH:-/usr/lib/nginx/modules}"
-docker-compose build --parallel
+docker compose build --parallel
 
 scratch=$(mktemp -d)
 mkfifo "$scratch/pipe"
@@ -28,7 +28,7 @@ else
 fi
 
 while read -r i tests; do
-    echo "docker-compose project \"test$i\" will run the following: $tests"
+    echo "docker compose project \"test$i\" will run the following: $tests"
     # shellcheck disable=SC2086
     COMPOSE_PROJECT_NAME="test$i" python3 -m unittest "$@" $tests &
 done <"$scratch/pipe"

--- a/test/cases/README.md
+++ b/test/cases/README.md
@@ -1,9 +1,9 @@
 These are the actual integration tests.
 
 The tests run as python `unittest` test cases.  They share an instance of
-`class Orchestration`, which encapsulates the `docker-compose` services
-session by running `docker-compose up` before any tests begin and by running
-`docker-compose down` after all tests have completed.
+`class Orchestration`, which encapsulates the `docker compose` services
+session by running `docker compose up` before any tests begin and by running
+`docker compose down` after all tests have completed.
 
 Usage
 -----
@@ -46,9 +46,9 @@ relevant.  For example, to run only the test
 $ test/bin/run cases.configuration.test_configuration
 ```
 
-To see very detailed output, tail the `logs/docker-compose-verbose.log` file.
+To see very detailed output, tail the `logs/test.log` file.
 ```console
-$ touch logs/docker-compose-verbose.log && tail -f logs/docker-compose-verbose.log &
+$ touch logs/test.log && tail -f logs/test.log &
 $ test/bin/run
 ```
 
@@ -77,16 +77,16 @@ The `*.py` directly in this directory are common code shared by the tests.
 
 - [case.py](case.py) is a wrapper around `unittest.TestCase` that provides an
   attribute `.orch` of type `Orchestration`.  Test cases can use this to share
-  a single scoped session of `docker-compose` services.
+  a single scoped session of `docker compose` services.
 - [formats.py](formats.py) contains parsing functions for the output of
-  `docker-compose up`, `docker-compose down`, and the JSON-formatted
+  `docker compose up`, `docker compose down`, and the JSON-formatted
   traces logged by the agent service.
 - [lazy_singleton.py](lazy_singleton.py) defines a generic singleton class,
   which is then used to define a single instance of `Orchestration`, the
-  `docker-compose` wrapper.
+  `docker compose` wrapper.
 - [orchestration.py](orchestration.py) defines a `class Orchestration` that
-   manages a thread that runs and consumes the output of `docker-compose up`,
-   and has methods for performing operations on the `docker-compose` setup,
+   manages a thread that runs and consumes the output of `docker compose up`,
+   and has methods for performing operations on the `docker compose` setup,
    e.g.
    - sending a request to nginx,
    - retrieving the logs of a service,

--- a/test/cases/case.py
+++ b/test/cases/case.py
@@ -31,8 +31,8 @@ class TestCase(unittest.TestCase):
 
 # `startTestRun` and `stopTestRun` are injected into the `unittest` module so
 # that test suites that span multiple modules share a scoped instance of
-# `Orchestration`, i.e. `docker-compose up` happens before any tests run,
-# and `docker-compose down` happens after all tests are finished.
+# `Orchestration`, i.e. `docker compose up` happens before any tests run,
+# and `docker compose down` happens after all tests are finished.
 #
 # See <https://stackoverflow.com/a/64892396>.
 global_orch_context = None

--- a/test/cases/formats.py
+++ b/test/cases/formats.py
@@ -1,4 +1,4 @@
-"""interpret the output of `docker-compose` commands"""
+"""interpret the output of `docker compose` commands"""
 
 import json
 import re
@@ -13,7 +13,7 @@ def parse_docker_compose_up_line(line):
     match = try_match(
         r'(?P<service>\S+)(?P<delimiter>[_-])\d+\s*\| (?P<payload>.*)\n', line)
     if match is not None:
-        # Some docker-compose setups (versions?) prefix the service name by the
+        # Some docker compose setups (versions?) prefix the service name by the
         # project name, while others don't.  The parts of the name are
         # delimited by either underscores or hyphens, and we don't use service
         # names with either delimiter in them, so we can pull apart the name
@@ -48,7 +48,7 @@ def parse_docker_compose_up_line(line):
             'container': match.groupdict()['container']
         })
 
-    # Different docker-compose setups (versions?) produce different output
+    # Different docker compose setups (versions?) produce different output
     # when a container is creating/created.  Here are the other flavors of
     # begin_create_container and finish_create_container.
 

--- a/test/cases/formats.py
+++ b/test/cases/formats.py
@@ -34,7 +34,7 @@ def parse_docker_compose_up_line(line):
         })
 
     # begin_create_container: {container}
-    begin_create_container = r'(Rec|C)reating (?P<container>\S+)\s*\.\.\.\s*'
+    begin_create_container = r'\s*(Rec|C)reating (?P<container>\S+)\s*\.\.\.\s*'
     match = try_match(begin_create_container, line)
     if match is not None:
         return ('begin_create_container', {
@@ -53,21 +53,21 @@ def parse_docker_compose_up_line(line):
     # begin_create_container and finish_create_container.
 
     # begin_create_container: {container}
-    match = try_match(r'Container (?P<container>\S+)\s+Creating\s*', line)
+    match = try_match(r'\s*Container (?P<container>\S+)\s+Creating\s*', line)
     if match is not None:
         return ('begin_create_container', {
             'container': match.groupdict()['container']
         })
 
     # finish_create_container: {container}
-    match = try_match(r'Container (?P<container>\S+)\s+Created\s*', line)
+    match = try_match(r'\s*Container (?P<container>\S+)\s+Created\s*', line)
     if match is not None:
         return ('finish_create_container', {
             'container': match.groupdict()['container']
         })
 
     # attach_to_logs:  {'containers': [container, ...]}
-    match = try_match(r'Attaching to (?P<containers>\S+(, \S+)*\s*)', line)
+    match = try_match(r'\s*Attaching to (?P<containers>\S+(, \S+)*\s*)', line)
     if match is not None:
         return ('attach_to_logs', {
             'containers': [
@@ -77,7 +77,7 @@ def parse_docker_compose_up_line(line):
         })
 
     # image_build_success: {image}
-    match = try_match(r'Successfully built (?P<image>\S+)\s*', line)
+    match = try_match(r'\s*Successfully built (?P<image>\S+)\s*', line)
     if match is not None:
         return ('image_build_success', {'image': match.groupdict()['image']})
 
@@ -85,11 +85,11 @@ def parse_docker_compose_up_line(line):
 
 
 def parse_docker_compose_down_line(line):
-    match = try_match(r'Removing network (?P<network>\S+)\n', line)
+    match = try_match(r'\s*Removing network (?P<network>\S+)\n', line)
     if match is not None:
         return ('remove_network', {'network': match.groupdict()['network']})
 
-    begin_stop_container = r'Stopping (?P<container>\S+)\s*\.\.\.\s*'
+    begin_stop_container = r'\s*Stopping (?P<container>\S+)\s*\.\.\.\s*'
     match = try_match(begin_stop_container, line)
     if match is not None:
         return ('begin_stop_container', {
@@ -102,7 +102,7 @@ def parse_docker_compose_down_line(line):
             'container': match.groupdict()['container']
         })
 
-    begin_remove_container = r'Removing (?P<container>\S+)\s*\.\.\.\s*'
+    begin_remove_container = r'\s*Removing (?P<container>\S+)\s*\.\.\.\s*'
     match = try_match(begin_remove_container, line)
     if match is not None:
         return ('begin_remove_container', {

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -23,7 +23,7 @@ services:
   # `agent` is a mock trace agent.  It listens on port 8126, accepts msgpack,
   # decodes the resulting traces, and prints them to standard output as JSON.
   # The tests can inspect traces sent to the agent (e.g. from the nginx module)
-  # by looking at `agent` log lines in the output of `docker-compose up`.
+  # by looking at `agent` log lines in the output of `docker compose up`.
   agent:
     image: nginx-datadog-test-services-agent
     build:
@@ -82,12 +82,12 @@ services:
       - agent
 
   # `client` is a container that exists solely so that the test runner can
-  # `docker-compose exec` into it to run command line tools such as `curl` and
+  # `docker compose exec` into it to run command line tools such as `curl` and
   # `grpcurl`.  This way, the test runner's network doesn't need access to the
-  # network created by docker-compose.  The test runner interacts with the
-  # docker-compose services via `docker-compose` and `docker` commands only.
+  # network created by docker compose.  The test runner interacts with the
+  # docker compose services via `docker compose` and `docker` commands only.
   # This became necessary when these tests were integrated into CircleCI --
-  # CircleCI's container-based remote-docker docker-compose setup does not
+  # CircleCI's container-based remote-docker docker compose setup does not
   # allow a host port binding.
   client:
     image: nginx-datadog-test-services-client

--- a/test/services/client/README.md
+++ b/test/services/client/README.md
@@ -2,11 +2,11 @@ This directory contains the build instructions for the "client" service from
 [docker-compose.yml](../../docker-compose.yml).
 
 It contains command line tools that the test runner will use via
-`docker-compose exec`, such as `grpcurl` and `curl`.  The test runner uses
+`docker compose exec`, such as `grpcurl` and `curl`.  The test runner uses
 these in-compose-container command line tools instead of using the network
-directly, so that the test runner's network and the docker-compose network need
+directly, so that the test runner's network and the docker compose network need
 not be bridged.  We want to be able to run the tests in contexts where host
-port binding is not allowed (such as CircleCI's in-docker docker-compose
+port binding is not allowed (such as CircleCI's in-docker docker compose
 offering).
 
 `curljson.sh` is a wrapper around curl whose output is easy to parse.

--- a/test/services/client/curljson.sh
+++ b/test/services/client/curljson.sh
@@ -12,7 +12,7 @@
 #   a JSON string, i.e. double quoted and with escape sequences.
 #
 # The intention is that the test driver invoke this script using
-# `docker-compose exec`.  The output format is chosen to be easy to parse in
+# `docker compose exec`.  The output format is chosen to be easy to parse in
 # Python.
 
 tmpdir=$(mktemp -d)

--- a/test/services/nginx/Dockerfile
+++ b/test/services/nginx/Dockerfile
@@ -9,7 +9,7 @@ RUN mkdir -p /usr/share/nginx/html
 COPY index.html /usr/share/nginx/html
 
 # Install the `kill` command (`procps` package on Debian), so that one-off
-# nginx instances that are started via `docker-compose exec` can be signaled to
+# nginx instances that are started via `docker compose exec` can be signaled to
 # gracefully shutdown.
 COPY ./install_tools.sh /tmp/
 RUN /tmp/install_tools.sh

--- a/test/services/nginx/README.md
+++ b/test/services/nginx/README.md
@@ -1,5 +1,5 @@
 This directory contains the build instructions for the "nginx" service from
 [docker-compose.yml](../../docker-compose.yml).  It's based on a specified
 nginx docker image, and then has the Datadog module installation added to it,
-along with some utilities that the integration tests `docker-compose exec`
+along with some utilities that the integration tests `docker compose exec`
 within the container (such as `kill`).


### PR DESCRIPTION
I was working on a side project last weekend that had me running `make test` on my personal laptop. It failed.

The reason was that `docker-compose` on that laptop prefixes messages like "Creating container [...] ..." with a space, so it's " Creating container [...] ...". `orchestration.py` was thus failing to recognize such lines and indicating that a container was created, and so the test driver was spinning forever waiting for things to come up.

This revision fixes that by adding the prefix `\s*` to all relevant regex patterns.

Another issue was how `docker-compose ps` works. The tests were written to expect that when `docker-compose ps <service>` has nothing to say, then the command will exit with a nonzero status. On my personal laptop, this is not true. So, now we wait for the condition "nonzero exit status and nonempty output." Five retries is no longer enough, so I increased it to 100.

Finally, I changed all mentions of `docker-compose` to be instead `docker compose`. They are different, though on CircleCI I think that `docker-compose` was just a wrapper that forwarded to `docker compose`. The original Python `docker-compose` is completely replaced by Docker's "compose" plugin (`docker compose`, written in Go).

The tests now pass on my personal laptop. Let's see what CircleCI thinks of these changes.