### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-* @DataDog/apm-proxy
+* @DataDog/dd-trace-cpp
 src/security/ @DataDog/asm-cpp


### PR DESCRIPTION
Updates the default codeowner from @DataDog/apm-proxy to @DataDog/dd-trace-cpp to align with the ownership in [dd-trace-cpp](https://github.com/DataDog/dd-trace-cpp/blob/main/.github/CODEOWNERS)