### PR TITLE
feat(ingress-nginx): avoid reporting healthcheck

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ endif()
 option(NGINX_PATCH_AWAY_LIBC "Patch away libc dependency" OFF)
 option(NGINX_COVERAGE "Add coverage instrumentation" OFF)
 option(ENABLE_FUZZERS "For building fuzzers" OFF)
+set(NGINX_DATADOG_FLAVOR "nginx" CACHE STRING "NGINX flavor")
 
 if (NGINX_DATADOG_RUM_ENABLED AND NGINX_DATADOG_ASM_ENABLED)
   message(FATAL_ERROR "ASM and RUM features are mutually exclusive")
@@ -126,10 +127,13 @@ configure_file(src/version.cpp.in ${CMAKE_BINARY_DIR}/version.cpp)
 # The shared library (nginx module) that we are building.
 add_library(ngx_http_datadog_module SHARED)
 
+# Define `DD_NGINX_FLAVOR`
+
 target_sources(ngx_http_datadog_module PRIVATE ${CMAKE_BINARY_DIR}/version.cpp)
 
 add_library(ngx_http_datadog_objs OBJECT)
 set_target_properties(ngx_http_datadog_objs PROPERTIES POSITION_INDEPENDENT_CODE ON)
+target_compile_definitions(ngx_http_datadog_objs PUBLIC DD_NGINX_FLAVOR="${NGINX_DATADOG_FLAVOR}")
 target_sources(ngx_http_datadog_objs
   PRIVATE
     src/array_util.cpp

--- a/Makefile
+++ b/Makefile
@@ -224,4 +224,5 @@ build-musl-aux-ingress:
 		-DNGINX_SRC_DIR="$(NGINX_SRC_DIR)" \
 		-DNGINX_DATADOG_ASM_ENABLED="$(WAF)" \
 		-DNGINX_COVERAGE=$(COVERAGE) . \
+		-DNGINX_DATADOG_FLAVOR="ingress-nginx" \
 		&& cmake --build .musl-build -j $(MAKE_JOB_COUNT) -v

--- a/src/nginx_flavors.h
+++ b/src/nginx_flavors.h
@@ -1,0 +1,29 @@
+#include <cstdint>
+#include <string_view>
+
+namespace datadog {
+namespace nginx {
+
+enum class flavor : uint8_t {
+  vanilla,
+  openresty,
+  ingress_nginx,
+};
+
+inline constexpr flavor from_str(std::string_view in) {
+  if (in == "nginx") {
+    return flavor::vanilla;
+  } else if (in == "openresty") {
+    return flavor::vanilla;
+  } else if (in == "ingress-nginx") {
+    return flavor::ingress_nginx;
+  }
+
+  static_assert(true, "unknown NGINX flavor");
+  std::abort();
+}
+
+inline constexpr flavor kNginx_flavor = from_str(DD_NGINX_FLAVOR);
+
+}  // namespace nginx
+}  // namespace datadog

--- a/src/tracing_library.cpp
+++ b/src/tracing_library.cpp
@@ -25,6 +25,7 @@ extern "C" {
 #ifdef WITH_WAF
 #include "security/waf_remote_cfg.h"
 #endif
+#include "nginx_flavors.h"
 #include "string_util.h"
 
 namespace datadog {
@@ -84,8 +85,7 @@ dd::Expected<dd::Tracer> TracingLibrary::make_tracer(
 
   auto final_config = dd::finalize_config(config);
 
-#if defined(DD_NGINX_FLAVOR)
-  if (std::string_view(DD_NGINX_FLAVOR) == "ingress-nginx") {
+  if constexpr (kNginx_flavor == nginx::flavor::ingress_nginx) {
     // NOTE(@dmehala): ingress-nginx regularly poll an healthcheck endpoint.
     // To avoid reporting traces, set the sampling rate to `0` for this
     // endpoint. This is done after `finalize_config` because it can
@@ -101,7 +101,6 @@ dd::Expected<dd::Tracer> TracingLibrary::make_tracer(
                     .tags = {}},
             .mechanism = datadog::tracing::SamplingMechanism::RULE});
   }
-#endif
 
   if (!final_config) {
     return final_config.error();

--- a/test/cases/ingress-nginx/conf/main.conf
+++ b/test/cases/ingress-nginx/conf/main.conf
@@ -1,0 +1,25 @@
+# "/datadog-tests" is a directory created by the docker build
+# of the nginx test image. It contains the module, the
+# nginx config, and "index.html".
+load_module /datadog-tests/ngx_http_datadog_module.so;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    server {
+        listen       80;
+
+        location / {
+            proxy_pass http://http:8080;
+        }
+
+        # replicate ingress-nginx:
+        # ingress-nginx expose an endpoint to assess the health
+        # of the ingress controller.
+        location /is-dynamic-lb-initialized {
+            proxy_pass http://http:8080;
+        }
+    }
+}

--- a/test/cases/ingress-nginx/test_rules.py
+++ b/test/cases/ingress-nginx/test_rules.py
@@ -1,0 +1,37 @@
+from .. import case
+
+import json
+import os
+from pathlib import Path
+from unittest import skipUnless
+
+
+@skipUnless(
+    os.getenv("NGINX_FLAVOR", "") == "ingress-nginx",
+    "Test embedded sampling rules only for ingress-nginx",
+)
+class TestIngressNginxRules(case.TestCase):
+
+    def test_healthcheck(self):
+        # Healthcheck request MUST not be generated traces.
+        conf_path = Path(__file__).parent / "conf" / "main.conf"
+        conf_text = conf_path.read_text()
+
+        status, log_lines = self.orch.nginx_replace_config(
+            conf_text, conf_path.name)
+        self.assertEqual(status, 0, log_lines)
+
+        status, _, body = self.orch.send_nginx_http_request(
+            "/is-dynamic-lb-initialized")
+        self.assertEqual(status, 200)
+
+        response = json.loads(body)
+        self.assertEqual(response["headers"]["x-datadog-sampling-priority"],
+                         "-1")
+
+        status, _, body = self.orch.send_nginx_http_request("/")
+        self.assertEqual(status, 200)
+
+        response = json.loads(body)
+        self.assertEqual(response["headers"]["x-datadog-sampling-priority"],
+                         "1")


### PR DESCRIPTION
The ingress-nginx controller frequently polls `/is-dynamic-lb-initialized` to check the load balancer's health. These requests are traced and reported to the agent, which provides no meaningful value and may unnecessarily increase costs.  

This PR introduces sampling rules embedded to exclude traces generated by this healthcheck endpoint.  