### PR TITLE
Update datadog_appsec_enabled documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Enabling AppSec
 To enable AppSec, besides using the correct binary (the relase artifact with
 "-appsec") in the name, it's necessary to edit the nginx configuration:
 
-* Set `datadog_appsec_enabled yes;`.
+* Set `datadog_appsec_enabled on;`.
 * Define one (or more thread pools).
 * Choose which thread pool AppSec will use, either on a global or a per-location
   basis.


### PR DESCRIPTION
Update datadog_appsec_enabled documentation, setting it to `yes` causes the following error:

```
nginx[1373237]: 2024/08/02 20:31:17 [emerg] 1373237#1373237: invalid value "yes" in "datadog_appsec_enabled" directive, it must be "on" or "off" in /etc/ngin>
```