### PR TITLE
Fix glibc incompatibility

### DIFF
--- a/src/glibc_compat.c
+++ b/src/glibc_compat.c
@@ -114,4 +114,11 @@ int pthread_atfork(void (*prepare)(void), void (*parent)(void),
     return real_atfork(prepare, parent, child);
 }
 
+// the symbol strerror_r in glibc is not the POSIX version; it returns char *
+// __xpg_sterror_r is exported by both glibc and musl
+int strerror_r(int errnum, char *buf, size_t buflen) {
+    int __xpg_strerror_r(int, char *, size_t);
+    return __xpg_strerror_r(errnum, buf, buflen);
+}
+
 #endif


### PR DESCRIPTION
Fixes [abort() call](https://github.com/llvm/llvm-project/blob/llvmorg-16.0.6/libcxx/src/system_error.cpp#L109) when libc++ attempts to call `strerror_r` and, while compiled against musl, calls the glibc version.