### PR TITLE
Bridge more musl/glibc diffs in aarch64

### DIFF
--- a/build_env/alltypes.h.diff
+++ b/build_env/alltypes.h.diff
@@ -1,6 +1,42 @@
---- bits/alltypes.h	2023-11-06 11:49:18.000000000 +0000
-+++ bits/alltypes.h	2024-04-22 09:30:09.927560000 +0000
-@@ -383,12 +383,20 @@
+--- bits/alltypes.h
++++ bits/alltypes.h
+@@ -299,17 +299,32 @@
+ #endif
+ 
+ #if defined(__NEED_pthread_mutexattr_t) && !defined(__DEFINED_pthread_mutexattr_t)
+-typedef struct { unsigned __attr; } pthread_mutexattr_t;
++typedef struct { union { unsigned __attr;
++#ifdef __aarch64__
++	long __glibc_compat;
++#endif
++};
++} pthread_mutexattr_t;
+ #define __DEFINED_pthread_mutexattr_t
+ #endif
+ 
+ #if defined(__NEED_pthread_condattr_t) && !defined(__DEFINED_pthread_condattr_t)
+-typedef struct { unsigned __attr; } pthread_condattr_t;
++typedef struct { union { unsigned __attr;
++#ifdef __aarch64__
++	long __glibc_compat;
++#endif
++};
++} pthread_condattr_t;
+ #define __DEFINED_pthread_condattr_t
+ #endif
+ 
+ #if defined(__NEED_pthread_barrierattr_t) && !defined(__DEFINED_pthread_barrierattr_t)
+-typedef struct { unsigned __attr; } pthread_barrierattr_t;
++typedef struct { union { unsigned __attr;
++#ifdef __aarch64__
++	long __glibc_compat;
++#endif
++};
++} pthread_barrierattr_t;
+ #define __DEFINED_pthread_barrierattr_t
+ #endif
+ 
+@@ -383,12 +398,20 @@
  
  
  #if defined(__NEED_pthread_attr_t) && !defined(__DEFINED_pthread_attr_t)


### PR DESCRIPTION
This should cover all the differences I could find on aarch64.

| Type                  | Glibc Size | Musl Size |
|-----------------------|------------|-----------|
| pthread_t            | 8 bytes    | 8 bytes   |
| pthread_attr_t       | 64 bytes   | 56 bytes  |
| pthread_mutex_t      | 48 bytes   | 40 bytes  |
| pthread_mutexattr_t  | 8 bytes    | 4 bytes   |
| pthread_cond_t       | 48 bytes   | 48 bytes  |
| pthread_condattr_t   | 8 bytes    | 4 bytes   |
| pthread_rwlock_t     | 56 bytes   | 56 bytes  |
| pthread_rwlockattr_t | 8 bytes    | 8 bytes   |
| pthread_barrier_t    | 32 bytes   | 32 bytes  |
| pthread_barrierattr_t| 8 bytes    | 4 bytes   |