### PR TITLE
fix: symbol split

### DIFF
--- a/nginx_module.ld
+++ b/nginx_module.ld
@@ -4,7 +4,7 @@
 		ngx_module_names;
 		ngx_module_order;
 		datadog_version_*;
-		ddatadog_semver_*;
-		ddatadog_build_id_nginx_mod;
+		datadog_semver_*;
+		datadog_build_id_nginx_mod;
 	local: *; /* Hide all other symbols */
 };


### PR DESCRIPTION
# Description
A recent version of the musl docker container has been pushed today which started to make this typo more explicit. This fix the symbol the keep.