### PR TITLE
chore(ci): split workflows

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -151,6 +151,9 @@ jobs:
         steps:
             - checkout
             - run:
+                command: "CIRCLE_CFG=generated-config.yml make circleci-config \ndiff .circleci/continue_config.yml generated-config.yml\n"
+                name: Verify
+            - run:
                 command: |
                     pip install yapf
                     update-alternatives --install /usr/local/bin/yapf3 yapf3 /usr/local/bin/yapf 100

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -1,788 +1,779 @@
----
-version: 2.1
-orbs:
-  codecov: codecov/codecov@4.1.0
-
-parameters:
-  build_all:
-    type: boolean
-    default: false
-  run-installer-workflow:
-    type: boolean
-    default: false
-
 executors:
-  docker-amd64:
-    parameters:
-      image:
-        type: string
-    docker:
-    - image: "<< parameters.image >>"
-    resource_class: xlarge
-  docker-arm64:
-    parameters:
-      image:
-        type: string
-    docker:
-    - image: "<< parameters.image >>"
-    resource_class: arm.xlarge
-
+    docker-amd64:
+        docker:
+            - image: << parameters.image >>
+        parameters:
+            image:
+                type: string
+        resource_class: xlarge
+    docker-arm64:
+        docker:
+            - image: << parameters.image >>
+        parameters:
+            image:
+                type: string
+        resource_class: arm.xlarge
 jobs:
-  build_amd64:
-    parameters:
-      nginx-version:
-        type: string
-      waf:
-        type: enum
-        enum:
-        - 'ON'
-        - 'OFF'
-    steps:
-    - checkout
-    - run: git submodule sync && git submodule update --init --recursive
-    - run:
-        name: Verify versions (release tag only)
-        command: |
-          if [[ $CIRCLE_TAG =~ ^v ]]; then
-            bin/verify_version.sh "$(echo "$CIRCLE_TAG" | tr -d v)"
-          else
-            echo "Not a release"
-          fi
-    - run:
-        command: 'make build-musl'
+    build_amd64:
         environment:
-          BUILD_TYPE: RelWithDebInfo
-          NGINX_VERSION: "<< parameters.nginx-version >>"
-    - persist_to_workspace:
-        root: "."
-        paths:
-          - ".musl-build/ngx_http_datadog_module.so"
-          - ".musl-build/ngx_http_datadog_module.so.debug"
-    - store_artifacts:
-        path: ".musl-build/ngx_http_datadog_module.so"
-        destination: ngx_http_datadog_module.so
-    - store_artifacts:
-        path: ".musl-build/ngx_http_datadog_module.so.debug"
-        destination: ngx_http_datadog_module.so.debug
-    machine:
-      image: ubuntu-2204:current
-    resource_class: xlarge
-    environment:
-      ARCH: x86_64
-      MAKE_JOB_COUNT: 8
-      WAF: "<< parameters.waf >>"
-      NGINX_VERSION: "<< parameters.nginx-version >>"
-  build_arm64:
-    parameters:
-      nginx-version:
-        type: string
-      waf:
-        type: enum
-        enum:
-        - 'ON'
-        - 'OFF'
-    steps:
-    - checkout
-    - run: git submodule sync && git submodule update --init --recursive
-    - run:
-        command: 'make build-musl'
+            ARCH: x86_64
+            MAKE_JOB_COUNT: 8
+            NGINX_VERSION: << parameters.nginx-version >>
+            WAF: << parameters.waf >>
+        machine:
+            image: ubuntu-2204:current
+        parameters:
+            nginx-version:
+                type: string
+            waf:
+                enum:
+                    - "ON"
+                    - "OFF"
+                type: enum
+        resource_class: xlarge
+        steps:
+            - checkout
+            - run: git submodule sync && git submodule update --init --recursive
+            - run:
+                command: |
+                    if [[ $CIRCLE_TAG =~ ^v ]]; then
+                      bin/verify_version.sh "$(echo "$CIRCLE_TAG" | tr -d v)"
+                    else
+                      echo "Not a release"
+                    fi
+                name: Verify versions (release tag only)
+            - run:
+                command: make build-musl
+                environment:
+                    BUILD_TYPE: RelWithDebInfo
+                    NGINX_VERSION: << parameters.nginx-version >>
+            - persist_to_workspace:
+                paths:
+                    - .musl-build/ngx_http_datadog_module.so
+                    - .musl-build/ngx_http_datadog_module.so.debug
+                root: .
+            - store_artifacts:
+                destination: ngx_http_datadog_module.so
+                path: .musl-build/ngx_http_datadog_module.so
+            - store_artifacts:
+                destination: ngx_http_datadog_module.so.debug
+                path: .musl-build/ngx_http_datadog_module.so.debug
+    build_arm64:
         environment:
-          BUILD_TYPE: RelWithDebInfo
-          NGINX_VERSION: "<< parameters.nginx-version >>"
-    - persist_to_workspace:
-        root: "."
-        paths:
-          - ".musl-build/ngx_http_datadog_module.so"
-          - ".musl-build/ngx_http_datadog_module.so.debug"
-    - store_artifacts:
-        path: ".musl-build/ngx_http_datadog_module.so"
-        destination: ngx_http_datadog_module.so
-    - store_artifacts:
-        path: ".musl-build/ngx_http_datadog_module.so.debug"
-        destination: ngx_http_datadog_module.so.debug
-    - store_artifacts:
-        path: nginx-version-info
-        destination: nginx-version-info
-    machine:
-      image: ubuntu-2204:current
-    resource_class: arm.xlarge
-    environment:
-      ARCH: aarch64
-      MAKE_JOB_COUNT: 8
-      WAF: "<< parameters.waf >>"
-      NGINX_VERSION: "<< parameters.nginx-version >>"
-  coverage:
-    environment:
-      DOCKER_BUILDKIT: 1
-    steps:
-    - checkout
-    - run: git submodule sync && git submodule update --init --recursive
-    - run: echo -e "ARCH=amd64\nBASE_IMAGE=nginx:1.26.0\n" > nginx-version-info
-    - run:
-        command: 'make coverage'
+            ARCH: aarch64
+            MAKE_JOB_COUNT: 8
+            NGINX_VERSION: << parameters.nginx-version >>
+            WAF: << parameters.waf >>
+        machine:
+            image: ubuntu-2204:current
+        parameters:
+            nginx-version:
+                type: string
+            waf:
+                enum:
+                    - "ON"
+                    - "OFF"
+                type: enum
+        resource_class: arm.xlarge
+        steps:
+            - checkout
+            - run: git submodule sync && git submodule update --init --recursive
+            - run:
+                command: make build-musl
+                environment:
+                    BUILD_TYPE: RelWithDebInfo
+                    NGINX_VERSION: << parameters.nginx-version >>
+            - persist_to_workspace:
+                paths:
+                    - .musl-build/ngx_http_datadog_module.so
+                    - .musl-build/ngx_http_datadog_module.so.debug
+                root: .
+            - store_artifacts:
+                destination: ngx_http_datadog_module.so
+                path: .musl-build/ngx_http_datadog_module.so
+            - store_artifacts:
+                destination: ngx_http_datadog_module.so.debug
+                path: .musl-build/ngx_http_datadog_module.so.debug
+            - store_artifacts:
+                destination: nginx-version-info
+                path: nginx-version-info
+    build_installer_amd64:
+        machine:
+            image: ubuntu-2204:current
+        resource_class: medium
+        steps:
+            - checkout
+            - run: CGO_ENABLED=0 go -C ./installer/configurator build -o nginx-configurator
+            - persist_to_workspace:
+                paths:
+                    - nginx-configurator
+                root: ./installer/configurator
+            - store_artifacts:
+                destination: nginx-configurator
+                path: ./installer/configurator/nginx-configurator
+    build_installer_arm64:
+        machine:
+            image: ubuntu-2204:current
+        resource_class: arm.medium
+        steps:
+            - checkout
+            - run: go test -C ./installer/configurator -v
+            - run: CGO_ENABLED=0 go -C ./installer/configurator build -o nginx-configurator
+            - store_artifacts:
+                destination: nginx-configurator
+                path: ./installer/configurator/nginx-configurator
+    coverage:
         environment:
-          ARCH: x86_64
-          MAKE_JOB_COUNT: 8
-          BUILD_TYPE: RelWithDebInfo
-          NGINX_VERSION: 1.26.0
-          WAF: ON
-    - codecov/upload:
-        upload_args: '--disable-search'
-        file: .musl-build/coverage.lcov
-        upload_name: circleci
-    machine:
-      image: ubuntu-2204:current
-    resource_class: xlarge
-  test:
-    parameters:
-      base-image:
-        type: string
-        default: ''
-      nginx-version:
-        type: string
-      arch:
-        type: string
-      waf:
-        type: string
-    executor:
-      name: docker-<< parameters.arch >>
-      image: cimg/python:3.10.13
-    environment:
-      # https://github.com/containers/podman/issues/13889
-      DOCKER_BUILDKIT: 1
-      WAF: "<< parameters.waf >>"
-    steps:
-    - checkout
-    - attach_workspace:
-        at: "/tmp/workspace"
-    - run: mv -v /tmp/workspace/.musl-build/ngx_http_datadog_module.so* test/services/nginx/
-    - run: printf "ARCH=%s\nBASE_IMAGE=%s\n" << parameters.arch >> << parameters.base-image >> > nginx-version-info
-    - setup_remote_docker:
-        docker_layer_caching: true
-    - run: test/bin/run --verbose --failfast
-    - store_artifacts:
-        path: test/logs/test.log
-        destination: test.log
-  system_tests:
-    machine:
-      # https://support.circleci.com/hc/en-us/articles/360007324514-How-can-I-use-Docker-volume-mounting-on-CircleCI-
-      image: ubuntu-2004:current
-    resource_class: large
-    steps:
-      - attach_workspace:
-          at: "/tmp/workspace"
-      - run:
-          name: clone system-tests repo
-          command: git clone https://github.com/DataDog/system-tests.git
-      - run:
-          name: Install python 3.9
-          command: sudo apt-get install python3.9-venv
-      - run:
-          name: Move the module to the system-tests directory
-          working_directory: ./system-tests
-          command: cp /tmp/workspace/.musl-build/ngx_http_datadog_module.so binaries/ngx_http_datadog_module-appsec-amd64-1.25.4.so
-      - run:
-          name: Build test targets
-          working_directory: ./system-tests
-          command: ./build.sh cpp
-      - run:
-          name: Run DEFAULT scenarios
-          working_directory: ./system-tests
-          command: ./run.sh
-          environment:
-            DD_API_KEY: fakekey
-  build_installer_arm64:
-    steps:
-    - checkout
-    - run: go test -C ./installer/configurator -v
-    - run: CGO_ENABLED=0 go -C ./installer/configurator build -o nginx-configurator
-    - store_artifacts:
-        path: "./installer/configurator/nginx-configurator"
-        destination: nginx-configurator
-    machine:
-      image: ubuntu-2204:current
-    resource_class: arm.medium
-  build_installer_amd64:
-    steps:
-    - checkout
-    - run: CGO_ENABLED=0 go -C ./installer/configurator build -o nginx-configurator
-    - persist_to_workspace:
-        root: "./installer/configurator"
-        paths:
-          - "nginx-configurator"
-    - store_artifacts:
-        path: "./installer/configurator/nginx-configurator"
-        destination: nginx-configurator
-    machine:
-      image: ubuntu-2204:current
-    resource_class: medium
-  installer_test:
-    parameters:
-      base-dockerfile:
-        type: string
-    machine:
-      image: ubuntu-2204:current
-    steps:
-    - checkout
-    - attach_workspace:
-        at: "/tmp/workspace"
-    - run:
-          name: Move the configurator go binary to the installer directory
-          working_directory: ./installer
-          command: cp /tmp/workspace/nginx-configurator .
-    - run:
-        name: Run installer tests
-        command: docker compose -f installer/test/docker-compose.yml up --build --exit-code-from nginx
-        environment:
-          DD_API_KEY: fakekey
-          NGINX_DOCKERFILE: << parameters.base-dockerfile >>
-  installer_download_test:
-    machine:
-      image: ubuntu-2204:current
-    steps:
-    - checkout
-    - run:
-        name: Run installer download tests
-        command: docker compose -f installer/test/docker-compose-download.yml up --build --exit-code-from nginx
-        environment:
-          DD_API_KEY: fakekey
-          NGINX_DOCKERFILE: bookworm.Dockerfile
-  format:
-    docker:
-    - image: datadog/docker-library:dd-trace-cpp-ci
-    resource_class: small
-    steps:
-    - checkout
-    - run:
-        name: Install Python dependencies
-        command: |
-          pip install yapf
-          update-alternatives --install /usr/local/bin/yapf3 yapf3 /usr/local/bin/yapf 100
-    - run: make lint
-  shellcheck:
-    docker:
-    - image: koalaman/shellcheck-alpine:v0.9.0
-      entrypoint: "/bin/sh"
-    steps:
-    - checkout
-    - run: find bin/ test/ example/ installer/ -type f -executable | xargs shellcheck --exclude
-        SC1071,SC1091,SC2317
-workflows:
-  build-and-test-installer:
-    when:
-      and:
-        - not: << pipeline.git.tag >>
-        - << pipeline.parameters.run-installer-workflow >>
-    jobs:
-     - build_installer_amd64:
-        name: build installer on amd64
-     - build_installer_arm64:
-        name: build installer on arm64
-     - installer_test:
-        matrix:
-          parameters:
+            DOCKER_BUILDKIT: 1
+        machine:
+            image: ubuntu-2204:current
+        resource_class: xlarge
+        steps:
+            - checkout
+            - run: git submodule sync && git submodule update --init --recursive
+            - run: echo -e "ARCH=amd64\nBASE_IMAGE=nginx:1.26.0\n" > nginx-version-info
+            - run:
+                command: make coverage
+                environment:
+                    ARCH: x86_64
+                    BUILD_TYPE: RelWithDebInfo
+                    MAKE_JOB_COUNT: 8
+                    NGINX_VERSION: 1.26.0
+                    WAF: "ON"
+            - codecov/upload:
+                file: .musl-build/coverage.lcov
+                upload_args: --disable-search
+                upload_name: circleci
+    format:
+        docker:
+            - image: datadog/docker-library:dd-trace-cpp-ci
+        resource_class: small
+        steps:
+            - checkout
+            - run:
+                command: |
+                    pip install yapf
+                    update-alternatives --install /usr/local/bin/yapf3 yapf3 /usr/local/bin/yapf 100
+                name: Install Python dependencies
+            - run: make lint
+    installer_download_test:
+        machine:
+            image: ubuntu-2204:current
+        steps:
+            - checkout
+            - run:
+                command: docker compose -f installer/test/docker-compose-download.yml up --build --exit-code-from nginx
+                environment:
+                    DD_API_KEY: fakekey
+                    NGINX_DOCKERFILE: bookworm.Dockerfile
+                name: Run installer download tests
+    installer_test:
+        machine:
+            image: ubuntu-2204:current
+        parameters:
             base-dockerfile:
-            - 'bookworm.Dockerfile'
-            - 'alpine.Dockerfile'
-            - 'al2023.Dockerfile'
-        name: test installer with << matrix.base-dockerfile >> base image
-        requires:
-        - build installer on amd64
-        - build installer on arm64
-     - installer_download_test:
-        name: test installer download
-  build-and-test:
-    when:
-      and:
-        - not: << pipeline.git.tag >>
-        - not: << pipeline.parameters.build_all >>
-    jobs:
-    - format
-    - shellcheck:
-        name: run shellcheck on shell scripts
-    - build_amd64:
-        matrix:
-          parameters:
-            nginx-version:
-            - 1.22.1
-            - 1.24.0
-            - 1.25.4
-            - 1.27.1
-            waf:
-            - 'ON'
-            - 'OFF'
-        name: build << matrix.nginx-version >> on amd64 WAF << matrix.waf >>
-    - build_arm64:
-        matrix:
-          parameters:
-            nginx-version:
-            - 1.22.1
-            - 1.24.0
-            - 1.27.1
-            waf:
-            - 'ON'
-            - 'OFF'
-        name: build << matrix.nginx-version >> on arm64 WAF << matrix.waf >>
-    - coverage:
-        name: Coverage on 1.27.0 with WAF ON
-    - test:
-        matrix:
-          parameters:
+                type: string
+        steps:
+            - checkout
+            - attach_workspace:
+                at: /tmp/workspace
+            - run:
+                command: cp /tmp/workspace/nginx-configurator .
+                name: Move the configurator go binary to the installer directory
+                working_directory: ./installer
+            - run:
+                command: docker compose -f installer/test/docker-compose.yml up --build --exit-code-from nginx
+                environment:
+                    DD_API_KEY: fakekey
+                    NGINX_DOCKERFILE: << parameters.base-dockerfile >>
+                name: Run installer tests
+    shellcheck:
+        docker:
+            - entrypoint: /bin/sh
+              image: koalaman/shellcheck-alpine:v0.9.0
+        steps:
+            - checkout
+            - run: find bin/ test/ example/ installer/ -type f -executable | xargs shellcheck --exclude SC1071,SC1091,SC2317
+    system_tests:
+        machine:
+            image: ubuntu-2004:current
+        resource_class: large
+        steps:
+            - attach_workspace:
+                at: /tmp/workspace
+            - run:
+                command: git clone https://github.com/DataDog/system-tests.git
+                name: clone system-tests repo
+            - run:
+                command: sudo apt-get install python3.9-venv
+                name: Install python 3.9
+            - run:
+                command: cp /tmp/workspace/.musl-build/ngx_http_datadog_module.so binaries/ngx_http_datadog_module-appsec-amd64-1.25.4.so
+                name: Move the module to the system-tests directory
+                working_directory: ./system-tests
+            - run:
+                command: ./build.sh cpp
+                name: Build test targets
+                working_directory: ./system-tests
+            - run:
+                command: ./run.sh
+                environment:
+                    DD_API_KEY: fakekey
+                name: Run DEFAULT scenarios
+                working_directory: ./system-tests
+    test:
+        environment:
+            DOCKER_BUILDKIT: 1
+            WAF: << parameters.waf >>
+        executor:
+            image: cimg/python:3.10.13
+            name: docker-<< parameters.arch >>
+        parameters:
             arch:
-            - amd64
-            - arm64
-            waf:
-            - 'ON'
-            - 'OFF'
+                type: string
             base-image:
-            - nginx:1.27.1-alpine
-            - nginx:1.27.1
+                default: ""
+                type: string
             nginx-version:
-            - 1.27.1
-        name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch
-          >> WAF << matrix.waf >>
-        requires:
-        - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf
-          >>
-    - test:
-        matrix:
-          parameters:
-            arch:
-            - amd64
-            - arm64
+                type: string
             waf:
-            - 'ON'
-            - 'OFF'
-            base-image:
-            - amazonlinux:2.0.20230418.0
-            nginx-version:
-            - 1.22.1
-        name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch
-          >> WAF << matrix.waf >>
-        requires:
-        - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf
-          >>
-    - test:
-        matrix:
-          parameters:
-            arch:
-            - amd64
-            - arm64
-            waf:
-            - 'ON'
-            - 'OFF'
-            base-image:
-            - amazonlinux:2023.3.20240219.0
-            nginx-version:
-            - 1.24.0
-        name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
-        requires:
-        - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>
-    - system_tests:
-        name: Run system tests
-        requires:
-        - build 1.25.4 on amd64 WAF ON
-  build-and-test-all:
-    when:
-      or:
-        -  << pipeline.parameters.build_all >>
-        - matches: { pattern: "^v[0-9]+\\.[0-9]+\\.[0-9]+", value: << pipeline.git.tag >> }
-    jobs:
-    # output of bin/generate_jobs_yaml.rb
-    - build_amd64:
-        matrix:
-          parameters:
-            nginx-version:
-            - 1.22.0
-            - 1.22.1
-            - 1.23.0
-            - 1.23.1
-            - 1.23.2
-            - 1.23.3
-            - 1.23.4
-            - 1.24.0
-            - 1.25.0
-            - 1.25.1
-            - 1.25.2
-            - 1.25.3
-            - 1.25.4
-            - 1.25.5
-            - 1.26.0
-            - 1.26.1
-            - 1.26.2
-            - 1.27.0
-            - 1.27.1
-            waf:
-            - 'ON'
-            - 'OFF'
-        name: build << matrix.nginx-version >> on amd64 WAF << matrix.waf >>
-    - build_arm64:
-        matrix:
-          parameters:
-            nginx-version:
-            - 1.22.0
-            - 1.22.1
-            - 1.23.0
-            - 1.23.1
-            - 1.23.2
-            - 1.23.3
-            - 1.23.4
-            - 1.24.0
-            - 1.25.0
-            - 1.25.1
-            - 1.25.2
-            - 1.25.3
-            - 1.25.4
-            - 1.25.5
-            - 1.26.0
-            - 1.26.1
-            - 1.26.2
-            - 1.27.0
-            - 1.27.1
-            waf:
-            - 'ON'
-            - 'OFF'
-        name: build << matrix.nginx-version >> on arm64 WAF << matrix.waf >>
-    - test:
-        matrix:
-          parameters:
-            arch:
-            - amd64
-            - arm64
-            waf:
-            - 'ON'
-            - 'OFF'
-            base-image:
-            - amazonlinux:2023.3.20240219.0
-            - nginx:1.24.0-alpine
-            - nginx:1.24.0
-            nginx-version:
-            - 1.24.0
-        name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
-        requires:
-        - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>
-    - test:
-        matrix:
-          parameters:
-            arch:
-            - amd64
-            - arm64
-            waf:
-            - 'ON'
-            - 'OFF'
-            base-image:
-            - amazonlinux:2.0.20230418.0
-            - amazonlinux:2.0.20230320.0
-            - amazonlinux:2.0.20230307.0
-            - amazonlinux:2.0.20230221.0
-            - amazonlinux:2.0.20230207.0
-            - amazonlinux:2.0.20230119.1
-            - amazonlinux:2.0.20221210.0
-            - amazonlinux:2.0.20221103.3
-            - amazonlinux:2.0.20221004.0
-            - amazonlinux:2.0.20220912.1
-            - amazonlinux:2.0.20220805.0
-            - amazonlinux:2.0.20220719.0
-            - amazonlinux:2.0.20220606.1
-            - amazonlinux:2.0.20220426.0
-            - amazonlinux:2.0.20220419.0
-            - amazonlinux:2.0.20220406.1
-            - amazonlinux:2.0.20220316.0
-            - amazonlinux:2.0.20220218.1
-            - amazonlinux:2.0.20220121.0
-            - nginx:1.22.1-alpine
-            - nginx:1.22.1
-            nginx-version:
-            - 1.22.1
-        name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
-        requires:
-        - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>
-    - test:
-        matrix:
-          parameters:
-            arch:
-            - amd64
-            - arm64
-            waf:
-            - 'ON'
-            - 'OFF'
-            base-image:
-            - nginx:1.27.1-alpine
-            - nginx:1.27.1
-            nginx-version:
-            - 1.27.1
-        name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
-        requires:
-        - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>
-    - test:
-        matrix:
-          parameters:
-            arch:
-            - amd64
-            - arm64
-            waf:
-            - 'ON'
-            - 'OFF'
-            base-image:
-            - nginx:1.27.0-alpine
-            - nginx:1.27.0
-            nginx-version:
-            - 1.27.0
-        name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
-        requires:
-        - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>
-    - test:
-        matrix:
-          parameters:
-            arch:
-            - amd64
-            - arm64
-            waf:
-            - 'ON'
-            - 'OFF'
-            base-image:
-            - nginx:1.26.2-alpine
-            - nginx:1.26.2
-            nginx-version:
-            - 1.26.2
-        name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
-        requires:
-        - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>
-    - test:
-        matrix:
-          parameters:
-            arch:
-            - amd64
-            - arm64
-            waf:
-            - 'ON'
-            - 'OFF'
-            base-image:
-            - nginx:1.26.1-alpine
-            - nginx:1.26.1
-            nginx-version:
-            - 1.26.1
-        name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
-        requires:
-        - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>
-    - test:
-        matrix:
-          parameters:
-            arch:
-            - amd64
-            - arm64
-            waf:
-            - 'ON'
-            - 'OFF'
-            base-image:
-            - nginx:1.26.0-alpine
-            - nginx:1.26.0
-            nginx-version:
-            - 1.26.0
-        name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
-        requires:
-        - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>
-    - test:
-        matrix:
-          parameters:
-            arch:
-            - amd64
-            - arm64
-            waf:
-            - 'ON'
-            - 'OFF'
-            base-image:
-            - nginx:1.25.5-alpine
-            - nginx:1.25.5
-            nginx-version:
-            - 1.25.5
-        name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
-        requires:
-        - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>
-    - test:
-        matrix:
-          parameters:
-            arch:
-            - amd64
-            - arm64
-            waf:
-            - 'ON'
-            - 'OFF'
-            base-image:
-            - nginx:1.25.4-alpine
-            - nginx:1.25.4
-            nginx-version:
-            - 1.25.4
-        name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
-        requires:
-        - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>
-    - test:
-        matrix:
-          parameters:
-            arch:
-            - amd64
-            - arm64
-            waf:
-            - 'ON'
-            - 'OFF'
-            base-image:
-            - nginx:1.25.3-alpine
-            - nginx:1.25.3
-            nginx-version:
-            - 1.25.3
-        name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
-        requires:
-        - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>
-    - test:
-        matrix:
-          parameters:
-            arch:
-            - amd64
-            - arm64
-            waf:
-            - 'ON'
-            - 'OFF'
-            base-image:
-            - nginx:1.25.2-alpine
-            - nginx:1.25.2
-            nginx-version:
-            - 1.25.2
-        name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
-        requires:
-        - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>
-    - test:
-        matrix:
-          parameters:
-            arch:
-            - amd64
-            - arm64
-            waf:
-            - 'ON'
-            - 'OFF'
-            base-image:
-            - nginx:1.25.1-alpine
-            - nginx:1.25.1
-            nginx-version:
-            - 1.25.1
-        name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
-        requires:
-        - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>
-    - test:
-        matrix:
-          parameters:
-            arch:
-            - amd64
-            - arm64
-            waf:
-            - 'ON'
-            - 'OFF'
-            base-image:
-            - nginx:1.25.0-alpine
-            - nginx:1.25.0
-            nginx-version:
-            - 1.25.0
-        name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
-        requires:
-        - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>
-    - test:
-        matrix:
-          parameters:
-            arch:
-            - amd64
-            - arm64
-            waf:
-            - 'ON'
-            - 'OFF'
-            base-image:
-            - nginx:1.23.4-alpine
-            - nginx:1.23.4
-            nginx-version:
-            - 1.23.4
-        name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
-        requires:
-        - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>
-    - test:
-        matrix:
-          parameters:
-            arch:
-            - amd64
-            - arm64
-            waf:
-            - 'ON'
-            - 'OFF'
-            base-image:
-            - nginx:1.23.3-alpine
-            - nginx:1.23.3
-            nginx-version:
-            - 1.23.3
-        name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
-        requires:
-        - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>
-    - test:
-        matrix:
-          parameters:
-            arch:
-            - amd64
-            - arm64
-            waf:
-            - 'ON'
-            - 'OFF'
-            base-image:
-            - nginx:1.23.2-alpine
-            - nginx:1.23.2
-            nginx-version:
-            - 1.23.2
-        name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
-        requires:
-        - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>
-    - test:
-        matrix:
-          parameters:
-            arch:
-            - amd64
-            - arm64
-            waf:
-            - 'ON'
-            - 'OFF'
-            base-image:
-            - nginx:1.23.1-alpine
-            - nginx:1.23.1
-            nginx-version:
-            - 1.23.1
-        name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
-        requires:
-        - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>
-    - test:
-        matrix:
-          parameters:
-            arch:
-            - amd64
-            - arm64
-            waf:
-            - 'ON'
-            - 'OFF'
-            base-image:
-            - nginx:1.23.0-alpine
-            - nginx:1.23.0
-            nginx-version:
-            - 1.23.0
-        name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
-        requires:
-        - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>
-    - test:
-        matrix:
-          parameters:
-            arch:
-            - amd64
-            - arm64
-            waf:
-            - 'ON'
-            - 'OFF'
-            base-image:
-            - nginx:1.22.0-alpine
-            - nginx:1.22.0
-            nginx-version:
-            - 1.22.0
-        name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
-        requires:
-        - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>
+                type: string
+        steps:
+            - checkout
+            - attach_workspace:
+                at: /tmp/workspace
+            - run: mv -v /tmp/workspace/.musl-build/ngx_http_datadog_module.so* test/services/nginx/
+            - run: printf "ARCH=%s\nBASE_IMAGE=%s\n" << parameters.arch >> << parameters.base-image >> > nginx-version-info
+            - setup_remote_docker:
+                docker_layer_caching: true
+            - run: test/bin/run --verbose --failfast
+            - store_artifacts:
+                destination: test.log
+                path: test/logs/test.log
+orbs:
+    codecov: codecov/codecov@4.1.0
+parameters:
+    build_all:
+        default: false
+        type: boolean
+    run-installer-workflow:
+        default: false
+        type: boolean
+version: 2.1
+workflows:
+    build-and-test:
+        jobs:
+            - format
+            - shellcheck:
+                name: run shellcheck on shell scripts
+            - build_amd64:
+                matrix:
+                    parameters:
+                        nginx-version:
+                            - 1.22.1
+                            - 1.24.0
+                            - 1.25.4
+                            - 1.27.1
+                        waf:
+                            - "ON"
+                            - "OFF"
+                name: build << matrix.nginx-version >> on amd64 WAF << matrix.waf >>
+            - build_arm64:
+                matrix:
+                    parameters:
+                        nginx-version:
+                            - 1.22.1
+                            - 1.24.0
+                            - 1.27.1
+                        waf:
+                            - "ON"
+                            - "OFF"
+                name: build << matrix.nginx-version >> on arm64 WAF << matrix.waf >>
+            - coverage:
+                name: Coverage on 1.27.0 with WAF ON
+            - test:
+                matrix:
+                    parameters:
+                        arch:
+                            - amd64
+                            - arm64
+                        base-image:
+                            - nginx:1.27.1-alpine
+                            - nginx:1.27.1
+                        nginx-version:
+                            - 1.27.1
+                        waf:
+                            - "ON"
+                            - "OFF"
+                name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
+                requires:
+                    - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>
+            - test:
+                matrix:
+                    parameters:
+                        arch:
+                            - amd64
+                            - arm64
+                        base-image:
+                            - amazonlinux:2.0.20230418.0
+                        nginx-version:
+                            - 1.22.1
+                        waf:
+                            - "ON"
+                            - "OFF"
+                name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
+                requires:
+                    - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>
+            - test:
+                matrix:
+                    parameters:
+                        arch:
+                            - amd64
+                            - arm64
+                        base-image:
+                            - amazonlinux:2023.3.20240219.0
+                        nginx-version:
+                            - 1.24.0
+                        waf:
+                            - "ON"
+                            - "OFF"
+                name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
+                requires:
+                    - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>
+            - system_tests:
+                name: Run system tests
+                requires:
+                    - build 1.25.4 on amd64 WAF ON
+        when:
+            and:
+                - not: << pipeline.git.tag >>
+                - not: << pipeline.parameters.build_all >>
+    build-and-test-all:
+        jobs:
+            - build_amd64:
+                matrix:
+                    parameters:
+                        nginx-version:
+                            - 1.22.0
+                            - 1.22.1
+                            - 1.23.0
+                            - 1.23.1
+                            - 1.23.2
+                            - 1.23.3
+                            - 1.23.4
+                            - 1.24.0
+                            - 1.25.0
+                            - 1.25.1
+                            - 1.25.2
+                            - 1.25.3
+                            - 1.25.4
+                            - 1.25.5
+                            - 1.26.0
+                            - 1.26.1
+                            - 1.26.2
+                            - 1.27.0
+                            - 1.27.1
+                        waf:
+                            - "ON"
+                            - "OFF"
+                name: build << matrix.nginx-version >> on amd64 WAF << matrix.waf >>
+            - build_arm64:
+                matrix:
+                    parameters:
+                        nginx-version:
+                            - 1.22.0
+                            - 1.22.1
+                            - 1.23.0
+                            - 1.23.1
+                            - 1.23.2
+                            - 1.23.3
+                            - 1.23.4
+                            - 1.24.0
+                            - 1.25.0
+                            - 1.25.1
+                            - 1.25.2
+                            - 1.25.3
+                            - 1.25.4
+                            - 1.25.5
+                            - 1.26.0
+                            - 1.26.1
+                            - 1.26.2
+                            - 1.27.0
+                            - 1.27.1
+                        waf:
+                            - "ON"
+                            - "OFF"
+                name: build << matrix.nginx-version >> on arm64 WAF << matrix.waf >>
+            - test:
+                matrix:
+                    parameters:
+                        arch:
+                            - amd64
+                            - arm64
+                        base-image:
+                            - amazonlinux:2023.3.20240219.0
+                            - nginx:1.24.0-alpine
+                            - nginx:1.24.0
+                        nginx-version:
+                            - 1.24.0
+                        waf:
+                            - "ON"
+                            - "OFF"
+                name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
+                requires:
+                    - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>
+            - test:
+                matrix:
+                    parameters:
+                        arch:
+                            - amd64
+                            - arm64
+                        base-image:
+                            - amazonlinux:2.0.20230418.0
+                            - amazonlinux:2.0.20230320.0
+                            - amazonlinux:2.0.20230307.0
+                            - amazonlinux:2.0.20230221.0
+                            - amazonlinux:2.0.20230207.0
+                            - amazonlinux:2.0.20230119.1
+                            - amazonlinux:2.0.20221210.0
+                            - amazonlinux:2.0.20221103.3
+                            - amazonlinux:2.0.20221004.0
+                            - amazonlinux:2.0.20220912.1
+                            - amazonlinux:2.0.20220805.0
+                            - amazonlinux:2.0.20220719.0
+                            - amazonlinux:2.0.20220606.1
+                            - amazonlinux:2.0.20220426.0
+                            - amazonlinux:2.0.20220419.0
+                            - amazonlinux:2.0.20220406.1
+                            - amazonlinux:2.0.20220316.0
+                            - amazonlinux:2.0.20220218.1
+                            - amazonlinux:2.0.20220121.0
+                            - nginx:1.22.1-alpine
+                            - nginx:1.22.1
+                        nginx-version:
+                            - 1.22.1
+                        waf:
+                            - "ON"
+                            - "OFF"
+                name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
+                requires:
+                    - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>
+            - test:
+                matrix:
+                    parameters:
+                        arch:
+                            - amd64
+                            - arm64
+                        base-image:
+                            - nginx:1.27.1-alpine
+                            - nginx:1.27.1
+                        nginx-version:
+                            - 1.27.1
+                        waf:
+                            - "ON"
+                            - "OFF"
+                name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
+                requires:
+                    - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>
+            - test:
+                matrix:
+                    parameters:
+                        arch:
+                            - amd64
+                            - arm64
+                        base-image:
+                            - nginx:1.27.0-alpine
+                            - nginx:1.27.0
+                        nginx-version:
+                            - 1.27.0
+                        waf:
+                            - "ON"
+                            - "OFF"
+                name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
+                requires:
+                    - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>
+            - test:
+                matrix:
+                    parameters:
+                        arch:
+                            - amd64
+                            - arm64
+                        base-image:
+                            - nginx:1.26.2-alpine
+                            - nginx:1.26.2
+                        nginx-version:
+                            - 1.26.2
+                        waf:
+                            - "ON"
+                            - "OFF"
+                name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
+                requires:
+                    - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>
+            - test:
+                matrix:
+                    parameters:
+                        arch:
+                            - amd64
+                            - arm64
+                        base-image:
+                            - nginx:1.26.1-alpine
+                            - nginx:1.26.1
+                        nginx-version:
+                            - 1.26.1
+                        waf:
+                            - "ON"
+                            - "OFF"
+                name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
+                requires:
+                    - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>
+            - test:
+                matrix:
+                    parameters:
+                        arch:
+                            - amd64
+                            - arm64
+                        base-image:
+                            - nginx:1.26.0-alpine
+                            - nginx:1.26.0
+                        nginx-version:
+                            - 1.26.0
+                        waf:
+                            - "ON"
+                            - "OFF"
+                name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
+                requires:
+                    - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>
+            - test:
+                matrix:
+                    parameters:
+                        arch:
+                            - amd64
+                            - arm64
+                        base-image:
+                            - nginx:1.25.5-alpine
+                            - nginx:1.25.5
+                        nginx-version:
+                            - 1.25.5
+                        waf:
+                            - "ON"
+                            - "OFF"
+                name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
+                requires:
+                    - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>
+            - test:
+                matrix:
+                    parameters:
+                        arch:
+                            - amd64
+                            - arm64
+                        base-image:
+                            - nginx:1.25.4-alpine
+                            - nginx:1.25.4
+                        nginx-version:
+                            - 1.25.4
+                        waf:
+                            - "ON"
+                            - "OFF"
+                name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
+                requires:
+                    - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>
+            - test:
+                matrix:
+                    parameters:
+                        arch:
+                            - amd64
+                            - arm64
+                        base-image:
+                            - nginx:1.25.3-alpine
+                            - nginx:1.25.3
+                        nginx-version:
+                            - 1.25.3
+                        waf:
+                            - "ON"
+                            - "OFF"
+                name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
+                requires:
+                    - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>
+            - test:
+                matrix:
+                    parameters:
+                        arch:
+                            - amd64
+                            - arm64
+                        base-image:
+                            - nginx:1.25.2-alpine
+                            - nginx:1.25.2
+                        nginx-version:
+                            - 1.25.2
+                        waf:
+                            - "ON"
+                            - "OFF"
+                name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
+                requires:
+                    - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>
+            - test:
+                matrix:
+                    parameters:
+                        arch:
+                            - amd64
+                            - arm64
+                        base-image:
+                            - nginx:1.25.1-alpine
+                            - nginx:1.25.1
+                        nginx-version:
+                            - 1.25.1
+                        waf:
+                            - "ON"
+                            - "OFF"
+                name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
+                requires:
+                    - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>
+            - test:
+                matrix:
+                    parameters:
+                        arch:
+                            - amd64
+                            - arm64
+                        base-image:
+                            - nginx:1.25.0-alpine
+                            - nginx:1.25.0
+                        nginx-version:
+                            - 1.25.0
+                        waf:
+                            - "ON"
+                            - "OFF"
+                name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
+                requires:
+                    - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>
+            - test:
+                matrix:
+                    parameters:
+                        arch:
+                            - amd64
+                            - arm64
+                        base-image:
+                            - nginx:1.23.4-alpine
+                            - nginx:1.23.4
+                        nginx-version:
+                            - 1.23.4
+                        waf:
+                            - "ON"
+                            - "OFF"
+                name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
+                requires:
+                    - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>
+            - test:
+                matrix:
+                    parameters:
+                        arch:
+                            - amd64
+                            - arm64
+                        base-image:
+                            - nginx:1.23.3-alpine
+                            - nginx:1.23.3
+                        nginx-version:
+                            - 1.23.3
+                        waf:
+                            - "ON"
+                            - "OFF"
+                name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
+                requires:
+                    - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>
+            - test:
+                matrix:
+                    parameters:
+                        arch:
+                            - amd64
+                            - arm64
+                        base-image:
+                            - nginx:1.23.2-alpine
+                            - nginx:1.23.2
+                        nginx-version:
+                            - 1.23.2
+                        waf:
+                            - "ON"
+                            - "OFF"
+                name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
+                requires:
+                    - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>
+            - test:
+                matrix:
+                    parameters:
+                        arch:
+                            - amd64
+                            - arm64
+                        base-image:
+                            - nginx:1.23.1-alpine
+                            - nginx:1.23.1
+                        nginx-version:
+                            - 1.23.1
+                        waf:
+                            - "ON"
+                            - "OFF"
+                name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
+                requires:
+                    - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>
+            - test:
+                matrix:
+                    parameters:
+                        arch:
+                            - amd64
+                            - arm64
+                        base-image:
+                            - nginx:1.23.0-alpine
+                            - nginx:1.23.0
+                        nginx-version:
+                            - 1.23.0
+                        waf:
+                            - "ON"
+                            - "OFF"
+                name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
+                requires:
+                    - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>
+            - test:
+                matrix:
+                    parameters:
+                        arch:
+                            - amd64
+                            - arm64
+                        base-image:
+                            - nginx:1.22.0-alpine
+                            - nginx:1.22.0
+                        nginx-version:
+                            - 1.22.0
+                        waf:
+                            - "ON"
+                            - "OFF"
+                name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
+                requires:
+                    - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>
+        when:
+            or:
+                - << pipeline.parameters.build_all >>
+                - matches:
+                    pattern: ^v[0-9]+\.[0-9]+\.[0-9]+
+                    value: << pipeline.git.tag >>
+    build-and-test-installer:
+        jobs:
+            - build_installer_amd64:
+                name: build installer on amd64
+            - build_installer_arm64:
+                name: build installer on arm64
+            - installer_test:
+                matrix:
+                    parameters:
+                        base-dockerfile:
+                            - bookworm.Dockerfile
+                            - alpine.Dockerfile
+                            - al2023.Dockerfile
+                name: test installer with << matrix.base-dockerfile >> base image
+                requires:
+                    - build installer on amd64
+                    - build installer on arm64
+            - installer_download_test:
+                name: test installer download
+        when:
+            and:
+                - not: << pipeline.git.tag >>
+                - << pipeline.parameters.run-installer-workflow >>
+

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -122,6 +122,14 @@ jobs:
             - store_artifacts:
                 destination: nginx-configurator
                 path: ./installer/configurator/nginx-configurator
+    check-ci-definition:
+        docker:
+            - image: circleci/circleci-cli:latest
+        steps:
+            - checkout
+            - run:
+                command: "CIRCLE_CFG=generated-config.yml make circleci-config \ndiff .circleci/continue_config.yml generated-config.yml\n"
+                name: Verify
     coverage:
         environment:
             DOCKER_BUILDKIT: 1
@@ -150,9 +158,6 @@ jobs:
         resource_class: small
         steps:
             - checkout
-            - run:
-                command: "CIRCLE_CFG=generated-config.yml make circleci-config \ndiff .circleci/continue_config.yml generated-config.yml\n"
-                name: Verify
             - run:
                 command: |
                     pip install yapf
@@ -266,9 +271,15 @@ version: 2.1
 workflows:
     build-and-test:
         jobs:
-            - format
+            - check-ci-definition
+            - format:
+                name: Verify formatting
+                requires:
+                    - check-ci-definition
             - shellcheck:
                 name: run shellcheck on shell scripts
+                requires:
+                    - check-ci-definition
             - build_amd64:
                 matrix:
                     parameters:
@@ -758,10 +769,15 @@ workflows:
                     value: << pipeline.git.tag >>
     build-and-test-installer:
         jobs:
+            - check-ci-definition
             - build_installer_amd64:
                 name: build installer on amd64
+                requires:
+                    - check-ci-definition
             - build_installer_arm64:
                 name: build installer on arm64
+                requires:
+                    - check-ci-definition
             - installer_test:
                 matrix:
                     parameters:

--- a/.circleci/src/@common.yml
+++ b/.circleci/src/@common.yml
@@ -1,0 +1,28 @@
+version: 2.1
+
+orbs:
+  codecov: codecov/codecov@4.1.0
+
+parameters:
+  build_all:
+    type: boolean
+    default: false
+  run-installer-workflow:
+    type: boolean
+    default: false
+
+executors:
+  docker-amd64:
+    parameters:
+      image:
+        type: string
+    docker:
+    - image: "<< parameters.image >>"
+    resource_class: xlarge
+  docker-arm64:
+    parameters:
+      image:
+        type: string
+    docker:
+    - image: "<< parameters.image >>"
+    resource_class: arm.xlarge

--- a/.circleci/src/@jobs.yml
+++ b/.circleci/src/@jobs.yml
@@ -169,11 +169,6 @@ jobs:
     steps:
     - checkout
     - run:
-        name: Verify 
-        command: |
-          CIRCLE_CFG=generated-config.yml make circleci-config 
-          diff .circleci/continue_config.yml generated-config.yml
-    - run:
         name: Install Python dependencies
         command: |
           pip install yapf
@@ -187,7 +182,16 @@ jobs:
     - checkout
     - run: find bin/ test/ example/ installer/ -type f -executable | xargs shellcheck --exclude
         SC1071,SC1091,SC2317
-
+  check-ci-definition:
+    docker:
+      - image: circleci/circleci-cli:latest
+    steps:
+    - checkout
+    - run:
+        name: Verify 
+        command: |
+          CIRCLE_CFG=generated-config.yml make circleci-config 
+          diff .circleci/continue_config.yml generated-config.yml
   build_installer_arm64:
     steps:
     - checkout

--- a/.circleci/src/@jobs.yml
+++ b/.circleci/src/@jobs.yml
@@ -1,0 +1,241 @@
+jobs:
+  build_amd64:
+    parameters:
+      nginx-version:
+        type: string
+      waf:
+        type: enum
+        enum:
+        - 'ON'
+        - 'OFF'
+    steps:
+    - checkout
+    - run: git submodule sync && git submodule update --init --recursive
+    - run:
+        name: Verify versions (release tag only)
+        command: |
+          if [[ $CIRCLE_TAG =~ ^v ]]; then
+            bin/verify_version.sh "$(echo "$CIRCLE_TAG" | tr -d v)"
+          else
+            echo "Not a release"
+          fi
+    - run:
+        command: 'make build-musl'
+        environment:
+          BUILD_TYPE: RelWithDebInfo
+          NGINX_VERSION: "<< parameters.nginx-version >>"
+    - persist_to_workspace:
+        root: "."
+        paths:
+          - ".musl-build/ngx_http_datadog_module.so"
+          - ".musl-build/ngx_http_datadog_module.so.debug"
+    - store_artifacts:
+        path: ".musl-build/ngx_http_datadog_module.so"
+        destination: ngx_http_datadog_module.so
+    - store_artifacts:
+        path: ".musl-build/ngx_http_datadog_module.so.debug"
+        destination: ngx_http_datadog_module.so.debug
+    machine:
+      image: ubuntu-2204:current
+    resource_class: xlarge
+    environment:
+      ARCH: x86_64
+      MAKE_JOB_COUNT: 8
+      WAF: "<< parameters.waf >>"
+      NGINX_VERSION: "<< parameters.nginx-version >>"
+  build_arm64:
+    parameters:
+      nginx-version:
+        type: string
+      waf:
+        type: enum
+        enum:
+        - 'ON'
+        - 'OFF'
+    steps:
+    - checkout
+    - run: git submodule sync && git submodule update --init --recursive
+    - run:
+        command: 'make build-musl'
+        environment:
+          BUILD_TYPE: RelWithDebInfo
+          NGINX_VERSION: "<< parameters.nginx-version >>"
+    - persist_to_workspace:
+        root: "."
+        paths:
+          - ".musl-build/ngx_http_datadog_module.so"
+          - ".musl-build/ngx_http_datadog_module.so.debug"
+    - store_artifacts:
+        path: ".musl-build/ngx_http_datadog_module.so"
+        destination: ngx_http_datadog_module.so
+    - store_artifacts:
+        path: ".musl-build/ngx_http_datadog_module.so.debug"
+        destination: ngx_http_datadog_module.so.debug
+    - store_artifacts:
+        path: nginx-version-info
+        destination: nginx-version-info
+    machine:
+      image: ubuntu-2204:current
+    resource_class: arm.xlarge
+    environment:
+      ARCH: aarch64
+      MAKE_JOB_COUNT: 8
+      WAF: "<< parameters.waf >>"
+      NGINX_VERSION: "<< parameters.nginx-version >>"
+  coverage:
+    environment:
+      DOCKER_BUILDKIT: 1
+    steps:
+    - checkout
+    - run: git submodule sync && git submodule update --init --recursive
+    - run: echo -e "ARCH=amd64\nBASE_IMAGE=nginx:1.26.0\n" > nginx-version-info
+    - run:
+        command: 'make coverage'
+        environment:
+          ARCH: x86_64
+          MAKE_JOB_COUNT: 8
+          BUILD_TYPE: RelWithDebInfo
+          NGINX_VERSION: 1.26.0
+          WAF: ON
+    - codecov/upload:
+        upload_args: '--disable-search'
+        file: .musl-build/coverage.lcov
+        upload_name: circleci
+    machine:
+      image: ubuntu-2204:current
+    resource_class: xlarge
+  test:
+    parameters:
+      base-image:
+        type: string
+        default: ''
+      nginx-version:
+        type: string
+      arch:
+        type: string
+      waf:
+        type: string
+    executor:
+      name: docker-<< parameters.arch >>
+      image: cimg/python:3.10.13
+    environment:
+      # https://github.com/containers/podman/issues/13889
+      DOCKER_BUILDKIT: 1
+      WAF: "<< parameters.waf >>"
+    steps:
+    - checkout
+    - attach_workspace:
+        at: "/tmp/workspace"
+    - run: mv -v /tmp/workspace/.musl-build/ngx_http_datadog_module.so* test/services/nginx/
+    - run: printf "ARCH=%s\nBASE_IMAGE=%s\n" << parameters.arch >> << parameters.base-image >> > nginx-version-info
+    - setup_remote_docker:
+        docker_layer_caching: true
+    - run: test/bin/run --verbose --failfast
+    - store_artifacts:
+        path: test/logs/test.log
+        destination: test.log
+  system_tests:
+    machine:
+      # https://support.circleci.com/hc/en-us/articles/360007324514-How-can-I-use-Docker-volume-mounting-on-CircleCI-
+      image: ubuntu-2004:current
+    resource_class: large
+    steps:
+      - attach_workspace:
+          at: "/tmp/workspace"
+      - run:
+          name: clone system-tests repo
+          command: git clone https://github.com/DataDog/system-tests.git
+      - run:
+          name: Install python 3.9
+          command: sudo apt-get install python3.9-venv
+      - run:
+          name: Move the module to the system-tests directory
+          working_directory: ./system-tests
+          command: cp /tmp/workspace/.musl-build/ngx_http_datadog_module.so binaries/ngx_http_datadog_module-appsec-amd64-1.25.4.so
+      - run:
+          name: Build test targets
+          working_directory: ./system-tests
+          command: ./build.sh cpp
+      - run:
+          name: Run DEFAULT scenarios
+          working_directory: ./system-tests
+          command: ./run.sh
+          environment:
+            DD_API_KEY: fakekey
+  format:
+    docker:
+    - image: datadog/docker-library:dd-trace-cpp-ci
+    resource_class: small
+    steps:
+    - checkout
+    - run:
+        name: Install Python dependencies
+        command: |
+          pip install yapf
+          update-alternatives --install /usr/local/bin/yapf3 yapf3 /usr/local/bin/yapf 100
+    - run: make lint
+  shellcheck:
+    docker:
+    - image: koalaman/shellcheck-alpine:v0.9.0
+      entrypoint: "/bin/sh"
+    steps:
+    - checkout
+    - run: find bin/ test/ example/ installer/ -type f -executable | xargs shellcheck --exclude
+        SC1071,SC1091,SC2317
+
+  build_installer_arm64:
+    steps:
+    - checkout
+    - run: go test -C ./installer/configurator -v
+    - run: CGO_ENABLED=0 go -C ./installer/configurator build -o nginx-configurator
+    - store_artifacts:
+        path: "./installer/configurator/nginx-configurator"
+        destination: nginx-configurator
+    machine:
+      image: ubuntu-2204:current
+    resource_class: arm.medium
+  build_installer_amd64:
+    steps:
+    - checkout
+    - run: CGO_ENABLED=0 go -C ./installer/configurator build -o nginx-configurator
+    - persist_to_workspace:
+        root: "./installer/configurator"
+        paths:
+          - "nginx-configurator"
+    - store_artifacts:
+        path: "./installer/configurator/nginx-configurator"
+        destination: nginx-configurator
+    machine:
+      image: ubuntu-2204:current
+    resource_class: medium
+  installer_test:
+    parameters:
+      base-dockerfile:
+        type: string
+    machine:
+      image: ubuntu-2204:current
+    steps:
+    - checkout
+    - attach_workspace:
+        at: "/tmp/workspace"
+    - run:
+          name: Move the configurator go binary to the installer directory
+          working_directory: ./installer
+          command: cp /tmp/workspace/nginx-configurator .
+    - run:
+        name: Run installer tests
+        command: docker compose -f installer/test/docker-compose.yml up --build --exit-code-from nginx
+        environment:
+          DD_API_KEY: fakekey
+          NGINX_DOCKERFILE: << parameters.base-dockerfile >>
+  installer_download_test:
+    machine:
+      image: ubuntu-2204:current
+    steps:
+    - checkout
+    - run:
+        name: Run installer download tests
+        command: docker compose -f installer/test/docker-compose-download.yml up --build --exit-code-from nginx
+        environment:
+          DD_API_KEY: fakekey
+          NGINX_DOCKERFILE: bookworm.Dockerfile

--- a/.circleci/src/@jobs.yml
+++ b/.circleci/src/@jobs.yml
@@ -169,6 +169,11 @@ jobs:
     steps:
     - checkout
     - run:
+        name: Verify 
+        command: |
+          CIRCLE_CFG=generated-config.yml make circleci-config 
+          diff .circleci/continue_config.yml generated-config.yml
+    - run:
         name: Install Python dependencies
         command: |
           pip install yapf

--- a/.circleci/src/workflows/build-and-test-all.yml
+++ b/.circleci/src/workflows/build-and-test-all.yml
@@ -1,0 +1,403 @@
+    when:
+      or:
+        -  << pipeline.parameters.build_all >>
+        - matches: { pattern: "^v[0-9]+\\.[0-9]+\\.[0-9]+", value: << pipeline.git.tag >> }
+    jobs:
+    # output of bin/generate_jobs_yaml.rb
+    - build_amd64:
+        matrix:
+          parameters:
+            nginx-version:
+            - 1.22.0
+            - 1.22.1
+            - 1.23.0
+            - 1.23.1
+            - 1.23.2
+            - 1.23.3
+            - 1.23.4
+            - 1.24.0
+            - 1.25.0
+            - 1.25.1
+            - 1.25.2
+            - 1.25.3
+            - 1.25.4
+            - 1.25.5
+            - 1.26.0
+            - 1.26.1
+            - 1.26.2
+            - 1.27.0
+            - 1.27.1
+            waf:
+            - 'ON'
+            - 'OFF'
+        name: build << matrix.nginx-version >> on amd64 WAF << matrix.waf >>
+    - build_arm64:
+        matrix:
+          parameters:
+            nginx-version:
+            - 1.22.0
+            - 1.22.1
+            - 1.23.0
+            - 1.23.1
+            - 1.23.2
+            - 1.23.3
+            - 1.23.4
+            - 1.24.0
+            - 1.25.0
+            - 1.25.1
+            - 1.25.2
+            - 1.25.3
+            - 1.25.4
+            - 1.25.5
+            - 1.26.0
+            - 1.26.1
+            - 1.26.2
+            - 1.27.0
+            - 1.27.1
+            waf:
+            - 'ON'
+            - 'OFF'
+        name: build << matrix.nginx-version >> on arm64 WAF << matrix.waf >>
+    - test:
+        matrix:
+          parameters:
+            arch:
+            - amd64
+            - arm64
+            waf:
+            - 'ON'
+            - 'OFF'
+            base-image:
+            - amazonlinux:2023.3.20240219.0
+            - nginx:1.24.0-alpine
+            - nginx:1.24.0
+            nginx-version:
+            - 1.24.0
+        name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
+        requires:
+        - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>
+    - test:
+        matrix:
+          parameters:
+            arch:
+            - amd64
+            - arm64
+            waf:
+            - 'ON'
+            - 'OFF'
+            base-image:
+            - amazonlinux:2.0.20230418.0
+            - amazonlinux:2.0.20230320.0
+            - amazonlinux:2.0.20230307.0
+            - amazonlinux:2.0.20230221.0
+            - amazonlinux:2.0.20230207.0
+            - amazonlinux:2.0.20230119.1
+            - amazonlinux:2.0.20221210.0
+            - amazonlinux:2.0.20221103.3
+            - amazonlinux:2.0.20221004.0
+            - amazonlinux:2.0.20220912.1
+            - amazonlinux:2.0.20220805.0
+            - amazonlinux:2.0.20220719.0
+            - amazonlinux:2.0.20220606.1
+            - amazonlinux:2.0.20220426.0
+            - amazonlinux:2.0.20220419.0
+            - amazonlinux:2.0.20220406.1
+            - amazonlinux:2.0.20220316.0
+            - amazonlinux:2.0.20220218.1
+            - amazonlinux:2.0.20220121.0
+            - nginx:1.22.1-alpine
+            - nginx:1.22.1
+            nginx-version:
+            - 1.22.1
+        name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
+        requires:
+        - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>
+    - test:
+        matrix:
+          parameters:
+            arch:
+            - amd64
+            - arm64
+            waf:
+            - 'ON'
+            - 'OFF'
+            base-image:
+            - nginx:1.27.1-alpine
+            - nginx:1.27.1
+            nginx-version:
+            - 1.27.1
+        name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
+        requires:
+        - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>
+    - test:
+        matrix:
+          parameters:
+            arch:
+            - amd64
+            - arm64
+            waf:
+            - 'ON'
+            - 'OFF'
+            base-image:
+            - nginx:1.27.0-alpine
+            - nginx:1.27.0
+            nginx-version:
+            - 1.27.0
+        name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
+        requires:
+        - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>
+    - test:
+        matrix:
+          parameters:
+            arch:
+            - amd64
+            - arm64
+            waf:
+            - 'ON'
+            - 'OFF'
+            base-image:
+            - nginx:1.26.2-alpine
+            - nginx:1.26.2
+            nginx-version:
+            - 1.26.2
+        name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
+        requires:
+        - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>
+    - test:
+        matrix:
+          parameters:
+            arch:
+            - amd64
+            - arm64
+            waf:
+            - 'ON'
+            - 'OFF'
+            base-image:
+            - nginx:1.26.1-alpine
+            - nginx:1.26.1
+            nginx-version:
+            - 1.26.1
+        name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
+        requires:
+        - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>
+    - test:
+        matrix:
+          parameters:
+            arch:
+            - amd64
+            - arm64
+            waf:
+            - 'ON'
+            - 'OFF'
+            base-image:
+            - nginx:1.26.0-alpine
+            - nginx:1.26.0
+            nginx-version:
+            - 1.26.0
+        name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
+        requires:
+        - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>
+    - test:
+        matrix:
+          parameters:
+            arch:
+            - amd64
+            - arm64
+            waf:
+            - 'ON'
+            - 'OFF'
+            base-image:
+            - nginx:1.25.5-alpine
+            - nginx:1.25.5
+            nginx-version:
+            - 1.25.5
+        name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
+        requires:
+        - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>
+    - test:
+        matrix:
+          parameters:
+            arch:
+            - amd64
+            - arm64
+            waf:
+            - 'ON'
+            - 'OFF'
+            base-image:
+            - nginx:1.25.4-alpine
+            - nginx:1.25.4
+            nginx-version:
+            - 1.25.4
+        name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
+        requires:
+        - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>
+    - test:
+        matrix:
+          parameters:
+            arch:
+            - amd64
+            - arm64
+            waf:
+            - 'ON'
+            - 'OFF'
+            base-image:
+            - nginx:1.25.3-alpine
+            - nginx:1.25.3
+            nginx-version:
+            - 1.25.3
+        name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
+        requires:
+        - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>
+    - test:
+        matrix:
+          parameters:
+            arch:
+            - amd64
+            - arm64
+            waf:
+            - 'ON'
+            - 'OFF'
+            base-image:
+            - nginx:1.25.2-alpine
+            - nginx:1.25.2
+            nginx-version:
+            - 1.25.2
+        name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
+        requires:
+        - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>
+    - test:
+        matrix:
+          parameters:
+            arch:
+            - amd64
+            - arm64
+            waf:
+            - 'ON'
+            - 'OFF'
+            base-image:
+            - nginx:1.25.1-alpine
+            - nginx:1.25.1
+            nginx-version:
+            - 1.25.1
+        name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
+        requires:
+        - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>
+    - test:
+        matrix:
+          parameters:
+            arch:
+            - amd64
+            - arm64
+            waf:
+            - 'ON'
+            - 'OFF'
+            base-image:
+            - nginx:1.25.0-alpine
+            - nginx:1.25.0
+            nginx-version:
+            - 1.25.0
+        name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
+        requires:
+        - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>
+    - test:
+        matrix:
+          parameters:
+            arch:
+            - amd64
+            - arm64
+            waf:
+            - 'ON'
+            - 'OFF'
+            base-image:
+            - nginx:1.23.4-alpine
+            - nginx:1.23.4
+            nginx-version:
+            - 1.23.4
+        name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
+        requires:
+        - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>
+    - test:
+        matrix:
+          parameters:
+            arch:
+            - amd64
+            - arm64
+            waf:
+            - 'ON'
+            - 'OFF'
+            base-image:
+            - nginx:1.23.3-alpine
+            - nginx:1.23.3
+            nginx-version:
+            - 1.23.3
+        name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
+        requires:
+        - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>
+    - test:
+        matrix:
+          parameters:
+            arch:
+            - amd64
+            - arm64
+            waf:
+            - 'ON'
+            - 'OFF'
+            base-image:
+            - nginx:1.23.2-alpine
+            - nginx:1.23.2
+            nginx-version:
+            - 1.23.2
+        name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
+        requires:
+        - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>
+    - test:
+        matrix:
+          parameters:
+            arch:
+            - amd64
+            - arm64
+            waf:
+            - 'ON'
+            - 'OFF'
+            base-image:
+            - nginx:1.23.1-alpine
+            - nginx:1.23.1
+            nginx-version:
+            - 1.23.1
+        name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
+        requires:
+        - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>
+    - test:
+        matrix:
+          parameters:
+            arch:
+            - amd64
+            - arm64
+            waf:
+            - 'ON'
+            - 'OFF'
+            base-image:
+            - nginx:1.23.0-alpine
+            - nginx:1.23.0
+            nginx-version:
+            - 1.23.0
+        name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
+        requires:
+        - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>
+    - test:
+        matrix:
+          parameters:
+            arch:
+            - amd64
+            - arm64
+            waf:
+            - 'ON'
+            - 'OFF'
+            base-image:
+            - nginx:1.22.0-alpine
+            - nginx:1.22.0
+            nginx-version:
+            - 1.22.0
+        name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
+        requires:
+        - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>

--- a/.circleci/src/workflows/build-and-test-installer.yml
+++ b/.circleci/src/workflows/build-and-test-installer.yml
@@ -3,10 +3,15 @@
         - not: << pipeline.git.tag >>
         - << pipeline.parameters.run-installer-workflow >>
     jobs:
+     - check-ci-definition
      - build_installer_amd64:
         name: build installer on amd64
+        requires: 
+        - check-ci-definition
      - build_installer_arm64:
         name: build installer on arm64
+        requires: 
+        - check-ci-definition
      - installer_test:
         matrix:
           parameters:

--- a/.circleci/src/workflows/build-and-test-installer.yml
+++ b/.circleci/src/workflows/build-and-test-installer.yml
@@ -1,0 +1,22 @@
+    when:
+      and:
+        - not: << pipeline.git.tag >>
+        - << pipeline.parameters.run-installer-workflow >>
+    jobs:
+     - build_installer_amd64:
+        name: build installer on amd64
+     - build_installer_arm64:
+        name: build installer on arm64
+     - installer_test:
+        matrix:
+          parameters:
+            base-dockerfile:
+            - 'bookworm.Dockerfile'
+            - 'alpine.Dockerfile'
+            - 'al2023.Dockerfile'
+        name: test installer with << matrix.base-dockerfile >> base image
+        requires:
+        - build installer on amd64
+        - build installer on arm64
+     - installer_download_test:
+        name: test installer download

--- a/.circleci/src/workflows/build-and-test.yml
+++ b/.circleci/src/workflows/build-and-test.yml
@@ -1,0 +1,90 @@
+when:
+  and:
+    - not: << pipeline.git.tag >>
+    - not: << pipeline.parameters.build_all >>
+jobs:
+- format
+- shellcheck:
+    name: run shellcheck on shell scripts
+- build_amd64:
+    matrix:
+      parameters:
+        nginx-version:
+        - 1.22.1
+        - 1.24.0
+        - 1.25.4
+        - 1.27.1
+        waf:
+        - 'ON'
+        - 'OFF'
+    name: build << matrix.nginx-version >> on amd64 WAF << matrix.waf >>
+- build_arm64:
+    matrix:
+      parameters:
+        nginx-version:
+        - 1.22.1
+        - 1.24.0
+        - 1.27.1
+        waf:
+        - 'ON'
+        - 'OFF'
+    name: build << matrix.nginx-version >> on arm64 WAF << matrix.waf >>
+- coverage:
+    name: Coverage on 1.27.0 with WAF ON
+- test:
+    matrix:
+      parameters:
+        arch:
+        - amd64
+        - arm64
+        waf:
+        - 'ON'
+        - 'OFF'
+        base-image:
+        - nginx:1.27.1-alpine
+        - nginx:1.27.1
+        nginx-version:
+        - 1.27.1
+    name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch
+      >> WAF << matrix.waf >>
+    requires:
+    - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf
+      >>
+- test:
+    matrix:
+      parameters:
+        arch:
+        - amd64
+        - arm64
+        waf:
+        - 'ON'
+        - 'OFF'
+        base-image:
+        - amazonlinux:2.0.20230418.0
+        nginx-version:
+        - 1.22.1
+    name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch
+      >> WAF << matrix.waf >>
+    requires:
+    - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf
+      >>
+- test:
+    matrix:
+      parameters:
+        arch:
+        - amd64
+        - arm64
+        waf:
+        - 'ON'
+        - 'OFF'
+        base-image:
+        - amazonlinux:2023.3.20240219.0
+        nginx-version:
+        - 1.24.0
+    name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
+    requires:
+    - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>
+- system_tests:
+    name: Run system tests
+    requires:
+    - build 1.25.4 on amd64 WAF ON

--- a/.circleci/src/workflows/build-and-test.yml
+++ b/.circleci/src/workflows/build-and-test.yml
@@ -3,9 +3,15 @@ when:
     - not: << pipeline.git.tag >>
     - not: << pipeline.parameters.build_all >>
 jobs:
-- format
+- check-ci-definition
+- format:
+    name: Verify formatting
+    requires: 
+    - check-ci-definition
 - shellcheck:
     name: run shellcheck on shell scripts
+    requires: 
+    - check-ci-definition
 - build_amd64:
     matrix:
       parameters:

--- a/Makefile
+++ b/Makefile
@@ -145,3 +145,10 @@ test-parallel: build-in-docker
 lab: build-musl
 	cp -v .musl-build/ngx_http_datadog_module.so* lab/services/nginx/
 	lab/bin/run $(TEST_ARGS)
+
+.PHONY: circleci-config
+circleci-config:
+	@echo "Compiling circleci config"
+	circleci config pack .circleci/src > .circleci/continue_config.yml
+	@echo "Validating circleci config"
+	circleci config validate .circleci/continue_config.yml 

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ NGINX_SRC_DIR ?= $(PWD)/nginx
 ARCH ?= $(shell arch)
 COVERAGE ?= OFF
 DOCKER_REPOS ?= public.ecr.aws/b1o7r7e0/nginx_musl_toolchain
+CIRCLE_CFG ?= .circleci/continue_config.yml
 
 SHELL := /bin/bash
 
@@ -149,6 +150,6 @@ lab: build-musl
 .PHONY: circleci-config
 circleci-config:
 	@echo "Compiling circleci config"
-	circleci config pack .circleci/src > .circleci/continue_config.yml
+	circleci config pack .circleci/src > $(CIRCLE_CFG)
 	@echo "Validating circleci config"
-	circleci config validate .circleci/continue_config.yml 
+	circleci config validate $(CIRCLE_CFG)


### PR DESCRIPTION
# Description
Refactor the CircleCI configuration to improve maintainability and readability. The `continue_config.yml` has been broken down into several files within the `.circle/src` folder:
- `@common.yml`: Contains shared orbs, parameters, and executors used across jobs and workflows.
- `@jobs.yml`: Defines all jobs shared across workflows.
- `workflow/`: Directory with all workflow definitions.

Since CircleCI is a 🦖 and revolves around a single configuration file, this split needs to be reassembled into a large, gigantic YAML soup to work with their system. 

You can rebuild the continue_config.yml using the new target as follows:

```sh
make circleci-config
```

This new target uses [CircleCI CLI tool](https://circleci.com/docs/local-cli/) under the hood.

## Motivation
I am going to include ingress-nginx support soon and finally reached a state where it felt necessary to broken down this configuration file.

## ~~⚠️ Note to maintainers ⚠️~~
~~Remember to `make circleci-config` for any CI changes.~~