### PR TITLE
Improve Build instructions: add note to do a git clone first

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,13 @@ Requirements:
 - CMake `v3.24` or newer.
 - Architecture must be `x86_64` or `arm64`.
 
+For build to be able to run properly, it must happen within the git clone of
+this repository:
+
+```shell
+git clone https://github.com/DataDog/nginx-datadog.git
+```
+
 For enhanced usability, we provide a [GNU make][1] compatible [Makefile](Makefile).
 
 ```shell


### PR DESCRIPTION
When `make build` runs, it depends on being able to issue git commands within the source code folder (namely, to download submodules).

If someone downloads a source code archive from Releases, their build will fail with a somewhat cryptic error message:

    git submodule update --init --recursive
    fatal: not a git repository (or any of the parent directories): .git
    make: *** [Makefile:31: dd-trace-cpp/.git] Error 128

Making a clear instruction that the build needs to run within a git clone'd working directory will solve this particular hurdle.