### PR TITLE
chore: avoid logging an error for requests without tracing context

### DIFF
--- a/src/request_tracing.cpp
+++ b/src/request_tracing.cpp
@@ -215,10 +215,12 @@ RequestTracing::RequestTracing(ngx_http_request_t *request,
     NgxHeaderReader reader{&request->headers_in.headers};
     auto maybe_span = tracer->extract_span(reader);
     if (auto *error = maybe_span.if_error()) {
-      ngx_log_error(
-          NGX_LOG_ERR, request->connection->log, 0,
-          "failed to extract a Datadog span request %p: [error code %d]: %s",
-          request, error->code, error->message.c_str());
+      if (error->code != dd::Error::NO_SPAN_TO_EXTRACT) {
+        ngx_log_error(
+            NGX_LOG_ERR, request->connection->log, 0,
+            "failed to extract a Datadog span request %p: [error code %d]: %s",
+            request, error->code, error->message.c_str());
+      }
       request_span_.emplace(tracer->create_span(config));
     } else {
       request_span_.emplace(std::move(*maybe_span));


### PR DESCRIPTION
# Description
With the new tracing API, extract_span returns an error if there's no tracing context. The assumption is that all errors should be logged, except in this case.

This resolves a regression introduced in 825fe30483b116ab867758c111d5c8bbd4b47722

Resolves #116