### PR TITLE
Add uWSGI support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@
 
 # scratch directory for preparing releases
 /.release/
+
+# Python
+__pycache__/

--- a/doc/API.md
+++ b/doc/API.md
@@ -358,8 +358,8 @@ If there is no location associated with the current request, then
 
 ### `datadog_proxy_directive`
 `$datadog_proxy_directive` expands to the name of the configuration directive
-used to proxy the current request, i.e. one of `proxy_pass`, `grpc_pass`, or
-`fastcgi_pass`.
+used to proxy the current request, i.e. one of `proxy_pass`, `grpc_pass`,
+`fastcgi_pass`, or `uwsgi_pass`.
 
 If the request was not configured by one of those directives, then
 `$datadog_proxy_directive` expands to "`location`".

--- a/example/README.md
+++ b/example/README.md
@@ -12,6 +12,7 @@ services:
 - `http` runs a NodeJS HTTP server that listens on port 8080.
 - `fastcgi` runs a NodeJS FastCGI server that listens on port 8080.
 - `grpc` runs a NodeJS gRPC server that listens on port 1337.
+- `uwsgi` runs a Python uWSGI server that listens on port 8080.
 - `client` contains the command line tools `curl` and `grpcurl`.
 
 Because client command line tools are available within the `client` service,

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - http
       - fastcgi
       - grpc
+      - uwsgi
       - agent
 
   # `agent` is the Datadog Agent to which traces are sent.
@@ -66,6 +67,18 @@ services:
       - DD_ENV=prod
       - DD_AGENT_HOST=agent
       - DD_SERVICE=grpc
+    depends_on:
+      - agent
+
+  # `uwsgi` is a uWSGI server that is reverse proxied by `nginx`.
+  uwsgi:
+    build:
+      context: ./services/uwsgi
+      dockerfile: ./Dockerfile
+    environment:
+      - DD_ENV=prod
+      - DD_AGENT_HOST=agent
+      - DD_SERVICE=uwsgi
     depends_on:
       - agent
 

--- a/example/services/nginx/nginx.conf
+++ b/example/services/nginx/nginx.conf
@@ -42,6 +42,11 @@ http {
         location /fastcgi {
             fastcgi_pass fastcgi:8080;
         }
+
+        location /uwsgi {
+            include uwsgi_params;
+            uwsgi_pass uwsgi:8080;
+        }
     }
 
     server {

--- a/example/services/uwsgi/Dockerfile
+++ b/example/services/uwsgi/Dockerfile
@@ -1,0 +1,13 @@
+FROM alpine:3.15
+
+RUN mkdir /opt/app
+WORKDIR /opt/app
+
+RUN apk update && apk add python3 py3-pip python3-dev build-base linux-headers pcre-dev
+RUN pip3 install --no-cache-dir uwsgi flask ddtrace
+
+COPY ./uwsgi.ini /opt/app/uwsgi.ini
+COPY ./wsgi.py /opt/app/wsgi.py
+COPY ./app.py /opt/app/app.py
+
+CMD ["uwsgi", "--ini", "uwsgi.ini"]

--- a/example/services/uwsgi/app.py
+++ b/example/services/uwsgi/app.py
@@ -1,0 +1,14 @@
+from flask import Flask, request, jsonify
+
+app = Flask(__name__)
+
+@app.route("/", defaults={"path": ""})
+@app.route("/<string:path>")
+@app.route("/<path:path>")
+def main(path):
+   response = {
+      "service": "uwsgi",
+      "headers": dict(request.headers)
+   }
+   print(response)
+   return jsonify(response)

--- a/example/services/uwsgi/uwsgi.ini
+++ b/example/services/uwsgi/uwsgi.ini
@@ -1,0 +1,11 @@
+[uwsgi]
+module = wsgi:app
+master = true
+socket = :8080
+
+;; dd-trace-py is used to trace the Flask application.
+;; It requires these options to supports uWSGI.
+;; See <https://ddtrace.readthedocs.io/en/stable/advanced_usage.html#uwsgi>.
+enable-threads = 1
+lazy-apps = 1
+import=ddtrace.bootstrap.sitecustomize

--- a/example/services/uwsgi/wsgi.py
+++ b/example/services/uwsgi/wsgi.py
@@ -1,0 +1,4 @@
+from app import app
+
+if __name__ == "__main__":
+    app.run()

--- a/module/config
+++ b/module/config
@@ -6,6 +6,6 @@ ngx_module_name="$ngx_addon_name"
 # configuration directives we override.  This way, our module can define
 # handlers for those directives that do some processing and then forward
 # to the "real" handler in the other module.
-ngx_module_order="$ngx_addon_name ngx_http_log_module ngx_http_fastcgi_module ngx_http_grpc_module ngx_http_proxy_module ngx_http_api_module"
+ngx_module_order="$ngx_addon_name ngx_http_log_module ngx_http_fastcgi_module ngx_http_grpc_module ngx_http_proxy_module ngx_http_api_module ngx_http_uwsgi_module"
 
 . auto/module

--- a/src/datadog_directive.h
+++ b/src/datadog_directive.h
@@ -26,6 +26,8 @@ char *propagate_grpc_datadog_context(ngx_conf_t *cf, ngx_command_t *command, voi
 
 char *hijack_grpc_pass(ngx_conf_t *cf, ngx_command_t *command, void *conf) noexcept;
 
+char *hijack_uwsgi_pass(ngx_conf_t *cf, ngx_command_t *command, void *conf) noexcept;
+
 char *hijack_access_log(ngx_conf_t *cf, ngx_command_t *command, void *conf) noexcept;
 
 char *add_datadog_tag(ngx_conf_t *cf, ngx_array_t *tags, ngx_str_t key, ngx_str_t value) noexcept;

--- a/src/ngx_http_datadog_module.cpp
+++ b/src/ngx_http_datadog_module.cpp
@@ -133,6 +133,13 @@ static ngx_command_t datadog_commands[] = {
       0,
       nullptr},
 
+    { ngx_string("uwsgi_pass"),
+      anywhere_but_main | NGX_CONF_TAKE1,
+      hijack_uwsgi_pass,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      0,
+      nullptr},
+
     // The configuration of this directive was copied from
     // ../nginx/src/http/modules/ngx_http_log_module.c.
     { ngx_string("access_log"),

--- a/test/cases/auto_propagation/conf/uwsgi_auto.conf
+++ b/test/cases/auto_propagation/conf/uwsgi_auto.conf
@@ -1,0 +1,16 @@
+load_module modules/ngx_http_datadog_module.so;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    server {
+        listen       80;
+
+        location / {
+            include /etc/nginx/uwsgi_params;
+            uwsgi_pass uwsgi:8080;
+        }
+    }
+}

--- a/test/cases/auto_propagation/conf/uwsgi_disabled_at_http.conf
+++ b/test/cases/auto_propagation/conf/uwsgi_disabled_at_http.conf
@@ -1,0 +1,17 @@
+load_module modules/ngx_http_datadog_module.so;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    datadog_disable;
+    server {
+        listen       80;
+
+        location / {
+            include /etc/nginx/uwsgi_params;
+            uwsgi_pass uwsgi:8080;
+        }
+    }
+}

--- a/test/cases/auto_propagation/conf/uwsgi_disabled_at_location.conf
+++ b/test/cases/auto_propagation/conf/uwsgi_disabled_at_location.conf
@@ -1,0 +1,17 @@
+load_module modules/ngx_http_datadog_module.so;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    server {
+        listen       80;
+
+        location / {
+            datadog_disable;
+            include /etc/nginx/uwsgi_params;
+            uwsgi_pass uwsgi:8080;
+        }
+    }
+}

--- a/test/cases/auto_propagation/conf/uwsgi_disabled_at_server.conf
+++ b/test/cases/auto_propagation/conf/uwsgi_disabled_at_server.conf
@@ -1,0 +1,17 @@
+load_module modules/ngx_http_datadog_module.so;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    server {
+        listen       80;
+        datadog_disable;
+
+        location / {
+            include /etc/nginx/uwsgi_params;
+            uwsgi_pass uwsgi:8080;
+        }
+    }
+}

--- a/test/cases/auto_propagation/conf/uwsgi_without_module.conf
+++ b/test/cases/auto_propagation/conf/uwsgi_without_module.conf
@@ -1,0 +1,15 @@
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    server {
+        listen       80;
+
+        location / {
+            include /etc/nginx/uwsgi_params;
+            uwsgi_pass uwsgi:8080;
+        }
+    }
+}

--- a/test/cases/auto_propagation/test_uwsgi.py
+++ b/test/cases/auto_propagation/test_uwsgi.py
@@ -1,0 +1,45 @@
+from .. import case
+
+import json
+from pathlib import Path
+
+
+class TestUWSGI(case.TestCase):
+
+    def test_auto_propagation(self):
+        return self.run_test('./conf/uwsgi_auto.conf', should_propagate=True)
+
+    def test_disabled_at_location(self):
+        return self.run_test('./conf/uwsgi_disabled_at_location.conf',
+                             should_propagate=False)
+
+    def test_disabled_at_server(self):
+        return self.run_test('./conf/uwsgi_disabled_at_server.conf',
+                             should_propagate=False)
+
+    def test_disabled_at_http(self):
+        return self.run_test('./conf/uwsgi_disabled_at_http.conf',
+                             should_propagate=False)
+
+    def test_without_module(self):
+        return self.run_test('./conf/uwsgi_without_module.conf',
+                             should_propagate=False)
+
+    def run_test(self, conf_relative_path, should_propagate):
+        conf_path = Path(__file__).parent / conf_relative_path
+        conf_text = conf_path.read_text()
+        status, log_lines = self.orch.nginx_replace_config(
+            conf_text, conf_path.name)
+        self.assertEqual(status, 0, log_lines)
+
+        status, body = self.orch.send_nginx_http_request('/')
+        self.assertEqual(status, 200)
+        response = json.loads(body)
+        self.assertEqual(response['service'], 'uwsgi')
+        headers = response['headers']
+        if should_propagate:
+            self.assertIn('X-Datadog-Sampling-Priority', headers)
+            priority = headers['X-Datadog-Sampling-Priority']
+            priority = int(priority)
+        else:
+            self.assertNotIn('X-Datadog-Sampling-Priority', headers)

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       - fastcgi
       - grpc
       - agent
+      - uwsgi
 
   # `agent` is a mock trace agent.  It listens on port 8126, accepts msgpack,
   # decodes the resulting traces, and prints them to standard output as JSON.
@@ -60,6 +61,22 @@ services:
       - DD_ENV=prod
       - DD_AGENT_HOST=agent
       - DD_SERVICE=fastcgi
+    depends_on:
+      - agent
+
+  # `uwsgi` is a uWSGI server that is reverse proxied by `nginx`.  It
+  # listens on port 8080 and responds with a JSON object containing the name of
+  # the service ("uwsgi") and the request's headers.  This way, tests can see
+  # which trace context, if any, was propagated to the reverse proxied server.
+  uwsgi:
+    image: nginx-datadog-test-services-uwsgi
+    build:
+      context: ./services/uwsgi
+      dockerfile: ./Dockerfile
+    environment:
+      - DD_ENV=prod
+      - DD_AGENT_HOST=agent
+      - DD_SERVICE=uwsgi
     depends_on:
       - agent
 

--- a/test/services/uwsgi/Dockerfile
+++ b/test/services/uwsgi/Dockerfile
@@ -1,0 +1,13 @@
+FROM alpine:3.15
+
+RUN mkdir /opt/app
+WORKDIR /opt/app
+
+RUN apk update && apk add python3 py3-pip python3-dev build-base linux-headers pcre-dev
+RUN pip3 install --no-cache-dir uwsgi flask ddtrace
+
+COPY ./uwsgi.ini /opt/app/uwsgi.ini
+COPY ./wsgi.py /opt/app/wsgi.py
+COPY ./app.py /opt/app/app.py
+
+CMD ["uwsgi", "--ini", "uwsgi.ini"]

--- a/test/services/uwsgi/app.py
+++ b/test/services/uwsgi/app.py
@@ -1,0 +1,12 @@
+from flask import Flask, request, jsonify
+
+app = Flask(__name__)
+
+@app.route("/")
+def main():
+   response = {
+      "service": "uwsgi",
+      "headers": dict(request.headers)
+   }
+   print(response)
+   return jsonify(response)

--- a/test/services/uwsgi/uwsgi.ini
+++ b/test/services/uwsgi/uwsgi.ini
@@ -1,0 +1,11 @@
+[uwsgi]
+module = wsgi:app
+master = true
+socket = :8080
+
+;; dd-trace-py is used to trace the Flask application.
+;; It requires these options to supports uWSGI.
+;; See <https://ddtrace.readthedocs.io/en/stable/advanced_usage.html#uwsgi>.
+enable-threads = 1
+lazy-apps = 1
+import=ddtrace.bootstrap.sitecustomize

--- a/test/services/uwsgi/wsgi.py
+++ b/test/services/uwsgi/wsgi.py
@@ -1,0 +1,4 @@
+from app import app
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
This PR add support for uWSGI. When `uwsgi_pass` directives are encountered, the module automatically propagate traces.

Content:
- Add uWSGI service for testing and as an example
- Add propagation tests for uwsgi directives
- Update example/README.md
- Ignore *.pyc

Resolves #38