### PR TITLE
Changes for compatibility with nginx:1.25.4-alpine

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -604,6 +604,42 @@ workflows:
         matrix:
           parameters:
             arch: [amd64,arm64]
+        name: "build on nginx:1.25.3-alpine-<< matrix.arch >>"
+        base-image: "nginx:1.25.3-alpine"
+        build-image: "datadog/docker-library:nginx-datadog-build-nginx_1.25.3-alpine"
+        nginx-version: "1.25.3"
+    - test:
+        <<: *release_tag_only
+        matrix:
+          parameters:
+            arch: [amd64,arm64]
+        requires:
+        - "build on nginx:1.25.3-alpine-<< matrix.arch >>"
+        name: "test on nginx:1.25.3-alpine-<< matrix.arch >>"
+        base-image: "nginx:1.25.3-alpine"
+    - build:
+        <<: *release_tag_only
+        matrix:
+          parameters:
+            arch: [amd64,arm64]
+        name: "build on nginx:1.25.3-<< matrix.arch >>"
+        base-image: "nginx:1.25.3"
+        build-image: "datadog/docker-library:nginx-datadog-build-nginx_1.25.3"
+        nginx-version: "1.25.3"
+    - test:
+        <<: *release_tag_only
+        matrix:
+          parameters:
+            arch: [amd64,arm64]
+        requires:
+        - "build on nginx:1.25.3-<< matrix.arch >>"
+        name: "test on nginx:1.25.3-<< matrix.arch >>"
+        base-image: "nginx:1.25.3"
+    - build:
+        <<: *release_tag_only
+        matrix:
+          parameters:
+            arch: [amd64,arm64]
         name: "build on nginx:1.25.2-alpine-<< matrix.arch >>"
         base-image: "nginx:1.25.2-alpine"
         build-image: "datadog/docker-library:nginx-datadog-build-nginx_1.25.2-alpine"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,10 +177,10 @@ workflows:
         matrix:
           parameters:
             arch: ["amd64", "arm64"]
-        name: "build on nginx:1.25.2-alpine-<< matrix.arch >>"
-        base-image: "nginx:1.25.2-alpine"
-        build-image: "datadog/docker-library:nginx-datadog-build-nginx_1.25.2-alpine"
-        nginx-version: "1.25.2"
+        name: "build on nginx:1.25.4-alpine-<< matrix.arch >>"
+        base-image: "nginx:1.25.4-alpine"
+        build-image: "datadog/docker-library:nginx-datadog-build-nginx_1.25.4-alpine"
+        nginx-version: "1.25.4"
         filters:
           tags:
             ignore: /^v[0-9]+\.[0-9]+\.[0-9]+/
@@ -188,10 +188,10 @@ workflows:
         matrix:
           parameters:
             arch: ["amd64", "arm64"]
-        name: "test on nginx:1.25.2-alpine-<< matrix.arch >>"
-        base-image: "nginx:1.25.2-alpine"
+        name: "test on nginx:1.25.4-alpine-<< matrix.arch >>"
+        base-image: "nginx:1.25.4-alpine"
         requires:
-        - "build on nginx:1.25.2-alpine-<< matrix.arch >>"
+        - "build on nginx:1.25.4-alpine-<< matrix.arch >>"
         filters:
           tags:
             ignore: /^v[0-9]+\.[0-9]+\.[0-9]+/
@@ -199,10 +199,10 @@ workflows:
         matrix:
           parameters:
             arch: ["amd64", "arm64"]
-        name: "build on nginx:1.25.2-<< matrix.arch >>"
-        base-image: "nginx:1.25.2"
-        build-image: "datadog/docker-library:nginx-datadog-build-nginx_1.25.2"
-        nginx-version: "1.25.2"
+        name: "build on nginx:1.25.4-<< matrix.arch >>"
+        base-image: "nginx:1.25.4"
+        build-image: "datadog/docker-library:nginx-datadog-build-nginx_1.25.4"
+        nginx-version: "1.25.4"
         filters:
           tags:
             ignore: /^v[0-9]+\.[0-9]+\.[0-9]+/
@@ -210,16 +210,17 @@ workflows:
         matrix:
           parameters:
             arch: ["amd64", "arm64"]
-        name: "test on nginx:1.25.2-<< matrix.arch >>"
-        base-image: "nginx:1.25.2"
+        name: "test on nginx:1.25.4-<< matrix.arch >>"
+        base-image: "nginx:1.25.4"
         requires:
-        - "build on nginx:1.25.2-<< matrix.arch >>"
+        - "build on nginx:1.25.4-<< matrix.arch >>"
         filters:
           tags:
             ignore: /^v[0-9]+\.[0-9]+\.[0-9]+/
 
   build-and-test-all:
     jobs:
+    # Output of `bin/generate_jobs_yaml.sh` begins on the following line.
     - build:
         <<: *release_tag_only
         matrix:
@@ -562,6 +563,42 @@ workflows:
         - "build on amazonlinux:2.0.20220121.0-<< matrix.arch >>"
         name: "test on amazonlinux:2.0.20220121.0-<< matrix.arch >>"
         base-image: "amazonlinux:2.0.20220121.0"
+    - build:
+        <<: *release_tag_only
+        matrix:
+          parameters:
+            arch: [amd64,arm64]
+        name: "build on nginx:1.25.4-alpine-<< matrix.arch >>"
+        base-image: "nginx:1.25.4-alpine"
+        build-image: "datadog/docker-library:nginx-datadog-build-nginx_1.25.4-alpine"
+        nginx-version: "1.25.4"
+    - test:
+        <<: *release_tag_only
+        matrix:
+          parameters:
+            arch: [amd64,arm64]
+        requires:
+        - "build on nginx:1.25.4-alpine-<< matrix.arch >>"
+        name: "test on nginx:1.25.4-alpine-<< matrix.arch >>"
+        base-image: "nginx:1.25.4-alpine"
+    - build:
+        <<: *release_tag_only
+        matrix:
+          parameters:
+            arch: [amd64,arm64]
+        name: "build on nginx:1.25.4-<< matrix.arch >>"
+        base-image: "nginx:1.25.4"
+        build-image: "datadog/docker-library:nginx-datadog-build-nginx_1.25.4"
+        nginx-version: "1.25.4"
+    - test:
+        <<: *release_tag_only
+        matrix:
+          parameters:
+            arch: [amd64,arm64]
+        requires:
+        - "build on nginx:1.25.4-<< matrix.arch >>"
+        name: "test on nginx:1.25.4-<< matrix.arch >>"
+        base-image: "nginx:1.25.4"
     - build:
         <<: *release_tag_only
         matrix:

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ MAKE_JOB_COUNT ?= $(shell nproc)
 
 .PHONY: build
 build: build-deps nginx/objs/Makefile sources
-	mkdir -p $(BUILD_DIR) && cd $(BUILD_DIR) && cmake -DBUILD_TESTING=OFF .. && make -j $(MAKE_JOB_COUNT) VERBOSE=1
+	mkdir -p $(BUILD_DIR) && cd $(BUILD_DIR) && cmake -DBUILD_TESTING=OFF --trace-expand .. && make -j $(MAKE_JOB_COUNT) VERBOSE=1
 	chmod 755 $(BUILD_DIR)/libngx_http_datadog_module.so
 	@echo 'build successful 👍'
 

--- a/bin/generate_jobs_yaml.sh
+++ b/bin/generate_jobs_yaml.sh
@@ -36,6 +36,8 @@ amazonlinux:2.0.20220218.1 1.22.1 amd64,arm64
 amazonlinux:2.0.20220121.0 1.22.1 amd64,arm64
 nginx:1.25.4-alpine 1.25.4 amd64,arm64
 nginx:1.25.4 1.25.4 amd64,arm64
+nginx:1.25.3-alpine 1.25.3 amd64,arm64
+nginx:1.25.3 1.25.3 amd64,arm64
 nginx:1.25.2-alpine 1.25.2 amd64,arm64
 nginx:1.25.2 1.25.2 amd64,arm64
 nginx:1.25.1-alpine 1.25.1 amd64,arm64

--- a/bin/generate_jobs_yaml.sh
+++ b/bin/generate_jobs_yaml.sh
@@ -34,6 +34,8 @@ amazonlinux:2.0.20220406.1 1.22.1 amd64,arm64
 amazonlinux:2.0.20220316.0 1.22.1 amd64,arm64
 amazonlinux:2.0.20220218.1 1.22.1 amd64,arm64
 amazonlinux:2.0.20220121.0 1.22.1 amd64,arm64
+nginx:1.25.4-alpine 1.25.4 amd64,arm64
+nginx:1.25.4 1.25.4 amd64,arm64
 nginx:1.25.2-alpine 1.25.2 amd64,arm64
 nginx:1.25.2 1.25.2 amd64,arm64
 nginx:1.25.1-alpine 1.25.1 amd64,arm64

--- a/bin/install_build_tooling_apk.sh
+++ b/bin/install_build_tooling_apk.sh
@@ -14,6 +14,14 @@ apk add coreutils
 # nginx uses perl-compatible regular expressions (PCRE) and zlib (for gzip).
 apk add pcre-dev zlib-dev
 
+# At some point, Alpine stopped having `/usr/bin/gmake` and instead has
+# `/usr/bin/make`. CMake assumes that the make driver is `/usr/bin/gmake`,
+# though. So, symlink if the latter is missing.
+if ! [ -e /usr/bin/gmake ]; then
+    ln -s /usr/bin/make /usr/bin/gmake
+    chmod a+x /usr/bin/gmake
+fi
+
 # Build a recent cmake from source.  dd-trace-cpp requires a version more recent than
 # what is commonly packaged.
 # We have to build it from source, because Kitware doesn't produce binary


### PR DESCRIPTION
- Symlink /usr/bin/make as /usr/bin/gmake if necessary.
- Upgrade to a revision of dd-trace-cpp that does not depend on zlib.
    - This also pulled in other recent changes to dd-trace-cpp.
- Increase verbosity of cmake's output.
    - This was for debugging, but I'm leaving it in.