### PR TITLE
Override pthread_cond_init in glibc-compat

### DIFF
--- a/build_env/glibc_compat.c
+++ b/build_env/glibc_compat.c
@@ -132,12 +132,11 @@ int pthread_atfork(
     return real_atfork(prepare, parent, child);
 }
 
+#    ifdef __x86_64__
 struct pthread_cond;
 struct pthread_condattr;
 typedef struct pthread_cond pthread_cond_t;
 typedef struct ipthread_condattr pthread_condattr_t;
-
-int __pthread_cond_init (pthread_cond_t *cond, const pthread_condattr_t * attr) __attribute__((weak));
 
 int pthread_cond_init(pthread_cond_t *cond, const pthread_condattr_t *cond_attr)
 {
@@ -146,16 +145,6 @@ int pthread_cond_init(pthread_cond_t *cond, const pthread_condattr_t *cond_attr)
     if (!real_pthread_cond_init) {
         void *handle = dlopen("libc.so.6", RTLD_LAZY);
         if (!handle) {
-#    ifdef __aarch64__
-            void *handle = dlopen("ld-musl-aarch64.so.1", RTLD_LAZY);
-            if (!handle) {
-                (void)fprintf(
-                    // NOLINTNEXTLINE(concurrency-mt-unsafe)
-                    stderr, "dlopen of ilbc.so.6 and ld-musl-aarch64.so.1 failed: %s\n",
-                    dlerror());
-                abort();
-            }
-#    else
             void *handle = dlopen("libc.musl-x86_64.so.1", RTLD_LAZY);
             if (!handle) {
                 (void)fprintf(
@@ -164,7 +153,6 @@ int pthread_cond_init(pthread_cond_t *cond, const pthread_condattr_t *cond_attr)
                     dlerror());
                 abort();
             }
-#    endif
         }
 
         real_pthread_cond_init = dlsym(handle, "pthread_cond_init");
@@ -178,6 +166,7 @@ int pthread_cond_init(pthread_cond_t *cond, const pthread_condattr_t *cond_attr)
 
     return real_pthread_cond_init(cond, cond_attr);
 }
+#    endif
 
 // the symbol strerror_r in glibc is not the POSIX version; it returns char *
 // __xpg_sterror_r is exported by both glibc and musl

--- a/build_env/glibc_compat.c
+++ b/build_env/glibc_compat.c
@@ -136,7 +136,7 @@ int pthread_atfork(
 struct pthread_cond;
 struct pthread_condattr;
 typedef struct pthread_cond pthread_cond_t;
-typedef struct ipthread_condattr pthread_condattr_t;
+typedef struct pthread_condattr pthread_condattr_t;
 
 int pthread_cond_init(pthread_cond_t *cond, const pthread_condattr_t *cond_attr)
 {


### PR DESCRIPTION
`pthread_cond_init` in glibc is provided in two different versions: the "current" version mapped to `__pthread_cond_init`, and the legacy version mapped to `__pthread_cond_init_2_0`. When using this function through a musl-built binary, the dynamic linker opts to resolve the non-default legacy version, presumably for backwards compatibility. 

However, the legacy API for condition variables forbids the use of clocks other than `CLOCK_REALTIME`, while in many cases `CLOCK_MONOTONIC` is preferred instead, resulting in an unexpected failure to initialise a condition variable.

The fix provided overrides `pthread_cond_init` with a weak symbol and then resolves the default `pthread_cond_init` provided in `libc.so.6`. Note that this is only a problem in `x86_64`.

The images will be updated once this has been merged.