### PR TITLE
ci: Add system-tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,6 +161,30 @@ jobs:
     - store_artifacts:
         path: test/logs/test.log
         destination: test.log
+  system_tests:
+    machine:
+      # https://support.circleci.com/hc/en-us/articles/360007324514-How-can-I-use-Docker-volume-mounting-on-CircleCI-
+      image: ubuntu-2004:current
+    resource_class: large
+    steps:
+      - attach_workspace:
+          at: "/tmp/workspace"
+      - run:
+          name: clone system-tests repo
+          command: git clone https://github.com/DataDog/system-tests.git
+      - run:
+          name: ls
+          command: ls -la /tmp/workspace/.musl-build
+      - run:
+          name: Build test targets
+          working_directory: ./system-tests
+          command: ./build.sh cpp
+      - run:
+          name: Run DEFAULT scenarios
+          working_directory: ./system-tests
+          command: ./run.sh
+
+
   format:
     docker:
     - image: datadog/docker-library:dd-trace-cpp-ci
@@ -285,6 +309,10 @@ workflows:
         filters:
           tags:
             ignore: "/^v[0-9]+\\.[0-9]+\\.[0-9]+/"
+    - system_tests:
+        name: Run system tests
+        requires:
+        - build 1.25.4 on amd64 WAF ON
   build-and-test-all:
     jobs:
     # output of bin/generate_jobs_yaml.rb
@@ -626,3 +654,7 @@ workflows:
         name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
         requires:
         - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>
+    - system_tests:
+        name: Run system tests
+        requires:
+        - build 1.25.4 on amd64 WAF ON

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,8 +173,13 @@ jobs:
           name: clone system-tests repo
           command: git clone https://github.com/DataDog/system-tests.git
       - run:
-          name: ls
-          command: ls -la /tmp/workspace/.musl-build
+          name: temporary, waiting for the system-tests PR to be merged
+          working_directory: ./system-tests
+          command: git switch cbeauchesne/cpp-binary
+      - run:
+          name: Move the module to the system-tests directory
+          working_directory: ./system-tests
+          command: cp /tmp/workspace/.musl-build/ngx_http_datadog_module.so binaries/ngx_http_datadog_module-appsec-amd64-1.25.4.so
       - run:
           name: Build test targets
           working_directory: ./system-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,6 +173,9 @@ jobs:
           name: clone system-tests repo
           command: git clone https://github.com/DataDog/system-tests.git
       - run:
+          name: Install python 3.9
+          command: sudo apt-get install python3.9-venv
+      - run:
           name: temporary, waiting for the system-tests PR to be merged
           working_directory: ./system-tests
           command: git switch cbeauchesne/cpp-binary

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,10 +176,6 @@ jobs:
           name: Install python 3.9
           command: sudo apt-get install python3.9-venv
       - run:
-          name: temporary, waiting for the system-tests PR to be merged
-          working_directory: ./system-tests
-          command: git switch cbeauchesne/cpp-binary
-      - run:
           name: Move the module to the system-tests directory
           working_directory: ./system-tests
           command: cp /tmp/workspace/.musl-build/ngx_http_datadog_module.so binaries/ngx_http_datadog_module-appsec-amd64-1.25.4.so

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,8 +191,8 @@ jobs:
           name: Run DEFAULT scenarios
           working_directory: ./system-tests
           command: ./run.sh
-
-
+          environment:
+            DD_API_KEY: fakekey
   format:
     docker:
     - image: datadog/docker-library:dd-trace-cpp-ci


### PR DESCRIPTION
Add a job in circleCI that run system-tests. It will prevent introducing bug tested in system tests.

For now, I only added the default scenario, up to C++ team to decide what to add or remove later.