### PR TITLE
chore: add architecture in release process

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ include the following:
 
 Each release contains one zipped tarball per supported image above. The
 naming convention is
-`<base image with underscores><hyphen>ngx_http_datadog_module.so.tgz`,
-e.g. `nginx_1.23.1-alpine-ngx_http_datadog_module.so.tgz` or
-`amazonlinux_2.0.20230119.1-ngx_http_datadog_module.so.tgz`.
+`<base image with underscores>-<arch>-ngx_http_datadog_module.so.tgz`,
+e.g. `nginx_1.23.1-alpine-amd64-ngx_http_datadog_module.so.tgz` or
+`amazonlinux_2.0.20230119.1-arm64-ngx_http_datadog_module.so.tgz`.
 
 The zipped tarball contains a single file, `ngx_http_datadog_module.so`, which
 is the Datadog tracing nginx module.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ naming convention is
 e.g. `nginx_1.23.1-alpine-amd64-ngx_http_datadog_module.so.tgz` or
 `amazonlinux_2.0.20230119.1-arm64-ngx_http_datadog_module.so.tgz`.
 
+Supported architectures (`<arch>`) are `amd64` and `arm64`.
+
 The zipped tarball contains a single file, `ngx_http_datadog_module.so`, which
 is the Datadog tracing nginx module.
 

--- a/bin/docker_build.sh
+++ b/bin/docker_build.sh
@@ -15,8 +15,10 @@ usage:
 
         Prompt the user for confirmation unless --yes is specified.
 
-        --platforms is a comma separated list of platforms to target. --platforms is required.
-        Example: --platforms linux/amd64,linux/arm64
+        --platforms is a comma separated list of platforms to target.
+        --platforms is required. The option has the same format as --platform
+        in `docker buildx build`.
+        For example: --platforms linux/amd64,linux/arm64
 
         If --push is specified, push the resulting image to DockerHub
         with a suitable tag.

--- a/bin/release.py
+++ b/bin/release.py
@@ -296,8 +296,14 @@ def prepare_release_artifact(build_job_number, work_dir):
         raise Exception(
             f"BASE_IMAGE not found in nginx-version-info: {nginx_version_info}"
         )
+    if 'ARCH' not in variables:
+        raise Exception(
+            f"ARCH not found in nginx-version-info: {nginx_version_info}"
+        )
+
+    arch = variables['ARCH']
     base_prefix = variables['BASE_IMAGE'].replace(':', '_')
-    tarball_path = work_dir / f'{base_prefix}-ngx_http_datadog_module.so.tgz'
+    tarball_path = work_dir / f'{base_prefix}-{arch}-ngx_http_datadog_module.so.tgz'
     command = [tar_exe, '-czf', tarball_path, '-C', work_dir, module_path.name]
     run(command, check=True)
 

--- a/bin/release.py
+++ b/bin/release.py
@@ -288,9 +288,9 @@ def prepare_release_artifact(build_job_number, work_dir):
     module_path = work_dir / 'ngx_http_datadog_module.so'
     download_file(module_url, module_path)
 
-    # `nginx_version_info` will define BASE_IMAGE. That's that value that we
-    # want to prefix the tarball name with, but with colons replaced by
-    # underscores.
+    # `nginx_version_info` serves to determine the values of BASE_IMAGE and ARCH.
+    # These values are instrumental in constructing the tarball name according to
+    # the specified convention: <BASE_IMAGE>-<ARCH>-ngx_http_datadog_module.so.tgz
     variables = parse_info_script(nginx_version_info)
     if 'BASE_IMAGE' not in variables:
         raise Exception(

--- a/nginx-version-info.example
+++ b/nginx-version-info.example
@@ -28,6 +28,11 @@
 #     BASE_IMAGE is not required for the "build" make target, but is required
 #     for "test", "build-in-docker", and "lab" targets.
 #
+# ARCH
+#     The docker image architecture to use. Here the list of architecture we support:
+#       - arm64
+#       - amd64
+#
 # NGINX_MODULES_PATH
 #     This variable is used during testing.  It's the path to the nginx modules
 #     directory in the nginx installation available within $BASE_IMAGE.
@@ -35,7 +40,7 @@
 #     NGINX_MODULES_PATH is not required for the "build" or "build-in-docker"
 #     make targets, but is required for the "test" and "lab" targets.
 
-ARCH=linux/amd64
+ARCH=amd64
 NGINX_VERSION=1.24.0
 BASE_IMAGE=nginx:1.24.0-alpine
 NGINX_MODULES_PATH=/usr/lib/nginx/modules

--- a/nginx-version-info.example
+++ b/nginx-version-info.example
@@ -28,22 +28,26 @@
 #     BASE_IMAGE is not required for the "build" make target, but is required
 #     for "test", "build-in-docker", and "lab" targets.
 #
-# ARCH
-#     The docker image architecture to use. Here the list of architecture we support:
-#       - arm64
-#       - amd64
-#
 # NGINX_MODULES_PATH
 #     This variable is used during testing.  It's the path to the nginx modules
 #     directory in the nginx installation available within $BASE_IMAGE.
 #
 #     NGINX_MODULES_PATH is not required for the "build" or "build-in-docker"
 #     make targets, but is required for the "test" and "lab" targets.
+#
+# ARCH
+#     The docker image architecture to use. The following values are supported:
+#
+#     - amd64
+#     - arm64
+#
+#     ARCH is not required by any of the make targets, but is used when
+#     preparing releases.
 
-ARCH=amd64
 NGINX_VERSION=1.24.0
 BASE_IMAGE=nginx:1.24.0-alpine
 NGINX_MODULES_PATH=/usr/lib/nginx/modules
+ARCH=amd64
 
 # NGINX_VERSION=1.14.1
 # BASE_IMAGE=nginx:1.14.1


### PR DESCRIPTION
## Description

I iterated so much across multiple branches to add `arm64` support, and in the process, I inadvertently lost this particular change. The objective of this pull request is to introduce multi-architecture support through the release process.

## ⚠️ Note to reviewer
This change is not backward compatible. Should we care about backward compatibility?