### PR TITLE
Fix stall upon auth phase subrequest

### DIFF
--- a/test/cases/sec_addresses/conf/http_auth_subrequest.conf
+++ b/test/cases/sec_addresses/conf/http_auth_subrequest.conf
@@ -1,0 +1,40 @@
+# "/datadog-tests" is a directory created by the docker build
+# of the nginx test image. It contains the module, the
+# nginx config, and "index.html".
+
+thread_pool waf_thread_pool threads=2 max_queue=5;
+
+load_module /datadog-tests/ngx_http_datadog_module.so;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    datadog_agent_url http://agent:8126;
+    datadog_appsec_enabled on;
+    datadog_appsec_waf_timeout 2s;
+    datadog_appsec_ruleset_file /tmp/waf.json;
+    datadog_waf_thread_pool_name waf_thread_pool;
+
+    server {
+        listen       80;
+
+        location /http {
+            set $auth_token $http_x_token;
+            auth_request /auth;
+
+            proxy_pass http://http:8080;
+        }
+
+        location =/auth {
+            internal;
+            proxy_pass http://http:8080/auth;
+            proxy_pass_request_body off;
+            proxy_pass_request_headers off;
+            proxy_set_header Content-Length "";
+            proxy_set_header Authorization $auth_token;
+        }
+    }
+}
+

--- a/test/cases/sec_addresses/test_sec_subrequests.py
+++ b/test/cases/sec_addresses/test_sec_subrequests.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+from .. import case
+
+
+class TestSecSubRequests(case.TestCase):
+    requires_waf = True
+    config_setup_done = False
+
+    def setUp(self):
+        super().setUp()
+        if not TestSecSubRequests.config_setup_done:
+            waf_path = Path(__file__).parent / './conf/waf.json'
+            waf_text = waf_path.read_text()
+            self.orch.nginx_replace_file('/tmp/waf.json', waf_text)
+
+            conf_path = Path(
+                __file__).parent / './conf/http_auth_subrequest.conf'
+            conf_text = conf_path.read_text()
+
+            status, log_lines = self.orch.nginx_replace_config(
+                conf_text, conf_path.name)
+            self.assertEqual(0, status, log_lines)
+
+            TestSecSubRequests.config_setup_done = True
+
+        # Consume any previous logging from the agent.
+        self.orch.sync_service('agent')
+
+    def get_appsec_data(self):
+        rep = self.orch.find_first_appsec_report()
+        if rep is None:
+            self.failureException('No _dd.appsec.json found in traces')
+        return rep
+
+    def test_req_attack(self):
+        status, _, _ = self.orch.send_nginx_http_request(
+            '/http?a=matched+value', 80, headers={'x-token': 'mysecret'})
+        self.assertEqual(status, 200)
+
+        appsec_data = self.get_appsec_data()
+        self.assertEqual(
+            appsec_data['triggers'][0]['rule_matches'][0]['parameters'][0]
+            ['value'], 'matched value')

--- a/test/services/http/http.js
+++ b/test/services/http/http.js
@@ -14,6 +14,18 @@ const ignoreRequestBody = request => {
 
 const requestListener = function (request, response) {
   ignoreRequestBody(request);
+  if (request.url === '/auth') {
+    const auth = request.headers.authorization;
+    if (auth === 'mysecret') {
+      response.writeHead(200);
+      response.end('');
+    } else {
+      response.writeHead(401, { "content-type": "text/plain" });
+      response.end('Unauthorized');
+    }
+    return;
+  }
+
   const responseBody = JSON.stringify({
     "service": "http",
     "headers": request.headers


### PR DESCRIPTION
Replace call to `ngx_http_core_run_phases` in WAF task completion handler with posting a write event. The reason is that `ngx_http_core_run_phases` will not run posted subrequests (`ngx_http_run_posted_requests`), whereas the connection's write handler (`ngx_http_request_handler`) does, after handling the event (delegated to `r->write_event_handler`, which should be `ngx_http_core_run_phases` at that point).