### PR TITLE
refactor!: remove use of proxy directives in span resource names

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -304,7 +304,7 @@ The request span is the span created while processing a request.
 ### `datadog_location_operation_name`
 
 - **syntax** `datadog_location_operation_name <name>`
-- **default**: `nginx.$datadog_proxy_directive`, e.g. `nginx.proxy_pass`
+- **default**: `nginx.location`
 - **context**: `http`, `server`, `location`
 
 Set the location span's "operation name" to the result of evaluating the
@@ -508,16 +508,6 @@ has location name "@updates".
 
 If there is no location associated with the current request, then
 `$datadog_location` expands to a hyphen character ("-").
-
-### `datadog_proxy_directive`
-`$datadog_proxy_directive` expands to the name of the configuration directive
-used to proxy the current request, i.e. one of `proxy_pass`, `grpc_pass`,
-`fastcgi_pass`, or `uwsgi_pass`.
-
-If the request was not configured by one of those directives, then
-`$datadog_proxy_directive` expands to "`location`".
-
-This variable is used in the implementation of the Datadog nginx module.
 
 ### `datadog_json`
 `$datadog_json` expands to a JSON object of trace context.  Each of its

--- a/module/config
+++ b/module/config
@@ -2,10 +2,9 @@ ngx_addon_name=ngx_http_datadog_module
 ngx_module_type=HTTP
 ngx_module_name="$ngx_addon_name"
 
-# Make sure that our module is listed _before_ any of the modules whose
-# configuration directives we override.  This way, our module can define
-# handlers for those directives that do some processing and then forward
-# to the "real" handler in the other module.
-ngx_module_order="$ngx_addon_name ngx_http_fastcgi_module ngx_http_grpc_module ngx_http_proxy_module ngx_http_uwsgi_module"
+# Mimick HTTP_AUX_FILTER order
+# Requires to be executed after the copy filter for Appsec, otherwise the
+# content can still be in a file.
+ngx_module_order="$ngx_addon_name ngx_http_copy_filter_module"
 
 . auto/module

--- a/src/datadog_conf.h
+++ b/src/datadog_conf.h
@@ -188,12 +188,6 @@ struct datadog_loc_conf_t {
   NgxScript loc_resource_name_script;
   ngx_flag_t trust_incoming_span = NGX_CONF_UNSET;
   ngx_array_t *tags;
-  // `proxy_directive` is the name of the configuration directive used to proxy
-  // requests at this location, i.e. `proxy_pass`, `grpc_pass`, or
-  // `fastcgi_pass`.  If this location does not have such a directive directly
-  // within it (as opposed to in a location nested within it), then
-  // `proxy_directive` is empty.
-  ngx_str_t proxy_directive;
   // `parent` is the parent context (e.g. the `server` to this `location`), or
   // `nullptr` if this context has no parent.
   datadog_loc_conf_t *parent;

--- a/src/datadog_directive.h
+++ b/src/datadog_directive.h
@@ -10,9 +10,6 @@ extern "C" {
 namespace datadog {
 namespace nginx {
 
-char *set_proxy_directive(ngx_conf_t *cf, ngx_command_t *command,
-                          void *conf) noexcept;
-
 char *delegate_to_datadog_directive_with_warning(ngx_conf_t *cf,
                                                  ngx_command_t *command,
                                                  void *conf) noexcept;

--- a/src/datadog_variable.cpp
+++ b/src/datadog_variable.cpp
@@ -203,38 +203,6 @@ static ngx_int_t expand_location_variable(
   return NGX_OK;
 }
 
-// Load into the specified `variable_value` the result of looking up the value
-// of the variable whose name is determined by
-// `TracingLibrary::proxy_directive_variable_name()`.  The variable evaluates
-// to the name of the proxy-related configuration directive directly within the
-// location associated with `request`, or "location" if there is no such
-// directive.
-static ngx_int_t expand_proxy_directive_variable(
-    ngx_http_request_t* request, ngx_http_variable_value_t* variable_value,
-    uintptr_t /*data*/) noexcept {
-  const auto loc_conf = static_cast<datadog_loc_conf_t*>(
-      ngx_http_get_module_loc_conf(request, ngx_http_datadog_module));
-
-  if (loc_conf == nullptr || str(loc_conf->proxy_directive).empty()) {
-    const ngx_str_t not_found_str = ngx_string("location");
-    variable_value->len = not_found_str.len;
-    variable_value->data = not_found_str.data;
-    variable_value->valid = true;
-    variable_value->no_cacheable = true;
-    variable_value->not_found = false;
-    return NGX_OK;
-  }
-
-  const ngx_str_t value_str = loc_conf->proxy_directive;
-  variable_value->len = value_str.len;
-  variable_value->valid = true;
-  variable_value->no_cacheable = true;
-  variable_value->not_found = false;
-  variable_value->data = value_str.data;
-
-  return NGX_OK;
-}
-
 ngx_int_t add_variables(ngx_conf_t* cf) noexcept {
   ngx_str_t prefix;
   ngx_http_variable_t* variable;
@@ -267,13 +235,6 @@ ngx_int_t add_variables(ngx_conf_t* cf) noexcept {
   name = to_ngx_str(TracingLibrary::location_variable_name());
   variable = ngx_http_add_variable(cf, &name, NGX_HTTP_VAR_NOHASH);
   variable->get_handler = expand_location_variable;
-  variable->data = 0;
-
-  // Register the variable name for getting a request's configured proxy
-  // directive (e.g. "proxy_pass" or "grpc_pass").
-  name = to_ngx_str(TracingLibrary::proxy_directive_variable_name());
-  variable = ngx_http_add_variable(cf, &name, NGX_HTTP_VAR_NOHASH);
-  variable->get_handler = expand_proxy_directive_variable;
   variable->data = 0;
 
   ngx_log_error(NGX_LOG_WARN, cf->log, 0,

--- a/src/ngx_http_datadog_module.cpp
+++ b/src/ngx_http_datadog_module.cpp
@@ -142,34 +142,6 @@ static ngx_command_t datadog_commands[] = {
       "datadog_grpc_propagate_context",
       anywhere | NGX_CONF_NOARGS),
 
-    { ngx_string("proxy_pass"),
-      anywhere_but_main | NGX_CONF_TAKE1,
-      set_proxy_directive,
-      NGX_HTTP_LOC_CONF_OFFSET,
-      0,
-      nullptr},
-
-    { ngx_string("fastcgi_pass"),
-      anywhere_but_main | NGX_CONF_TAKE1,
-      set_proxy_directive,
-      NGX_HTTP_LOC_CONF_OFFSET,
-      0,
-      nullptr},
-
-    { ngx_string("grpc_pass"),
-      anywhere_but_main | NGX_CONF_TAKE1,
-      set_proxy_directive,
-      NGX_HTTP_LOC_CONF_OFFSET,
-      0,
-      nullptr},
-
-    { ngx_string("uwsgi_pass"),
-      anywhere_but_main | NGX_CONF_TAKE1,
-      set_proxy_directive,
-      NGX_HTTP_LOC_CONF_OFFSET,
-      0,
-      nullptr},
-
     DEFINE_COMMAND_WITH_OLD_ALIAS(
       "datadog_operation_name",
       "opentracing_operation_name",

--- a/src/tracing_library.cpp
+++ b/src/tracing_library.cpp
@@ -114,10 +114,6 @@ std::string_view TracingLibrary::location_variable_name() {
   return "datadog_location";
 }
 
-std::string_view TracingLibrary::proxy_directive_variable_name() {
-  return "datadog_proxy_directive";
-}
-
 namespace {
 
 class SpanContextJSONWriter : public dd::DictWriter {
@@ -188,7 +184,7 @@ std::string_view TracingLibrary::default_request_operation_name_pattern() {
 }
 
 std::string_view TracingLibrary::default_location_operation_name_pattern() {
-  return "nginx.$datadog_proxy_directive";
+  return "nginx.location";
 }
 
 std::unordered_map<std::string_view, std::string_view>

--- a/src/tracing_library.h
+++ b/src/tracing_library.h
@@ -77,10 +77,6 @@ struct TracingLibrary {
   // location chosen for the current request.
   static std::string_view location_variable_name();
 
-  // Return the name of the nginx variable that expands to the name of the
-  // configuration directive used to proxy requests through a location.
-  static std::string_view proxy_directive_variable_name();
-
   // Return the pattern of an nginx variable script that will be used for the
   // operation name of request spans that do not have an operation name defined
   // in the nginx configuration.  Note that the storage to which the returned

--- a/test/cases/operation_name/test_operation_name.py
+++ b/test/cases/operation_name/test_operation_name.py
@@ -35,7 +35,7 @@ class TestOperationName(case.TestCase):
             # We assume that the request span comes first, because it starts
             # first.
             self.assertEqual("nginx.request", first["name"], chunk)
-            self.assertEqual("nginx.proxy_pass", rest[0]["name"], chunk)
+            self.assertEqual("nginx.location", rest[0]["name"], chunk)
 
         return self.run_operation_name_test("./conf/default_in_location.conf",
                                             on_chunk)


### PR DESCRIPTION
# Description
BREAKING CHANGE: when `datadog_trace_locations` is enabled, the resource name of the additional span will no longer include the proxy directive. Instead, it will consistently be set to `nginx.location`.
Also, this remove support for `$datadog_proxy_directive` variable.

This change can impact dashboards and metrics based on resource name.

## Motivation
Please read https://github.com/DataDog/nginx-datadog/pull/101 motivation section.