### PR TITLE
Fix .circleci/config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
         name: Verify versions (release tag only)
         command: |
           if [[ $CIRCLE_TAG =~ ^v ]]; then
-            bin/verify_version.sh "$(echo \"$CIRCLE_TAG\" | tr -d v)"
+            bin/verify_version.sh "$(echo "$CIRCLE_TAG" | tr -d v)"
           else
             echo "Not a release"
           fi


### PR DESCRIPTION
Yaml is a confusing format. To wit:

```
$ cat a.yml
a: "foobar"
b: foo "bar"
c: \"foobar\"
d: "foo\"bar"
$ ruby -e 'require "yaml"; a = YAML.load_file "a.yml"; puts a["a"]; puts a["b"]; puts a["c"]; puts a["d"]'
foobar
foo "bar"
\"foobar\"
foo"bar
```

end result was error:

```
datadog_version_ngx_mod mismatch: "1.2.0" != 1.2.0

Exited with code exit status 1
```