### PR TITLE
chore(documentation): improvement of the documentation and the build process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,13 +9,17 @@ NGINX_SRC_DIR ?= $(PWD)/nginx
 ARCH ?= $(shell arch)
 COVERAGE ?= OFF
 DOCKER_REPOS ?= public.ecr.aws/b1o7r7e0/nginx_musl_toolchain
+MACOS ?= false
+ifeq ($(MACOS), true)
+	PCRE2_PATH ?= /opt/homebrew/Cellar/pcre2/10.44
+	MAC_OPTIONS = -DCMAKE_C_FLAGS=-I$(PCRE2_PATH)/include/ -DCMAKE_CXX_FLAGS=-I$(PCRE2_PATH)/include/ -DCMAKE_LDFLAGS=$(PCRE2_PATH)/lib -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
+endif
 
 SHELL := /bin/bash
 
 .PHONY: build
-build: build-deps sources
-	# -DCMAKE_C_FLAGS=-I/opt/homebrew/Cellar/pcre2/10.42/include/ -DCMAKE_CXX_FLAGS=-I/opt/homebrew/Cellar/pcre2/10.42/include/ -DCMAKE_LDFLAGS=-L/opt/homebrew/Cellar/pcre2/10.42/lib -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
-	cmake -B$(BUILD_DIR) -DNGINX_SRC_DIR=$(NGINX_SRC_DIR) \
+build: build-deps
+	cmake -B$(BUILD_DIR) -DNGINX_SRC_DIR=$(NGINX_SRC_DIR) $(MAC_OPTIONS) \
 		-DNGINX_COVERAGE=$(COVERAGE) -DCMAKE_BUILD_TYPE=$(BUILD_TYPE) -DNGINX_DATADOG_ASM_ENABLED=$(WAF) . \
 		&& cmake --build $(BUILD_DIR) -j $(MAKE_JOB_COUNT) -v
 	chmod 755 $(BUILD_DIR)/ngx_http_datadog_module.so

--- a/README.md
+++ b/README.md
@@ -88,17 +88,50 @@ Requirements:
 
 For enhanced usability, we provide a [GNU make][1] compatible [Makefile](Makefile).
 
+The easiest way to build the project is through [Docker][2].
+
+Build using Docker
+---------------
+### Linux, MacOS AMD64
+```shell
+NGINX_VERSION=1.25.2 make build-musl
+```
+
+### MacOS with Apple Silicon 
+```shell
+NGINX_VERSION=1.25.2 ARCH=aarch64 make build-musl
+```
+The resulting nginx module is `.musl-build\ngx_http_datadog_module.so`
+
+The `build-musl` target builds against musl and libc++ a glibc-compatible
+module. The Dockerfile for the docker image used in the process can be found in
+[build_env/Dockerfile](./build_env/Dockerfile).
+
+Build in Local Environment 
+--------------------------
+### Linux
 ```shell
 NGINX_VERSION=1.25.2 make build
 ```
 
-You can set the environment variable `WAF` to `ON` to build an AppSec-supporting
-module:
-
+### MacOS
 ```shell
-WAF=ON NGINX_VERSION=1.25.2 make build
+MACOS=true NGINX_VERSION=1.25.2 make build
 ```
 
+You will need pcre2 to be able to build the module correctly.
+You can install it with:
+```shell
+brew install pcre2
+```
+
+We assumes that the installation path is `/opt/homebrew/Cellar/pcre2/10.44`.
+This can be changed by changing the `PCRE2_PATH` param in the makefile or by overriding it during the build, i.e:
+
+```shell
+MACOS=true PCRE2_PATH=/your/path NGINX_VERSION=1.25.2 make build
+```
+#
 The resulting nginx module is `.build/ngx\_http\_datadog\_module.so`
 
 The `build` target does the following:
@@ -111,19 +144,48 @@ The `build` target does the following:
 `make clean` deletes CMake's build directory. `make clobber` deletes
 everything done by the build.
 
-Build in Docker
----------------
+### AppSec-supporting module
+
+
+You can set the environment variable `WAF` to `ON` to build an AppSec-supporting
+module:
+
 ```shell
-make build-musl
+WAF=ON NGINX_VERSION=1.25.2 make build
 ```
 
-The `build-musl` target builds against musl and libc++ a glibc-compatible
-module. The Dockerfile for the docker image used in the process can be found in
-[build_env/Dockerfile](./build_env/Dockerfile).
+Testing
+-------
 
-Test
-----
-See [test/README.md](test/README.md).
+To launch the tests, you will need to create a nginx-version-info file at the root of the project. You can use the nginx-version-info.example template. 
+
+You can easily launch the tests with the command:
+
+#
+### Linux, MacOS AMD64
+```shell
+NGINX_VERSION=1.25.2 make test
+```
+
+### MacOS with Apple Silicon
+```shell
+NGINX_VERSION=1.25.2 ARCH=aarch64 make test
+```
+
+#
+The `NGINX_VERSION`in the command and in the nginx-version-info should correspond.
+
+To run the tests related to AppSec:
+```shell
+WAF=ON NGINX_VERSION=1.25.2 make test
+```
+
+You can pass on arguments to test suites using : 
+```shell
+TEST_ARGS="foo=bar" NGINX_VERSION=1.25.2 make test
+```
+
+For more information on tests, see [test/README.md](test/README.md).
 
 Acknowledgements
 ----------------


### PR DESCRIPTION
Just by following the readme, it was almost impossible to either build something on Mac or even run the tests. 

From my point of view, when arriving on a repository should be able to build/test etc... the thing without modifying anything not explicitly mentioned in the documentation

Therefore, this pull request aims to enrich the readme so that the various actions can be carried out by following only the steps within it.