### PR TITLE
feat: use hex representation for `$datadog_trace_id` and `$datadog_parent_id` variables

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -476,6 +476,14 @@ Note that if `datadog_trace_locations` is `on`, then `$datadog_span_id` will
 refer to the span associated with the location (outbound request), not its
 parent (inbound request).
 
+### `datadog_trace_id_dec`
+Same as `$datadog_trace_id`, but in decimal format. Up until v1.2.1, this was
+the value returned by `$datadog_trace_id`.
+
+### `datadog_span_id_dec`
+Same as `$datadog_span_id`, but in decimal format. Up until v1.2.1, this was
+the value returned by `$datadog_span_id`.
+
 ### `datadog_location`
 `$datadog_location` expands to the name or pattern of the `location` block that
 matched the current request.  For example,

--- a/doc/API.md
+++ b/doc/API.md
@@ -464,25 +464,23 @@ about the currently active trace.
 
 ### `datadog_trace_id`
 `$datadog_trace_id` expands to the decimal representation of the unsigned
-64-bit ID of the currently active trace.  If there is no currently active
+64-bit ID of the currently active trace. If there is no currently active
 trace, then the variable expands to a hyphen character (`-`) instead.
 
 ### `datadog_span_id`
 `$datadog_span_id` expands to the decimal representation of the unsigned 64-bit
-ID of the currently active span.  If there is no currently active span, then
+ID of the currently active span.If there is no currently active span, then
 the variable expands to a hyphen character (`-`) instead.
 
 Note that if `datadog_trace_locations` is `on`, then `$datadog_span_id` will
 refer to the span associated with the location (outbound request), not its
 parent (inbound request).
 
-### `datadog_trace_id_dec`
-Same as `$datadog_trace_id`, but in decimal format. Up until v1.2.1, this was
-the value returned by `$datadog_trace_id`.
+### `datadog_trace_id_hex`
+Same as `$datadog_trace_id`, but is the hexadecimal representation of the 128-bit ID. 
 
-### `datadog_span_id_dec`
-Same as `$datadog_span_id`, but in decimal format. Up until v1.2.1, this was
-the value returned by `$datadog_span_id`.
+### `datadog_span_id_hex`
+Same as `$datadog_span_id`, but is the hexadecimal representation.
 
 ### `datadog_location`
 `$datadog_location` expands to the name or pattern of the `location` block that

--- a/src/datadog_context.cpp
+++ b/src/datadog_context.cpp
@@ -93,7 +93,6 @@ ngx_str_t DatadogContext::lookup_span_variable_value(
     throw std::runtime_error{
         "lookup_span_variable_value failed: could not find request trace"};
   }
-
   return trace->lookup_span_variable_value(key);
 }
 

--- a/src/datadog_context.cpp
+++ b/src/datadog_context.cpp
@@ -93,6 +93,7 @@ ngx_str_t DatadogContext::lookup_span_variable_value(
     throw std::runtime_error{
         "lookup_span_variable_value failed: could not find request trace"};
   }
+
   return trace->lookup_span_variable_value(key);
 }
 

--- a/src/datadog_variable.cpp
+++ b/src/datadog_variable.cpp
@@ -277,6 +277,11 @@ ngx_int_t add_variables(ngx_conf_t* cf) noexcept {
   variable = ngx_http_add_variable(cf, &name, NGX_HTTP_VAR_NOHASH);
   variable->get_handler = expand_proxy_directive_variable;
   variable->data = 0;
+
+  ngx_log_error(
+      NGX_LOG_WARN, cf->log, 0,
+      "$datadog_trace_id and $datadog_span_id are now hexadecimal values. Use "
+      "$datadog_trace_id_dec and $datadog_span_id_dec for the old behaviour.");
   return NGX_OK;
 }
 }  // namespace nginx

--- a/src/datadog_variable.cpp
+++ b/src/datadog_variable.cpp
@@ -278,10 +278,6 @@ ngx_int_t add_variables(ngx_conf_t* cf) noexcept {
   variable->get_handler = expand_proxy_directive_variable;
   variable->data = 0;
 
-  ngx_log_error(
-      NGX_LOG_WARN, cf->log, 0,
-      "$datadog_trace_id and $datadog_span_id are now hexadecimal values. Use "
-      "$datadog_trace_id_dec and $datadog_span_id_dec for the old behaviour.");
   return NGX_OK;
 }
 }  // namespace nginx

--- a/src/datadog_variable.cpp
+++ b/src/datadog_variable.cpp
@@ -278,6 +278,9 @@ ngx_int_t add_variables(ngx_conf_t* cf) noexcept {
   variable->get_handler = expand_proxy_directive_variable;
   variable->data = 0;
 
+  ngx_log_error(NGX_LOG_WARN, cf->log, 0,
+                "In the next release, $datadog_trace_id and $datadog_span_id "
+                "will return their values in hexadecimal format.");
   return NGX_OK;
 }
 }  // namespace nginx

--- a/src/tracing_library.cpp
+++ b/src/tracing_library.cpp
@@ -4,6 +4,7 @@
 #include <datadog/environment.h>
 #include <datadog/error.h>
 #include <datadog/expected.h>
+#include <datadog/hex.h>
 #include <datadog/span.h>
 #include <datadog/tracer.h>
 #include <datadog/tracer_config.h>
@@ -117,8 +118,12 @@ std::string span_property(std::string_view key, const dd::Span &span) {
   const auto not_found = "-";
 
   if (key == "trace_id") {
-    return std::to_string(span.trace_id().low);
+    return span.trace_id().hex_padded();
   } else if (key == "span_id") {
+    return datadog::tracing::hex_padded(span.id());
+  } else if (key == "trace_id_dec") {
+    return std::to_string(span.trace_id().low);
+  } else if (key == "span_id_dec") {
     return std::to_string(span.id());
   } else if (key == "json") {
     SpanContextJSONWriter writer;

--- a/src/tracing_library.cpp
+++ b/src/tracing_library.cpp
@@ -117,13 +117,13 @@ class SpanContextJSONWriter : public dd::DictWriter {
 std::string span_property(std::string_view key, const dd::Span &span) {
   const auto not_found = "-";
 
-  if (key == "trace_id") {
+  if (key == "trace_id_hex") {
     return span.trace_id().hex_padded();
-  } else if (key == "span_id") {
+  } else if (key == "span_id_hex") {
     return datadog::tracing::hex_padded(span.id());
-  } else if (key == "trace_id_dec") {
+  } else if (key == "trace_id") {
     return std::to_string(span.trace_id().low);
-  } else if (key == "span_id_dec") {
+  } else if (key == "span_id") {
     return std::to_string(span.id());
   } else if (key == "json") {
     SpanContextJSONWriter writer;


### PR DESCRIPTION
Changes:
- Add two variables: $datadog_trace_id_dec and $datadog_span_id_dec.
- Update API.md with those two variables.
- Warn at startup about the change of behaviour for $datadog_trace_id and $datadog_span_id.

Resolves #102 