### PR TITLE
refactor: Implement simpler header injection mechanism

### DIFF
--- a/src/datadog_directive.h
+++ b/src/datadog_directive.h
@@ -12,21 +12,12 @@ namespace nginx {
 
 char *propagate_datadog_context(ngx_conf_t *cf, ngx_command_t *command, void *conf) noexcept;
 
-char *hijack_proxy_pass(ngx_conf_t *cf, ngx_command_t *command, void *conf) noexcept;
+char *warn_deprecated_command(ngx_conf_t *cf, ngx_command_t *command, void *conf) noexcept;
+
+char *set_proxy_directive(ngx_conf_t *cf, ngx_command_t *command, void *conf) noexcept;
 
 char *delegate_to_datadog_directive_with_warning(ngx_conf_t *cf, ngx_command_t *command,
                                                  void *conf) noexcept;
-
-char *propagate_fastcgi_datadog_context(ngx_conf_t *cf, ngx_command_t *command,
-                                        void *conf) noexcept;
-
-char *hijack_fastcgi_pass(ngx_conf_t *cf, ngx_command_t *command, void *conf) noexcept;
-
-char *propagate_grpc_datadog_context(ngx_conf_t *cf, ngx_command_t *command, void *conf) noexcept;
-
-char *hijack_grpc_pass(ngx_conf_t *cf, ngx_command_t *command, void *conf) noexcept;
-
-char *hijack_uwsgi_pass(ngx_conf_t *cf, ngx_command_t *command, void *conf) noexcept;
 
 char *hijack_access_log(ngx_conf_t *cf, ngx_command_t *command, void *conf) noexcept;
 

--- a/src/ngx_header_writer.h
+++ b/src/ngx_header_writer.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "string_util.h"
+#include <datadog/dict_writer.h>
+
+extern "C" {
+#include <nginx.h>
+#include <ngx_config.h>
+#include <ngx_core.h>
+#include <ngx_http.h>
+}
+
+namespace datadog {
+namespace nginx {
+
+class NgxHeaderWriter : public datadog::tracing::DictWriter {
+  ngx_http_request_t *request_;
+  ngx_pool_t *pool_;
+
+public:
+  explicit NgxHeaderWriter(ngx_http_request_t *request)
+      : request_(request), pool_(request_->pool) {}
+
+  void set(std::string_view key, std::string_view value) override {
+    // Question: Should we check first if the key already exist?
+    const auto key_size = key.size();
+
+    ngx_table_elt_t *h = (ngx_table_elt_t*)ngx_list_push(&request_->headers_in.headers);
+    if (h == NULL) {
+      return;
+    }
+
+    h->hash = 1;
+
+    // HTTP proxy module expects the header to has a lowercased key value
+    // Instead of allocating twice the same key, `h->key` and `h->lowcase_key`
+    // use the same data.
+    h->key.data = (u_char*)ngx_pnalloc(pool_, sizeof(char) * key_size);
+    h->key.len = key_size;
+    for (std::size_t i = 0; i < key_size; ++i) {
+      h->key.data[i] = to_lower(key[i]);
+    }
+    h->lowcase_key = h->key.data;
+
+    h->value = to_ngx_str(pool_, value);
+  }
+};
+
+}
+}

--- a/src/ngx_http_datadog_module.cpp
+++ b/src/ngx_http_datadog_module.cpp
@@ -51,6 +51,9 @@ using namespace datadog::nginx;
         NGX_HTTP_LOC_CONF_OFFSET, 0, nullptr                                         \
   }
 
+#define DEFINE_DEPRECATED_COMMAND(NAME, TYPE) \
+  {ngx_string(NAME), TYPE, warn_deprecated_command, NGX_HTTP_LOC_CONF_OFFSET, 0, NULL}
+
 // Part of configuring a command is saying where the command is allowed to
 // appear, e.g. in the `server` block, in a `location` block, etc.
 // There are two sets of places Datadog commands can appear: either "anywhere,"
@@ -111,35 +114,6 @@ static ngx_command_t datadog_commands[] = {
       NGX_HTTP_LOC_CONF_OFFSET,
       0,
       nullptr),
-
-    { ngx_string("proxy_pass"),
-      anywhere_but_main | NGX_CONF_TAKE1,
-      hijack_proxy_pass,
-      NGX_HTTP_LOC_CONF_OFFSET,
-      0,
-      nullptr},
-
-    { ngx_string("fastcgi_pass"),
-      anywhere_but_main | NGX_CONF_TAKE1,
-      hijack_fastcgi_pass,
-      NGX_HTTP_LOC_CONF_OFFSET,
-      0,
-      nullptr},
-
-    { ngx_string("grpc_pass"),
-      anywhere_but_main | NGX_CONF_TAKE1,
-      hijack_grpc_pass,
-      NGX_HTTP_LOC_CONF_OFFSET,
-      0,
-      nullptr},
-
-    { ngx_string("uwsgi_pass"),
-      anywhere_but_main | NGX_CONF_TAKE1,
-      hijack_uwsgi_pass,
-      NGX_HTTP_LOC_CONF_OFFSET,
-      0,
-      nullptr},
-
     // The configuration of this directive was copied from
     // ../nginx/src/http/modules/ngx_http_log_module.c.
     { ngx_string("access_log"),
@@ -150,23 +124,43 @@ static ngx_command_t datadog_commands[] = {
       0,
       NULL },
 
-    DEFINE_COMMAND_WITH_OLD_ALIAS(
-      "datadog_fastcgi_propagate_context",
+    DEFINE_DEPRECATED_COMMAND(
       "opentracing_fastcgi_propagate_context",
-      anywhere | NGX_CONF_NOARGS,
-      propagate_fastcgi_datadog_context,
-      NGX_HTTP_LOC_CONF_OFFSET,
-      0,
-      nullptr),
+      anywhere | NGX_CONF_NOARGS
+    ),
 
-    DEFINE_COMMAND_WITH_OLD_ALIAS(
-      "datadog_grpc_propagate_context",
+    DEFINE_DEPRECATED_COMMAND(
       "opentracing_grpc_propagate_context",
-      anywhere | NGX_CONF_NOARGS,
-      propagate_grpc_datadog_context,
+      anywhere | NGX_CONF_NOARGS
+    ),
+
+    { ngx_string("proxy_pass"),
+      anywhere_but_main | NGX_CONF_TAKE1,
+      set_proxy_directive,
       NGX_HTTP_LOC_CONF_OFFSET,
       0,
-      nullptr),
+      nullptr},
+
+    { ngx_string("fastcgi_pass"),
+      anywhere_but_main | NGX_CONF_TAKE1,
+      set_proxy_directive,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      0,
+      nullptr},
+
+    { ngx_string("grpc_pass"),
+      anywhere_but_main | NGX_CONF_TAKE1,
+      set_proxy_directive,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      0,
+      nullptr},
+
+    { ngx_string("uwsgi_pass"),
+      anywhere_but_main | NGX_CONF_TAKE1,
+      set_proxy_directive,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      0,
+      nullptr},
 
     DEFINE_COMMAND_WITH_OLD_ALIAS(
       "datadog_operation_name",

--- a/test/cases/auto_propagation/conf/http_auto_not_shadowing.conf
+++ b/test/cases/auto_propagation/conf/http_auto_not_shadowing.conf
@@ -1,0 +1,17 @@
+load_module modules/ngx_http_datadog_module.so;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    server {
+        listen       80;
+
+        proxy_set_header server-proxy-header not-shadowing;
+
+        location /http {
+            proxy_pass http://http:8080;
+        }
+    }
+}

--- a/test/cases/auto_propagation/test_http.py
+++ b/test/cases/auto_propagation/test_http.py
@@ -5,41 +5,59 @@ from pathlib import Path
 
 
 class TestHTTP(case.TestCase):
-
     def test_auto_propagation(self):
-        return self.run_test('./conf/http_auto.conf', should_propagate=True)
+        return self.run_test("./conf/http_auto.conf", should_propagate=True)
+
+    def test_auto_propagation_not_shadowing_proxy_set_header(self):
+        conf_path = Path(__file__).parent / "./conf/http_auto_not_shadowing.conf"
+        conf_text = conf_path.read_text()
+        status, log_lines = self.orch.nginx_replace_config(conf_text, conf_path.name)
+        self.assertEqual(status, 0, log_lines)
+
+        status, body = self.orch.send_nginx_http_request("/http")
+        self.assertEqual(status, 200)
+        response = json.loads(body)
+        self.assertEqual(response["service"], "http")
+        headers = response["headers"]
+        self.assertIn("x-datadog-sampling-priority", headers)
+        priority = headers["x-datadog-sampling-priority"]
+        priority = int(priority)
+
+        self.assertIn("server-proxy-header", headers)
+        self.assertEqual("not-shadowing", headers["server-proxy-header"])
 
     def test_disabled_at_location(self):
-        return self.run_test('./conf/http_disabled_at_location.conf',
-                             should_propagate=False)
+        return self.run_test(
+            "./conf/http_disabled_at_location.conf", should_propagate=False
+        )
 
     def test_disabled_at_server(self):
-        return self.run_test('./conf/http_disabled_at_server.conf',
-                             should_propagate=False)
+        return self.run_test(
+            "./conf/http_disabled_at_server.conf", should_propagate=False
+        )
 
     def test_disabled_at_http(self):
-        return self.run_test('./conf/http_disabled_at_http.conf',
-                             should_propagate=False)
+        return self.run_test(
+            "./conf/http_disabled_at_http.conf", should_propagate=False
+        )
 
     def test_without_module(self):
-        return self.run_test('./conf/http_without_module.conf',
-                             should_propagate=False)
+        return self.run_test("./conf/http_without_module.conf", should_propagate=False)
 
     def run_test(self, conf_relative_path, should_propagate):
         conf_path = Path(__file__).parent / conf_relative_path
         conf_text = conf_path.read_text()
-        status, log_lines = self.orch.nginx_replace_config(
-            conf_text, conf_path.name)
+        status, log_lines = self.orch.nginx_replace_config(conf_text, conf_path.name)
         self.assertEqual(status, 0, log_lines)
 
-        status, body = self.orch.send_nginx_http_request('/http')
+        status, body = self.orch.send_nginx_http_request("/http")
         self.assertEqual(status, 200)
         response = json.loads(body)
-        self.assertEqual(response['service'], 'http')
-        headers = response['headers']
+        self.assertEqual(response["service"], "http")
+        headers = response["headers"]
         if should_propagate:
-            self.assertIn('x-datadog-sampling-priority', headers)
-            priority = headers['x-datadog-sampling-priority']
+            self.assertIn("x-datadog-sampling-priority", headers)
+            priority = headers["x-datadog-sampling-priority"]
             priority = int(priority)
         else:
-            self.assertNotIn('x-datadog-sampling-priority', headers)
+            self.assertNotIn("x-datadog-sampling-priority", headers)

--- a/test/cases/configuration/test_configuration.py
+++ b/test/cases/configuration/test_configuration.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 
 class TestConfiguration(case.TestCase):
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.default_config = None
@@ -17,8 +16,7 @@ class TestConfiguration(case.TestCase):
         conf_path = Path(__file__).parent / "conf" / "vanilla.conf"
         conf_text = conf_path.read_text()
 
-        status, log_lines = self.orch.nginx_replace_config(
-            conf_text, conf_path.name)
+        status, log_lines = self.orch.nginx_replace_config(conf_text, conf_path.name)
         self.assertEqual(0, status, log_lines)
 
         status, body = self.orch.send_nginx_http_request("/")
@@ -36,8 +34,7 @@ class TestConfiguration(case.TestCase):
         conf_path = Path(__file__).parent / "conf" / "in_http.conf"
         conf_text = conf_path.read_text()
 
-        status, log_lines = self.orch.nginx_replace_config(
-            conf_text, conf_path.name)
+        status, log_lines = self.orch.nginx_replace_config(conf_text, conf_path.name)
         self.assertEqual(0, status, log_lines)
 
         status, body = self.orch.send_nginx_http_request("/")
@@ -55,10 +52,10 @@ class TestConfiguration(case.TestCase):
         del expected["runtime_id"]
         expected["defaults"]["service"] = "foosvc"
         expected["defaults"]["environment"] = "fooment"
+        expected["collector"]["config"]["traces_url"] = "http://bogus:1234/v0.4/traces"
         expected["collector"]["config"][
-            "traces_url"] = "http://bogus:1234/v0.4/traces"
-        expected["collector"]["config"][
-            "telemetry_url"] = "http://bogus:1234/telemetry/proxy/api/v2/apmtelemetry"
+            "telemetry_url"
+        ] = "http://bogus:1234/telemetry/proxy/api/v2/apmtelemetry"
         styles = ["B3", "Datadog"]
         expected["injection_styles"] = styles
         expected["extraction_styles"] = styles
@@ -69,11 +66,11 @@ class TestConfiguration(case.TestCase):
         conf_path = Path(__file__).parent / conf_relative_path
         conf_text = conf_path.read_text()
 
-        status, log_lines = self.orch.nginx_test_config(
-            conf_text, conf_path.name)
+        status, log_lines = self.orch.nginx_test_config(conf_text, conf_path.name)
         self.assertNotEqual(0, status)
-        self.assertTrue(any(diagnostic_excerpt in line for line in log_lines),
-                        log_lines)
+        self.assertTrue(
+            any(diagnostic_excerpt in line for line in log_lines), log_lines
+        )
 
     def test_duplicate_service_name(self):
         self.run_error_test(
@@ -96,54 +93,40 @@ class TestConfiguration(case.TestCase):
     def test_duplicate_propagation_styles(self):
         self.run_error_test(
             conf_relative_path="./conf/duplicate/propagation_styles.conf",
-            diagnostic_excerpt=
-            "Datadog propagation styles are already configured.",
-        )
-
-    def test_propagation_styles_error(self):
-        return self.run_error_test(
-            conf_relative_path="./conf/propagation_styles_error.conf",
-            diagnostic_excerpt=
-            "Datadog propagation styles are already configured.",
+            diagnostic_excerpt="Datadog propagation styles are already configured.",
         )
 
     def run_wrong_block_test(self, conf_relative_path):
         conf_path = Path(__file__).parent / conf_relative_path
         conf_text = conf_path.read_text()
 
-        status, log_lines = self.orch.nginx_test_config(
-            conf_text, conf_path.name)
+        status, log_lines = self.orch.nginx_test_config(conf_text, conf_path.name)
         self.assertNotEqual(0, status)
         excerpt = "directive is not allowed here"
         self.assertTrue(any(excerpt in line for line in log_lines), log_lines)
 
     def test_error_in_main_service_name(self):
-        return self.run_wrong_block_test(
-            "./conf/error_in_main/service_name.conf")
+        return self.run_wrong_block_test("./conf/error_in_main/service_name.conf")
 
     def test_error_in_main_environment(self):
-        return self.run_wrong_block_test(
-            "./conf/error_in_main/environment.conf")
+        return self.run_wrong_block_test("./conf/error_in_main/environment.conf")
 
     def test_error_in_main_agent_url(self):
         return self.run_wrong_block_test("./conf/error_in_main/agent_url.conf")
 
     def test_error_in_main_propagation_styles(self):
-        return self.run_wrong_block_test(
-            "./conf/error_in_main/propagation_styles.conf")
+        return self.run_wrong_block_test("./conf/error_in_main/propagation_styles.conf")
 
     def test_error_in_server_service_name(self):
-        return self.run_wrong_block_test(
-            "./conf/error_in_server/service_name.conf")
+        return self.run_wrong_block_test("./conf/error_in_server/service_name.conf")
 
     def test_error_in_server_environment(self):
-        return self.run_wrong_block_test(
-            "./conf/error_in_server/environment.conf")
+        return self.run_wrong_block_test("./conf/error_in_server/environment.conf")
 
     def test_error_in_server_agent_url(self):
-        return self.run_wrong_block_test(
-            "./conf/error_in_server/agent_url.conf")
+        return self.run_wrong_block_test("./conf/error_in_server/agent_url.conf")
 
     def test_error_in_server_propagation_styles(self):
         return self.run_wrong_block_test(
-            "./conf/error_in_server/propagation_styles.conf")
+            "./conf/error_in_server/propagation_styles.conf"
+        )

--- a/test/cases/deprecations/test_deprecation_warnings.py
+++ b/test/cases/deprecations/test_deprecation_warnings.py
@@ -4,53 +4,65 @@ from pathlib import Path
 
 
 class TestDeprecationWarnings(case.TestCase):
-
     def test_opentracing_trace_locations(self):
-        directive = 'opentracing_trace_locations'
-        return self.run_test_for_config(f'conf/{directive}.conf', directive)
+        directive = "opentracing_trace_locations"
+        return self.run_test_for_config(f"conf/{directive}.conf", directive)
 
     def test_opentracing_propagate_context(self):
-        directive = 'opentracing_propagate_context'
-        return self.run_test_for_config(f'conf/{directive}.conf', directive)
+        directive = "opentracing_propagate_context"
+        return self.run_test_for_config(f"conf/{directive}.conf", directive)
 
     def test_opentracing_fastcgi_propagate_context(self):
-        directive = 'opentracing_fastcgi_propagate_context'
-        return self.run_test_for_config(f'conf/{directive}.conf', directive)
+        directive = "opentracing_fastcgi_propagate_context"
+        return self.run_test_deprecated(f"conf/{directive}.conf", directive)
 
     def test_opentracing_grpc_propagate_context(self):
-        directive = 'opentracing_grpc_propagate_context'
-        return self.run_test_for_config(f'conf/{directive}.conf', directive)
+        directive = "opentracing_grpc_propagate_context"
+        return self.run_test_deprecated(f"conf/{directive}.conf", directive)
 
     def test_opentracing_operation_name(self):
-        directive = 'opentracing_operation_name'
-        return self.run_test_for_config(f'conf/{directive}.conf', directive)
+        directive = "opentracing_operation_name"
+        return self.run_test_for_config(f"conf/{directive}.conf", directive)
 
     def test_opentracing_location_operation_name(self):
-        directive = 'opentracing_location_operation_name'
-        return self.run_test_for_config(f'conf/{directive}.conf', directive)
+        directive = "opentracing_location_operation_name"
+        return self.run_test_for_config(f"conf/{directive}.conf", directive)
 
     def test_opentracing_trust_incoming_span(self):
-        directive = 'opentracing_trust_incoming_span'
-        return self.run_test_for_config(f'conf/{directive}.conf', directive)
+        directive = "opentracing_trust_incoming_span"
+        return self.run_test_for_config(f"conf/{directive}.conf", directive)
 
     def test_opentracing_tag(self):
-        directive = 'opentracing_tag'
-        return self.run_test_for_config(f'conf/{directive}.conf', directive)
+        directive = "opentracing_tag"
+        return self.run_test_for_config(f"conf/{directive}.conf", directive)
+
+    def run_test_deprecated(self, config_relative_path, directive):
+        config_path = Path(__file__).parent / config_relative_path
+        config_text = config_path.read_text()
+        status, log_lines = self.orch.nginx_test_config(config_text, config_path.name)
+
+        self.assertEqual(status, 0)
+
+        old = directive
+        expected = f'Directive "{old}" is deprecated and can be removed since v1.0.15'
+        self.assertTrue(
+            any(expected in line for line in log_lines),
+            {"expected": expected, "log_lines": log_lines},
+        )
 
     def run_test_for_config(self, config_relative_path, directive):
         config_path = Path(__file__).parent / config_relative_path
         config_text = config_path.read_text()
-        status, log_lines = self.orch.nginx_test_config(
-            config_text, config_path.name)
+        status, log_lines = self.orch.nginx_test_config(config_text, config_path.name)
 
         self.assertEqual(status, 0)
 
         # old ="opentracing_something"
         # new = "datadog_something"
         old = directive
-        new = 'datadog_' + old[len('opentracing_'):]
+        new = directive.replace("opentracing_", "datadog_")
         expected = f'Backward compatibility with the "{old}" configuration directive is deprecated.  Please use "{new}" instead.'
-        self.assertTrue(any(expected in line for line in log_lines), {
-            'expected': expected,
-            'log_lines': log_lines
-        })
+        self.assertTrue(
+            any(expected in line for line in log_lines),
+            {"expected": expected, "log_lines": log_lines},
+        )

--- a/test/cases/operation_name/test_operation_name.py
+++ b/test/cases/operation_name/test_operation_name.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 
 class TestOperationName(case.TestCase):
-
     def test_default_in_request(self):
         """Verify that the request span's operation name matches the default
         pattern when not otherwise configured.
@@ -16,10 +15,9 @@ class TestOperationName(case.TestCase):
         def on_chunk(chunk):
             first, *rest = chunk
             self.assertEqual(0, len(rest), chunk)
-            self.assertEqual('nginx.request', first['name'], chunk)
+            self.assertEqual("nginx.request", first["name"], chunk)
 
-        return self.run_operation_name_test('./conf/default_in_request.conf',
-                                            on_chunk)
+        return self.run_operation_name_test("./conf/default_in_request.conf", on_chunk)
 
     def test_default_in_location(self):
         """Verify that both the request span and the location span's operation
@@ -34,11 +32,10 @@ class TestOperationName(case.TestCase):
             self.assertEqual(1, len(rest), chunk)
             # We assume that the request span comes first, because it starts
             # first.
-            self.assertEqual('nginx.request', first['name'], chunk)
-            self.assertEqual('nginx.proxy_pass', rest[0]['name'], chunk)
+            self.assertEqual("nginx.request", first["name"], chunk)
+            self.assertEqual("nginx.proxy_pass", rest[0]["name"], chunk)
 
-        return self.run_operation_name_test('./conf/default_in_location.conf',
-                                            on_chunk)
+        return self.run_operation_name_test("./conf/default_in_location.conf", on_chunk)
 
     def test_manual_in_request_at_location(self):
         """Verify that using the `datadog_operation_name` directive in a
@@ -49,10 +46,11 @@ class TestOperationName(case.TestCase):
         def on_chunk(chunk):
             first, *rest = chunk
             self.assertEqual(0, len(rest), chunk)
-            self.assertEqual('go GET em /foo', first['name'], chunk)
+            self.assertEqual("go GET em /foo", first["name"], chunk)
 
         return self.run_operation_name_test(
-            './conf/manual_in_request_at_location.conf', on_chunk)
+            "./conf/manual_in_request_at_location.conf", on_chunk
+        )
 
     def test_manual_in_request_at_server(self):
         """Verify that using the `datadog_operation_name` directive in a
@@ -63,10 +61,11 @@ class TestOperationName(case.TestCase):
         def on_chunk(chunk):
             first, *rest = chunk
             self.assertEqual(0, len(rest), chunk)
-            self.assertEqual('go GET em /foo', first['name'], chunk)
+            self.assertEqual("go GET em /foo", first["name"], chunk)
 
         return self.run_operation_name_test(
-            './conf/manual_in_request_at_server.conf', on_chunk)
+            "./conf/manual_in_request_at_server.conf", on_chunk
+        )
 
     def test_manual_in_request_at_http(self):
         """Verify that using the `datadog_operation_name` directive in a `http`
@@ -77,10 +76,11 @@ class TestOperationName(case.TestCase):
         def on_chunk(chunk):
             first, *rest = chunk
             self.assertEqual(0, len(rest), chunk)
-            self.assertEqual('go GET em /foo', first['name'], chunk)
+            self.assertEqual("go GET em /foo", first["name"], chunk)
 
         return self.run_operation_name_test(
-            './conf/manual_in_request_at_http.conf', on_chunk)
+            "./conf/manual_in_request_at_http.conf", on_chunk
+        )
 
     def test_manual_in_location_at_location(self):
         """Verify that using the `datadog_location_operation_name` directive in
@@ -93,10 +93,11 @@ class TestOperationName(case.TestCase):
             self.assertEqual(2, len(chunk), chunk)
             # We assume that the location span comes second, because it starts
             # second.
-            self.assertEqual('go GET em /foo', chunk[1]['name'], chunk)
+            self.assertEqual("go GET em /foo", chunk[1]["name"], chunk)
 
         return self.run_operation_name_test(
-            './conf/manual_in_location_at_location.conf', on_chunk)
+            "./conf/manual_in_location_at_location.conf", on_chunk
+        )
 
     def test_manual_in_location_at_server(self):
         """Verify that using the `datadog_location_operation_name` directive in
@@ -109,10 +110,11 @@ class TestOperationName(case.TestCase):
             self.assertEqual(2, len(chunk), chunk)
             # We assume that the location span comes second, because it starts
             # second.
-            self.assertEqual('go GET em /foo', chunk[1]['name'], chunk)
+            self.assertEqual("go GET em /foo", chunk[1]["name"], chunk)
 
         return self.run_operation_name_test(
-            './conf/manual_in_location_at_server.conf', on_chunk)
+            "./conf/manual_in_location_at_server.conf", on_chunk
+        )
 
     def test_manual_in_location_at_http(self):
         """Verify that using the `datadog_location_operation_name` directive in
@@ -125,28 +127,28 @@ class TestOperationName(case.TestCase):
             self.assertEqual(2, len(chunk), chunk)
             # We assume that the location span comes second, because it starts
             # second.
-            self.assertEqual('go GET em /foo', chunk[1]['name'], chunk)
+            self.assertEqual("go GET em /foo", chunk[1]["name"], chunk)
 
         return self.run_operation_name_test(
-            './conf/manual_in_location_at_http.conf', on_chunk)
+            "./conf/manual_in_location_at_http.conf", on_chunk
+        )
 
     def run_operation_name_test(self, conf_relative_path, on_chunk):
         conf_path = Path(__file__).parent / conf_relative_path
         conf_text = conf_path.read_text()
-        status, log_lines = self.orch.nginx_replace_config(
-            conf_text, conf_path.name)
+        status, log_lines = self.orch.nginx_replace_config(conf_text, conf_path.name)
         self.assertEqual(0, status, log_lines)
 
         # Clear any outstanding logs from the agent.
-        self.orch.sync_service('agent')
+        self.orch.sync_service("agent")
 
-        status, _ = self.orch.send_nginx_http_request('/foo')
+        status, _ = self.orch.send_nginx_http_request("/foo")
         self.assertEqual(200, status)
 
         # Reload nginx to force it to send its traces.
         self.orch.reload_nginx()
 
-        log_lines = self.orch.sync_service('agent')
+        log_lines = self.orch.sync_service("agent")
         # Find the trace that came from nginx, and pass its chunks (groups of
         # spans) to the callback.
         found_nginx_trace = False
@@ -156,7 +158,7 @@ class TestOperationName(case.TestCase):
                 # not a trace; some other logging
                 continue
             for chunk in trace:
-                if chunk[0]['service'] != 'nginx':
+                if chunk[0]["service"] != "nginx":
                     continue
                 found_nginx_trace = True
                 on_chunk(chunk)


### PR DESCRIPTION
# Description
This commit introduces a refined header injection mechanism that modify the request structure with headers to inject, instead of mutating nginx's configuration with `proxy_set_header`, `fastcgi_param`, `grpc_set_header` or `uwsgi_param`.

Resolves #19

### Changes:
  - Add a DictWriter implementation for nginx.
  - Add a test covering issue #19.
  - Deprecate `opentracing_*_propagate_context`.
  - Remove tests no longer necessary.
  - Update existing tests to align with the new implementation.

## Note to reviewer
I am aware of the [OpenTracing saga with `headers_in`](http://mailman.nginx.org/pipermail/nginx-devel/2018-March/011008.html) and thruth be told, it made me a bit worry.

On the investigation front, OpenTracing's implementation wasn't exactly a walk in the park - memory lifecycle issues and not setting  the `lowercase_key` field [which could lead to a crash](https://www.nginx.com/resources/wiki/start/topics/examples/headers_management/). This implementation take care of both issues. 

This isn't emerging out of nowhere or against the trend; we have examples of plugins with comparable implementation:
- OpenTelemetry: https://github.com/open-telemetry/opentelemetry-cpp-contrib/blob/130c6e62ee6602b1fc034969a2156670910e37f1/instrumentation/nginx/src/propagate.cpp#L17
- Headers-more: https://github.com/openresty/headers-more-nginx-module/blob/3fb97bcf57b17106ee68f47eb01233cd0eeb2d54/src/ngx_http_headers_more_headers_in.c#L321