### PR TITLE
[AIT-8098] Update cpp/nginx macrobenchmark

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -31,12 +31,12 @@ variables:
   # By marking the benchmarks as allow_failure, the Github checks are not displayed.
   allow_failure: true
 
-baseline-benchmarks:
+baseline:
   extends: .benchmarks
   variables:
     DD_BENCHMARKS_CONFIGURATION: baseline
 
-only-tracing-benchmarks:
+only-tracing:
   extends: .benchmarks
   variables:
     DD_BENCHMARKS_CONFIGURATION: only-tracing

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -26,7 +26,19 @@ variables:
     FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"
     KUBERNETES_SERVICE_ACCOUNT_OVERWRITE: nginx-datadog
     DD_BENCHMARKS_NGINX_IMAGE_TAG: nginx_1.18.0
-    K6_RUN_ID_PREFIX: ci
+
+    K6_OPTIONS_NORMAL_OPERATION_RATE: 30
+    K6_OPTIONS_NORMAL_OPERATION_DURATION: 30m
+    K6_OPTIONS_NORMAL_OPERATION_GRACEFUL_STOP: 1m
+    K6_OPTIONS_NORMAL_OPERATION_PRE_ALLOCATED_VUS: 4
+    K6_OPTIONS_NORMAL_OPERATION_MAX_VUS: 4
+
+    K6_OPTIONS_HIGH_LOAD_RATE: 200
+    K6_OPTIONS_HIGH_LOAD_DURATION: 15m
+    K6_OPTIONS_HIGH_LOAD_GRACEFUL_STOP: 30s
+    K6_OPTIONS_HIGH_LOAD_PRE_ALLOCATED_VUS: 4
+    K6_OPTIONS_HIGH_LOAD_MAX_VUS: 4
+
   # Workaround: Currently we're not running the benchmarks on every PR, but GitHub still shows them as pending.
   # By marking the benchmarks as allow_failure, the Github checks are not displayed.
   allow_failure: true


### PR DESCRIPTION
This PR aligns macrobenchmarks CI jobs with updates made to the `cpp/nginx` branch in the `benchmarking-platform` repo: [https://github.com/DataDog/benchmarking-platform/pull/24](https://github.com/DataDog/benchmarking-platform/pull/24).

The changes to the `cpp/nginx` are:
> - Updated benchmarking platform tags (from `perf_*` to `bp_*`), introduced new and better tags.
> 	- `bp_branch == $CI_COMMIT_REF_NAME`
> 	- `bp_project == $CI_PROJECT_NAME`  
> 	- `bp_app == app name`, .e.g. nginx or trace-agent
> - Refactored and improved naming (the most important of which is removing cumbersome suffixes from CI job names; we use now `ci_job_name` as a discriminator for the resource usage of different variants/scenarios)
> - Exposed k6 options through environment variables in `gitlab-ci.yml` and in `.env`.
> - Summarized the k6 execution information into a single script, `k6/script.js`. The scenarios are chosen through the environment variable `SCENARIO`. The `EXTENDED_SCENARIO_NAME` environment variable is built with `SCENARIO` and `DD_BENCHMARKS_CONFIGURATION`, and is the scenario name exported to the datadog dashboard.

**Testing**
- Pipeline called from `nginx-datadog`: https://gitlab.ddbuild.io/DataDog/apm-reliability/nginx-datadog/-/pipelines/19396668
- Results on a testing dashboard: https://ddstaging.datadoghq.com/dashboard/jsu-dva-zz5/benchmarking-platform--c?tpl_var_bp_branch%5B0%5D=igoragoli%2Fupdate_cpp_nginx_macrobenchmarks_testing&from_ts=1693296073763&to_ts=1693299100000&live=false
