### PR TITLE
support amazonlinux:2023.3.20240219.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,7 +158,7 @@ workflows:
         name: "build on amazonlinux:2023.3.20240219.0-<< matrix.arch >>"
         base-image: "amazonlinux:2023.3.20240219.0"
         build-image: "datadog/docker-library:nginx-datadog-build-amazonlinux_2023.3.20240219.0"
-        nginx-version: "1.22.1"
+        nginx-version: "1.24.0"
         filters:
           tags:
             ignore: /^v[0-9]+\.[0-9]+\.[0-9]+/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,6 +155,28 @@ workflows:
         matrix:
           parameters:
             arch: ["amd64", "arm64"]
+        name: "build on amazonlinux:2023.3.20240219.0-<< matrix.arch >>"
+        base-image: "amazonlinux:2023.3.20240219.0"
+        build-image: "datadog/docker-library:nginx-datadog-build-amazonlinux_2023.3.20240219.0"
+        nginx-version: "1.22.1"
+        filters:
+          tags:
+            ignore: /^v[0-9]+\.[0-9]+\.[0-9]+/
+    - test:
+        matrix:
+          parameters:
+            arch: ["amd64", "arm64"]
+        name: "test on amazonlinux:2023.3.20240219.0-<< matrix.arch >>"
+        base-image: "amazonlinux:2023.3.20240219.0"
+        requires:
+        - "build on amazonlinux:2023.3.20240219.0-<< matrix.arch >>"
+        filters:
+          tags:
+            ignore: /^v[0-9]+\.[0-9]+\.[0-9]+/
+    - build:
+        matrix:
+          parameters:
+            arch: ["amd64", "arm64"]
         name: "build on amazonlinux:2.0.20230418.0-<< matrix.arch >>"
         base-image: "amazonlinux:2.0.20230418.0"
         build-image: "datadog/docker-library:nginx-datadog-build-amazonlinux_2.0.20230418.0"
@@ -221,6 +243,24 @@ workflows:
   build-and-test-all:
     jobs:
     # Output of `bin/generate_jobs_yaml.sh` begins on the following line.
+    - build:
+        <<: *release_tag_only
+        matrix:
+          parameters:
+            arch: [amd64,arm64]
+        name: "build on amazonlinux:2023.3.20240219.0-<< matrix.arch >>"
+        base-image: "amazonlinux:2023.3.20240219.0"
+        build-image: "datadog/docker-library:nginx-datadog-build-amazonlinux_2023.3.20240219.0"
+        nginx-version: "1.24.0"
+    - test:
+        <<: *release_tag_only
+        matrix:
+          parameters:
+            arch: [amd64,arm64]
+        requires:
+        - "build on amazonlinux:2023.3.20240219.0-<< matrix.arch >>"
+        name: "test on amazonlinux:2023.3.20240219.0-<< matrix.arch >>"
+        base-image: "amazonlinux:2023.3.20240219.0"
     - build:
         <<: *release_tag_only
         matrix:

--- a/bin/docker_build.sh
+++ b/bin/docker_build.sh
@@ -67,9 +67,13 @@ while [ $# -ne 0 ]; do
       platforms="$2"
       shift
       ;;
+    -*)
+      >&2 printf 'unknown option: %s\n' "$1"
+      exit 1
+      ;;
     *)
         if [ -n "$base_image" ]; then
-            >&2 printf 'base image was specified twice: first as %s and now as %s.' "$base_image" "$1"
+            >&2 printf 'base image was specified twice: first as %s and now as %s.\n' "$base_image" "$1"
             exit 1
         fi
         base_image="$1"
@@ -97,7 +101,7 @@ local_destination="$(pwd)/${built_tag}.tar"
 remote_destination="datadog/docker-library:$built_tag"
 buildx_output_args="--output=type=image,name=${remote_destination},push=true"
 
-if ! ask "Build image compatible with ${base_image} for ${platforms} and tag as ${built_tag}?"; then
+if ! ask "Build image compatible with ${base_image} for ${platforms}?"; then
     exit 1
 fi
 

--- a/bin/generate_jobs_yaml.sh
+++ b/bin/generate_jobs_yaml.sh
@@ -2,7 +2,7 @@
 
 # Print out a snippet that will go in .circleci/config.yaml
 #
-# It describes a "build" and "test" job for each supported nginx tag.
+# It describes a "build" and "test" job for each supported base docker image.
 
 set -e
 
@@ -13,8 +13,9 @@ cd "$REPO"
 
 # Here are the supported build/test configurations.
 version_table=$(mktemp)
-# base-image    nginx-version    architecture
->"$version_table" cat <<END_NGINX_TAGS
+# base-image    nginx-version    architectures
+>"$version_table" cat <<END_TABLE
+amazonlinux:2023.3.20240219.0 1.24.0 amd64,arm64
 amazonlinux:2.0.20230418.0 1.22.1 amd64,arm64
 amazonlinux:2.0.20230320.0 1.22.1 amd64,arm64
 amazonlinux:2.0.20230307.0 1.22.1 amd64,arm64
@@ -125,7 +126,7 @@ nginx:1.17.0-alpine 1.17.0 amd64,arm64
 nginx:1.16.1-alpine 1.16.1 amd64,arm64
 nginx:1.16.1 1.16.1 amd64,arm64
 nginx:1.16.0-alpine 1.16.0 amd64,arm64
-END_NGINX_TAGS
+END_TABLE
 
 while read -r base_image nginx_version archs; do
   base_image_without_colons=$(echo "$base_image" | tr ':' '_')

--- a/bin/install_build_tooling_yum.sh
+++ b/bin/install_build_tooling_yum.sh
@@ -12,17 +12,41 @@ yum install -y wget openssl openssl-devel pcre-devel zlib-devel
 # C and C++ build toolchains, and a bunch of other utilities like git.
 yum groupinstall -y 'Development Tools'
 
-# Install a more recent version of GCC, and set up symbolic links so that CMake
-# will choose the more recent installation (/usr/local/bin comes before /usr/bin
-# in PATH).
+compiler_major_version() {
+    # `g++ --version` looks something like:
+    #
+    #     g++ (GCC) 11.4.1 20230605 (Red Hat 11.4.1-2)
+    #     Copyright (C) 2021 Free Software Foundation, Inc.
+    #     This is free software; see the source for copying conditions.  There is NO
+    #     warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+    #
+    # We're interested in the major version number. So,
+    #
+    # - take the first line
+    # - take the third "word" ("11.4.1")
+    # - take until before the first period ("11")
+    # - the major version is 11.
+    g++ --version | head -1 | awk '{print $3}' | sed 's/\..*//'
+}
+
+# If g++ is older than major version 10, then install a more recent version of
+# GCC, and set up symbolic links so that CMake will choose the more recent
+# installation (/usr/local/bin comes before /usr/bin in PATH).
 #
-# Amazon Linux 2, as of this writing, packages gcc 7.x by default, which has
+# Older versions of Amazon Linux package gcc 7.x by default, which has
 # incomplete support for C++17, which dd-trace-cpp requires.
-#
-# gcc 10 does better.
-yum install -y gcc10 gcc10-c++
-ln -s /usr/bin/gcc10-gcc /usr/local/bin/cc
-ln -s /usr/bin/gcc10-g++ /usr/local/bin/c++
+if [ "$(compiler_major_version)" -lt 10 ]; then
+    yum install -y gcc10 gcc10-c++
+    ln -s /usr/bin/gcc10-gcc /usr/local/bin/cc
+    ln -s /usr/bin/gcc10-g++ /usr/local/bin/c++
+fi
+
+# On newer versions of Amazon Linux, the static version of libstdc++ is a
+# separate package. If present, the package will be called "libstdc++-static".
+# Install it if it's available.
+if 2>/dev/null 1>&2 yum list libstdc++-static; then
+    yum install -y libstdc++-static
+fi
 
 # Install a recent cmake.  We need at least 3.24 (for dd-trace-cpp),
 # but package managers tend to have an earlier version.

--- a/example/services/nginx/install_datadog.sh
+++ b/example/services/nginx/install_datadog.sh
@@ -73,7 +73,12 @@ if ! is_installed nginx; then
       apk add nginx
   elif is_installed yum; then
       yum update -y
-      amazon-linux-extras enable -y nginx1
+      # Older versions of Amazon Linux needed "amazon-linux-extras" in order to
+      # install nginx. Newer versions of Amazon Linux don't have
+      # "amazon-linux-extras".
+      if >/dev/null command -v amazon-linux-extras; then
+          amazon-linux-extras enable -y nginx1
+      fi
       yum install -y nginx
   else
       >&2 printf 'Did not find a supported package manager.\n'

--- a/lab/services/nginx/install_tools.sh
+++ b/lab/services/nginx/install_tools.sh
@@ -3,7 +3,12 @@
 set -e
 
 install_nginx_on_amazon_linux() {
-    amazon-linux-extras enable -y nginx1
+    # Older versions of Amazon Linux needed "amazon-linux-extras" in order to
+    # install nginx. Newer versions of Amazon Linux don't have
+    # "amazon-linux-extras".
+    if >/dev/null command -v amazon-linux-extras; then
+        amazon-linux-extras enable -y nginx1
+    fi
     yum install -y nginx
 }
 

--- a/test/services/nginx/install_tools.sh
+++ b/test/services/nginx/install_tools.sh
@@ -3,7 +3,12 @@
 set -e
 
 install_nginx_on_amazon_linux() {
-    amazon-linux-extras enable -y nginx1
+    # Older versions of Amazon Linux needed "amazon-linux-extras" in order to
+    # install nginx. Newer versions of Amazon Linux don't have
+    # "amazon-linux-extras".
+    if >/dev/null command -v amazon-linux-extras; then
+        amazon-linux-extras enable -y nginx1
+    fi
     yum install -y nginx
 }
 


### PR DESCRIPTION
These changes are an alternative to Gustavo's proposed [PR](https://github.com/DataDog/nginx-datadog/pull/54).

To support the newer "2023" flavor of Amazon Linux, our yum-based docker image setup needs to be modified:

- Installing GCC 10 explicitly is not necessary, since the packaged GCC is already 11.
- `amazon-linux-extras` is gone, and so not required when installing nginx.
- The static version of libstdc++ has to be installed as its own package.

I also made some unrelated tweaks to `docker_build.sh`.