### PR TITLE
Update the example curl script in install-nginx-datadog.sh

### DIFF
--- a/installer/install-nginx-datadog.sh
+++ b/installer/install-nginx-datadog.sh
@@ -12,7 +12,7 @@
 #
 # 1. download the script
 #
-#   $ curl -fsSL https://raw.githubusercontent.com/DataDog/nginx-datadog/master/rum-injection-installer/install-nginx-datadog.sh -o install-nginx-datadog.sh
+#   $ curl -fsSL https://raw.githubusercontent.com/DataDog/nginx-datadog/master/installer/install-nginx-datadog.sh -o install-nginx-datadog.sh
 #
 # 2. run the script either as root, or using sudo to perform the installation.
 #


### PR DESCRIPTION
I think the folder got renamed:  

I don't see this script in the `rum-injection-installer` folder:
```
https://raw.githubusercontent.com/DataDog/nginx-datadog/master/rum-injection-installer/install-nginx-datadog.sh -o install-nginx-datadog.sh
```

Instead, it seems to be in the `installer` folder.