### PR TITLE
feat: add datadog_tracing directive

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -188,7 +188,7 @@ the service than it can within nginx.
 
 Sampling delegation is `off` by default. The directive's argument can be a
 variable expression that evaluates to either of `on` or `off`. If the
-directive's argument is omitted, then it is as if it were `on`
+directive's argument is omitted, then it is as if it were `on`.
 
 ### `datadog_tracing`
 - **syntax** `datadog_tracing on|off`

--- a/doc/API.md
+++ b/doc/API.md
@@ -188,34 +188,25 @@ the service than it can within nginx.
 
 Sampling delegation is `off` by default. The directive's argument can be a
 variable expression that evaluates to either of `on` or `off`. If the
-directive's argument is omitted, then it is as if it were `on`.
+directive's argument is omitted, then it is as if it were `on`
 
-### `datadog_enable`
-- **syntax** `datadog_enable`
+### `datadog_tracing`
+- **syntax** `datadog_tracing on|off`
+- **default** `on`
 - **context** `http`, `server`, `location`
 
-Enable Datadog tracing in the current configuration context.  This overrides
-any `datadog_disable` directives at higher levels, and may be overridden by
-`datadog_disable` directives at lower levels.
+If `on`, enable Datadog tracing in the current configuration context.
+If `off`, disable Datadog tracing in the current configuration context.
+
+This overrides any `datadog_tracing` directives at higher levels,
+and may be overriden by `datadog_tracing` directives at lower levels.
 
 When tracing is enabled, a span is created for each request, and trace context
 is propagated to the proxied service.
-
-Datadog tracing is enabled by default.
-
-### `datadog_disable`
-- **syntax** `datadog_disable`
-- **context** `http`, `server`, `location`
-
-Disable Datadog tracing in the current configuration context.  This overrides
-any `datadog_enable` directives at higher levels, and may be overridden by
-`datadog_enable` directives at lower levels.
-
 When tracing is disabled, no span is created when a request is handled, and no
 trace context is propagated to proxied services.
 
-Datadog tracing is enabled by default.  This directive is the way to disable
-it.
+Datadog tracing is enabled by default.
 
 ### `datadog_resource_name`
 

--- a/example/tracing/services/nginx/nginx.conf
+++ b/example/tracing/services/nginx/nginx.conf
@@ -42,7 +42,7 @@ http {
 
         location /http-no-trace {
             # Don't trace these requests.
-            datadog_disable;
+            datadog_tracing off;
             proxy_pass http://http:8080;
         }
 

--- a/installer/configurator/nginx_configurator.go
+++ b/installer/configurator/nginx_configurator.go
@@ -262,7 +262,7 @@ func transformConfig(n *NginxConfigurator, content []byte, agentUri string, appI
 	datadogConfig := fmt.Sprintf(`    datadog_agent_url %s;
 
     # Disable APM Tracing. Remove the next line to enable APM Tracing.
-    datadog_disable;
+    datadog_tracing off;
 
     # Enable RUM Injection
     datadog_rum on;

--- a/installer/configurator/testdata/basic.conf.snap
+++ b/installer/configurator/testdata/basic.conf.snap
@@ -15,7 +15,7 @@ http {
     datadog_agent_url http://localhost:8126;
 
     # Disable APM Tracing. Remove the next line to enable APM Tracing.
-    datadog_disable;
+    datadog_tracing off;
 
     # Enable RUM Injection
     datadog_rum on;

--- a/installer/configurator/testdata/example1.conf.snap
+++ b/installer/configurator/testdata/example1.conf.snap
@@ -13,7 +13,7 @@ http {
     datadog_agent_url http://localhost:8126;
 
     # Disable APM Tracing. Remove the next line to enable APM Tracing.
-    datadog_disable;
+    datadog_tracing off;
 
     # Enable RUM Injection
     datadog_rum on;

--- a/installer/configurator/testdata/example2.conf.snap
+++ b/installer/configurator/testdata/example2.conf.snap
@@ -22,7 +22,7 @@ http {
     datadog_agent_url http://localhost:8126;
 
     # Disable APM Tracing. Remove the next line to enable APM Tracing.
-    datadog_disable;
+    datadog_tracing off;
 
     # Enable RUM Injection
     datadog_rum on;

--- a/installer/configurator/testdata/weird_http_spaces.conf.snap
+++ b/installer/configurator/testdata/weird_http_spaces.conf.snap
@@ -20,7 +20,7 @@ http
     datadog_agent_url http://localhost:8126;
 
     # Disable APM Tracing. Remove the next line to enable APM Tracing.
-    datadog_disable;
+    datadog_tracing off;
 
     # Enable RUM Injection
     datadog_rum on;

--- a/lab/services/nginx/nginx.conf
+++ b/lab/services/nginx/nginx.conf
@@ -78,7 +78,7 @@ http {
 
         location /self {
             datadog_delegate_sampling;
-            # datadog_disable;
+            # datadog_tracing off;
             proxy_pass "http://localhost:80/";
         }
 

--- a/src/datadog_conf.h
+++ b/src/datadog_conf.h
@@ -183,7 +183,7 @@ struct datadog_sample_rate_condition_t {
 };
 
 struct datadog_loc_conf_t {
-  ngx_flag_t enable = NGX_CONF_UNSET;
+  ngx_flag_t enable_tracing = NGX_CONF_UNSET;
   ngx_flag_t enable_locations = NGX_CONF_UNSET;
   NgxScript operation_name_script;
   NgxScript loc_operation_name_script;

--- a/src/datadog_context.cpp
+++ b/src/datadog_context.cpp
@@ -24,7 +24,7 @@ DatadogContext::DatadogContext(ngx_http_request_t *request,
     : sec_ctx_{security::Context::maybe_create()}
 #endif
 {
-  if (loc_conf->enable) {
+  if (loc_conf->enable_tracing) {
     traces_.emplace_back(request, core_loc_conf, loc_conf);
   }
 
@@ -48,7 +48,7 @@ DatadogContext::DatadogContext(ngx_http_request_t *request,
 void DatadogContext::on_change_block(ngx_http_request_t *request,
                                      ngx_http_core_loc_conf_t *core_loc_conf,
                                      datadog_loc_conf_t *loc_conf) {
-  if (loc_conf->enable) {
+  if (loc_conf->enable_tracing) {
     auto trace = find_trace(request);
     if (trace != nullptr) {
       trace->on_change_block(core_loc_conf, loc_conf);
@@ -158,7 +158,7 @@ void DatadogContext::on_log_request(ngx_http_request_t *request) {
     throw std::runtime_error{"on_log_request failed: could not get loc conf"};
   }
 
-  if (!loc_conf->enable) {
+  if (!loc_conf->enable_tracing) {
     return;
   }
 

--- a/src/datadog_directive.cpp
+++ b/src/datadog_directive.cpp
@@ -179,13 +179,10 @@ char *toggle_opentracing(ngx_conf_t *cf, ngx_command_t *command,
   const auto values = static_cast<const ngx_str_t *>(cf->args->elts);
   assert(cf->args->nelts == 2);
 
-  std::string_view preferred;
   if (str(values[1]) == "on") {
-    loc_conf->enable = true;
-    preferred = "datadog_enable";
+    loc_conf->enable_tracing = true;
   } else if (str(values[1]) == "off") {
-    loc_conf->enable = false;
-    preferred = "datadog_disable";
+    loc_conf->enable_tracing = false;
   } else {
     ngx_log_error(
         NGX_LOG_ERR, cf->log, 0,
@@ -194,29 +191,15 @@ char *toggle_opentracing(ngx_conf_t *cf, ngx_command_t *command,
     return static_cast<char *>(NGX_CONF_ERROR);
   }
 
-  // Warn the user to prefer the corresponding "datadog_{enable,disable}"
+  // Warn the user to prefer the corresponding "datadog_tracing"
   // directive.
-  const ngx_str_t preferred_str = to_ngx_str(preferred);
+  const ngx_str_t preferred_str = to_ngx_str({"datadog_tracing"});
   ngx_log_error(
       NGX_LOG_WARN, cf->log, 0,
       "Backward compatibility with the \"%V %V;\" configuration directive is "
       "deprecated.  Please use \"%V;\" instead.",
       &values[0], &values[1], &preferred_str);
 
-  return static_cast<char *>(NGX_CONF_OK);
-}
-
-char *datadog_enable(ngx_conf_t *cf, ngx_command_t *command,
-                     void *conf) noexcept {
-  const auto loc_conf = static_cast<datadog_loc_conf_t *>(conf);
-  loc_conf->enable = true;
-  return static_cast<char *>(NGX_CONF_OK);
-}
-
-char *datadog_disable(ngx_conf_t *cf, ngx_command_t *command,
-                      void *conf) noexcept {
-  const auto loc_conf = static_cast<datadog_loc_conf_t *>(conf);
-  loc_conf->enable = false;
   return static_cast<char *>(NGX_CONF_OK);
 }
 
@@ -535,14 +518,29 @@ char *hijack_auth_request(ngx_conf_t *cf, ngx_command_t *command,
                 e.what());
   return static_cast<char *>(NGX_CONF_ERROR);
 }
-char *warn_deprecated_command(ngx_conf_t *cf, ngx_command_t * /*command*/,
-                              void * /*conf*/) noexcept {
+
+char *warn_deprecated_command_1_2_0(ngx_conf_t *cf, ngx_command_t * /*command*/,
+                                    void * /*conf*/) noexcept {
   const auto elements = static_cast<ngx_str_t *>(cf->args->elts);
   assert(cf->args->nelts >= 1);
 
   ngx_log_error(
       NGX_LOG_WARN, cf->log, 0,
       "Directive \"%V\" is deprecated and can be removed since v1.2.0.",
+      &elements[0]);
+
+  return NGX_OK;
+}
+
+char *warn_deprecated_command_datadog_tracing(ngx_conf_t *cf,
+                                              ngx_command_t * /*command*/,
+                                              void * /*conf*/) noexcept {
+  const auto elements = static_cast<ngx_str_t *>(cf->args->elts);
+  assert(cf->args->nelts >= 1);
+
+  ngx_log_error(
+      NGX_LOG_WARN, cf->log, 0,
+      "Directive \"%V\" is deprecated. Use datadog_tracing on/off instead",
       &elements[0]);
 
   return NGX_OK;

--- a/src/datadog_directive.h
+++ b/src/datadog_directive.h
@@ -39,12 +39,6 @@ char *set_datadog_location_resource_name(ngx_conf_t *cf, ngx_command_t *command,
 char *toggle_opentracing(ngx_conf_t *cf, ngx_command_t *command,
                          void *conf) noexcept;
 
-char *datadog_enable(ngx_conf_t *cf, ngx_command_t *command,
-                     void *conf) noexcept;
-
-char *datadog_disable(ngx_conf_t *cf, ngx_command_t *command,
-                      void *conf) noexcept;
-
 char *plugin_loading_deprecated(ngx_conf_t *cf, ngx_command_t *command,
                                 void *conf) noexcept;
 
@@ -65,8 +59,12 @@ char *set_datadog_agent_url(ngx_conf_t *, ngx_command_t *, void *conf) noexcept;
 char *hijack_auth_request(ngx_conf_t *cf, ngx_command_t *command,
                           void *conf) noexcept;
 
-char *warn_deprecated_command(ngx_conf_t *cf, ngx_command_t * /*command*/,
-                              void * /*conf*/) noexcept;
+char *warn_deprecated_command_1_2_0(ngx_conf_t *cf, ngx_command_t * /*command*/,
+                                    void * /*conf*/) noexcept;
+
+char *warn_deprecated_command_datadog_tracing(ngx_conf_t *cf,
+                                              ngx_command_t * /*command*/,
+                                              void * /*conf*/) noexcept;
 
 #ifdef WITH_WAF
 char *waf_thread_pool_name(ngx_conf_t *cf, ngx_command_t *command,

--- a/src/datadog_handler.cpp
+++ b/src/datadog_handler.cpp
@@ -24,11 +24,11 @@ static bool is_datadog_tracing_enabled(
     const datadog_loc_conf_t *loc_conf) noexcept {
   // Check if this is a main request instead of a subrequest.
   if (request == request->main) {
-    return loc_conf->enable;
+    return loc_conf->enable_tracing;
   } else {
     // Only trace subrequests if `log_subrequest` is enabled; otherwise the
     // spans won't be finished.
-    return loc_conf->enable && core_loc_conf->log_subrequest;
+    return loc_conf->enable_tracing && core_loc_conf->log_subrequest;
   }
 }
 

--- a/test/cases/auto_propagation/conf/fastcgi_disabled_at_http.conf
+++ b/test/cases/auto_propagation/conf/fastcgi_disabled_at_http.conf
@@ -8,7 +8,7 @@ events {
 }
 
 http {
-    datadog_disable;
+    datadog_tracing off;
     server {
         listen       80;
 

--- a/test/cases/auto_propagation/conf/fastcgi_disabled_at_location.conf
+++ b/test/cases/auto_propagation/conf/fastcgi_disabled_at_location.conf
@@ -12,7 +12,7 @@ http {
         listen       80;
 
         location /fastcgi {
-            datadog_disable;
+            datadog_tracing off;
             fastcgi_pass fastcgi:8080;
         }
     }

--- a/test/cases/auto_propagation/conf/fastcgi_disabled_at_server.conf
+++ b/test/cases/auto_propagation/conf/fastcgi_disabled_at_server.conf
@@ -10,7 +10,7 @@ events {
 http {
     server {
         listen       80;
-        datadog_disable;
+        datadog_tracing off;
 
         location /fastcgi {
             fastcgi_pass fastcgi:8080;

--- a/test/cases/auto_propagation/conf/grpc_disabled_at_http.conf
+++ b/test/cases/auto_propagation/conf/grpc_disabled_at_http.conf
@@ -8,7 +8,7 @@ events {
 }
 
 http {
-    datadog_disable;
+    datadog_tracing off;
     server {
         listen 1337 http2;
 

--- a/test/cases/auto_propagation/conf/grpc_disabled_at_location.conf
+++ b/test/cases/auto_propagation/conf/grpc_disabled_at_location.conf
@@ -12,7 +12,7 @@ http {
         listen 1337 http2;
 
         location / {
-            datadog_disable;
+            datadog_tracing off;
             grpc_pass grpc://grpc:1337;
         }
     }

--- a/test/cases/auto_propagation/conf/http_disabled_at_http.conf
+++ b/test/cases/auto_propagation/conf/http_disabled_at_http.conf
@@ -8,7 +8,7 @@ events {
 }
 
 http {
-    datadog_disable;
+    datadog_tracing off;
     server {
         listen       80;
 

--- a/test/cases/auto_propagation/conf/http_disabled_at_location.conf
+++ b/test/cases/auto_propagation/conf/http_disabled_at_location.conf
@@ -12,7 +12,7 @@ http {
         listen       80;
 
         location /http {
-            datadog_disable;
+            datadog_tracing off;
             proxy_pass http://http:8080;
         }
     }

--- a/test/cases/auto_propagation/conf/http_disabled_at_server.conf
+++ b/test/cases/auto_propagation/conf/http_disabled_at_server.conf
@@ -10,7 +10,7 @@ events {
 http {
     server {
         listen       80;
-        datadog_disable;
+        datadog_tracing off;
 
         location /http {
             proxy_pass http://http:8080;

--- a/test/cases/auto_propagation/conf/uwsgi_disabled_at_http.conf
+++ b/test/cases/auto_propagation/conf/uwsgi_disabled_at_http.conf
@@ -8,7 +8,7 @@ events {
 }
 
 http {
-    datadog_disable;
+    datadog_tracing off;
     server {
         listen       80;
 

--- a/test/cases/auto_propagation/conf/uwsgi_disabled_at_location.conf
+++ b/test/cases/auto_propagation/conf/uwsgi_disabled_at_location.conf
@@ -12,7 +12,7 @@ http {
         listen       80;
 
         location / {
-            datadog_disable;
+            datadog_tracing off;
             include /etc/nginx/uwsgi_params;
             uwsgi_pass uwsgi:8080;
         }

--- a/test/cases/auto_propagation/conf/uwsgi_disabled_at_server.conf
+++ b/test/cases/auto_propagation/conf/uwsgi_disabled_at_server.conf
@@ -10,7 +10,7 @@ events {
 http {
     server {
         listen       80;
-        datadog_disable;
+        datadog_tracing off;
 
         location / {
             include /etc/nginx/uwsgi_params;

--- a/test/cases/configuration/conf/datadog_tracing_precedence.conf
+++ b/test/cases/configuration/conf/datadog_tracing_precedence.conf
@@ -8,12 +8,13 @@ events {
 }
 
 http {
+    datadog_tracing off;
     server {
-        listen 1337 http2;
-        datadog_tracing off;
+        listen       80;
 
-        location / {
-            grpc_pass grpc://grpc:1337;
+        location /http {
+            datadog_tracing on;
+            proxy_pass http://http:8080;
         }
     }
 }

--- a/test/cases/configuration/test_configuration.py
+++ b/test/cases/configuration/test_configuration.py
@@ -190,3 +190,21 @@ class TestConfiguration(case.TestCase):
     def test_error_in_server_propagation_styles(self):
         return self.run_wrong_block_test(
             "./conf/error_in_server/propagation_styles.conf")
+
+    def run_precedence_test(self, conf_relative_path):
+        conf_path = Path(__file__).parent / conf_relative_path
+        conf_text = conf_path.read_text()
+        status, log_lines = self.orch.nginx_replace_config(
+            conf_text, conf_path.name)
+        self.assertEqual(status, 0, log_lines)
+
+        status, _, body = self.orch.send_nginx_http_request("/http")
+        self.assertEqual(status, 200)
+        response = json.loads(body)
+        self.assertEqual(response["service"], "http")
+        headers = response["headers"]
+        self.assertIn("x-datadog-sampling-priority", headers)
+
+    def test_datadog_tracing_precedence(self):
+        return self.run_precedence_test(
+            "./conf/datadog_tracing_precedence.conf")

--- a/test/cases/deprecations/conf/datadog_disable.conf
+++ b/test/cases/deprecations/conf/datadog_disable.conf
@@ -9,11 +9,13 @@ events {
 
 http {
     server {
-        listen 1337 http2;
-        datadog_tracing off;
+        listen       80;
+        server_name  localhost;
 
-        location / {
-            grpc_pass grpc://grpc:1337;
+        location /http {
+            # datadog_disable is now replace by datadog_tracing off
+            datadog_disable;
+            proxy_pass http://http:8080;
         }
     }
 }

--- a/test/cases/deprecations/conf/datadog_enable.conf
+++ b/test/cases/deprecations/conf/datadog_enable.conf
@@ -9,11 +9,13 @@ events {
 
 http {
     server {
-        listen 1337 http2;
-        datadog_tracing off;
+        listen       80;
+        server_name  localhost;
 
-        location / {
-            grpc_pass grpc://grpc:1337;
+        location /http {
+            # datadog_enable is now replace by datadog_tracing on
+            datadog_enable;
+            proxy_pass http://http:8080;
         }
     }
 }

--- a/test/cases/deprecations/test_deprecation_warnings.py
+++ b/test/cases/deprecations/test_deprecation_warnings.py
@@ -11,18 +11,18 @@ class TestDeprecationWarnings(case.TestCase):
 
     def test_opentracing_propagate_context(self):
         directive = "opentracing_propagate_context"
-        return self.run_test_deprecated_directive(f"conf/{directive}.conf",
-                                                  directive)
+        return self.run_test_deprecated_1_2_0_directive(
+            f"conf/{directive}.conf", directive)
 
     def test_opentracing_fastcgi_propagate_context(self):
         directive = "opentracing_fastcgi_propagate_context"
-        return self.run_test_deprecated_directive(f"conf/{directive}.conf",
-                                                  directive)
+        return self.run_test_deprecated_1_2_0_directive(
+            f"conf/{directive}.conf", directive)
 
     def test_opentracing_grpc_propagate_context(self):
         directive = "opentracing_grpc_propagate_context"
-        return self.run_test_deprecated_directive(f"conf/{directive}.conf",
-                                                  directive)
+        return self.run_test_deprecated_1_2_0_directive(
+            f"conf/{directive}.conf", directive)
 
     def test_opentracing_operation_name(self):
         directive = "opentracing_operation_name"
@@ -39,6 +39,16 @@ class TestDeprecationWarnings(case.TestCase):
     def test_opentracing_tag(self):
         directive = "opentracing_tag"
         return self.run_test_for_config(f"conf/{directive}.conf", directive)
+
+    def test_datadog_enable_tag(self):
+        directive = "datadog_enable"
+        return self.run_test_deprecated_datadog_tracing_directive(
+            f"conf/{directive}.conf", directive)
+
+    def test_datadog_disable_tag(self):
+        directive = "datadog_disable"
+        return self.run_test_deprecated_datadog_tracing_directive(
+            f"conf/{directive}.conf", directive)
 
     def run_test_for_config(self, config_relative_path, directive):
         config_path = Path(__file__).parent / config_relative_path
@@ -61,7 +71,8 @@ class TestDeprecationWarnings(case.TestCase):
             },
         )
 
-    def run_test_deprecated_directive(self, config_relative_path, directive):
+    def run_test_deprecated_1_2_0_directive(self, config_relative_path,
+                                            directive):
         config_path = Path(__file__).parent / config_relative_path
         config_text = config_path.read_text()
         status, log_lines = self.orch.nginx_test_config(
@@ -71,6 +82,26 @@ class TestDeprecationWarnings(case.TestCase):
 
         old = directive
         expected = f'Directive "{old}" is deprecated and can be removed since v1.2.0'
+        self.assertTrue(
+            any(expected in line for line in log_lines),
+            {
+                "expected": expected,
+                "log_lines": log_lines
+            },
+        )
+
+    def run_test_deprecated_datadog_tracing_directive(self,
+                                                      config_relative_path,
+                                                      directive):
+        config_path = Path(__file__).parent / config_relative_path
+        config_text = config_path.read_text()
+        status, log_lines = self.orch.nginx_test_config(
+            config_text, config_path.name)
+
+        self.assertEqual(status, 0)
+
+        old = directive
+        expected = f'Directive "{old}" is deprecated. Use datadog_tracing on/off instead'
         self.assertTrue(
             any(expected in line for line in log_lines),
             {

--- a/test/cases/rum/conf/rum_enabled.conf
+++ b/test/cases/rum/conf/rum_enabled.conf
@@ -8,7 +8,7 @@ events {
 
 http {
     server {
-        datadog_disable;
+        datadog_tracing off;
 
         datadog_rum on;
         datadog_rum_config "v5" {


### PR DESCRIPTION
**Important**: I had to create a new PR because my initial commits were unsigned and when i signed all of them, it destroyed the history of the branch

- Deprecation for datadog_enable / datadog_disable
- Creation of datadog_tracing on/off (which do exactly the same as datadog_enable / datadog_disable)
- Creation of multiple macro for deprecating directive (one for 1.2.0, one for 1.4.0)
- Add a new test to see if the "specialization" of datadog_tracing on/off was working