### PR TITLE
chore: use https remote for libddwaf

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = ../dd-trace-cpp.git
 [submodule "libddwaf"]
 	path = libddwaf
-	url = git@github.com:DataDog/libddwaf.git
+	url = https://github.com/DataDog/libddwaf.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = ../dd-trace-cpp.git
 [submodule "libddwaf"]
 	path = libddwaf
-	url = https://github.com/DataDog/libddwaf.git
+	url = ../libddwaf.git


### PR DESCRIPTION
# Description

Clone `libddwaf` using the HTTPS url.

Resolves #85 