### PR TITLE
feat: evaluate `datadog_*` value during request processing

### DIFF
--- a/src/datadog_conf.cpp
+++ b/src/datadog_conf.cpp
@@ -1,7 +1,5 @@
 #include "datadog_conf.h"
 
-#include <format>
-
 #include "string_util.h"
 
 namespace datadog {

--- a/src/datadog_conf.cpp
+++ b/src/datadog_conf.cpp
@@ -1,5 +1,7 @@
 #include "datadog_conf.h"
 
+#include <format>
+
 #include "string_util.h"
 
 namespace datadog {

--- a/src/datadog_conf.h
+++ b/src/datadog_conf.h
@@ -19,6 +19,9 @@ extern "C" {
 #include <string>
 #include <vector>
 
+#define DD_NGX_CONF_COMPLEX_UNSET \
+  (ngx_http_complex_value_t *)NGX_CONF_UNSET_PTR;
+
 namespace datadog {
 namespace nginx {
 
@@ -176,17 +179,19 @@ struct datadog_sample_rate_condition_t {
 struct datadog_loc_conf_t {
   ngx_flag_t enable_tracing = NGX_CONF_UNSET;
   ngx_flag_t enable_locations = NGX_CONF_UNSET;
-  NgxScript operation_name_script;
-  NgxScript loc_operation_name_script;
-  NgxScript resource_name_script;
-  NgxScript loc_resource_name_script;
+  ngx_http_complex_value_t *operation_name_script = DD_NGX_CONF_COMPLEX_UNSET;
+  ngx_http_complex_value_t *loc_operation_name_script =
+      DD_NGX_CONF_COMPLEX_UNSET;
+  ngx_http_complex_value_t *resource_name_script = DD_NGX_CONF_COMPLEX_UNSET;
+  ngx_http_complex_value_t *loc_resource_name_script =
+      DD_NGX_CONF_COMPLEX_UNSET;
   ngx_flag_t trust_incoming_span = NGX_CONF_UNSET;
   // `service_name` is set by the `datadog_service_name` directive.
-  std::optional<std::string> service_name;
+  ngx_http_complex_value_t *service_name = DD_NGX_CONF_COMPLEX_UNSET;
   // `service_env` is set by the `datadog_environment` directive.
-  std::optional<std::string> service_env;
+  ngx_http_complex_value_t *service_env = DD_NGX_CONF_COMPLEX_UNSET;
   // `service_version` is set by the `datadog_version` directive.
-  std::optional<std::string> service_version;
+  ngx_http_complex_value_t *service_version = DD_NGX_CONF_COMPLEX_UNSET;
   ngx_array_t *tags;
   // `parent` is the parent context (e.g. the `server` to this `location`), or
   // `nullptr` if this context has no parent.
@@ -224,10 +229,12 @@ struct datadog_loc_conf_t {
 #endif
 
 #ifdef WITH_RUM
-  ngx_flag_t rum_enable;
-  Snippet *rum_snippet;
+  ngx_flag_t rum_enable = NGX_CONF_UNSET;
+  Snippet *rum_snippet = nullptr;
 #endif
 };
 
 }  // namespace nginx
 }  // namespace datadog
+
+#undef DD_NGX_CONF_COMPLEX_UNSET

--- a/src/datadog_directive.cpp
+++ b/src/datadog_directive.cpp
@@ -62,19 +62,6 @@ char *lock_propagation_styles(const ngx_command_t *command, ngx_conf_t *conf) {
 
 }  // namespace
 
-static char *set_script(ngx_conf_t *cf, ngx_command_t *command,
-                        NgxScript &script) noexcept {
-  if (script.is_valid()) return const_cast<char *>("is duplicate");
-
-  auto value = static_cast<ngx_str_t *>(cf->args->elts);
-  auto pattern = &value[1];
-
-  if (script.compile(cf, *pattern) != NGX_OK)
-    return static_cast<char *>(NGX_CONF_ERROR);
-
-  return static_cast<char *>(NGX_CONF_OK);
-}
-
 char *delegate_to_datadog_directive_with_warning(ngx_conf_t *cf,
                                                  ngx_command_t *command,
                                                  void *conf) noexcept {
@@ -146,31 +133,6 @@ char *json_config_deprecated(ngx_conf_t *cf, ngx_command_t *command,
                 "Error occurred at \"%V\" in %V:%d",
                 &location.directive_name, &location.file_name, location.line);
   return static_cast<char *>(NGX_CONF_ERROR);
-}
-
-char *set_datadog_operation_name(ngx_conf_t *cf, ngx_command_t *command,
-                                 void *conf) noexcept {
-  auto loc_conf = static_cast<datadog_loc_conf_t *>(conf);
-  return set_script(cf, command, loc_conf->operation_name_script);
-}
-
-char *set_datadog_location_operation_name(ngx_conf_t *cf,
-                                          ngx_command_t *command,
-                                          void *conf) noexcept {
-  auto loc_conf = static_cast<datadog_loc_conf_t *>(conf);
-  return set_script(cf, command, loc_conf->loc_operation_name_script);
-}
-
-char *set_datadog_resource_name(ngx_conf_t *cf, ngx_command_t *command,
-                                void *conf) noexcept {
-  auto loc_conf = static_cast<datadog_loc_conf_t *>(conf);
-  return set_script(cf, command, loc_conf->resource_name_script);
-}
-
-char *set_datadog_location_resource_name(ngx_conf_t *cf, ngx_command_t *command,
-                                         void *conf) noexcept {
-  auto loc_conf = static_cast<datadog_loc_conf_t *>(conf);
-  return set_script(cf, command, loc_conf->loc_resource_name_script);
 }
 
 char *toggle_opentracing(ngx_conf_t *cf, ngx_command_t *command,
@@ -382,57 +344,6 @@ char *set_datadog_propagation_styles(ngx_conf_t *cf, ngx_command_t *command,
   }
 
   return lock_propagation_styles(command, cf);
-}
-
-char *set_datadog_service_name(ngx_conf_t *cf, ngx_command_t *command,
-                               void *conf) noexcept {
-  assert(conf != nullptr);
-  auto &loc_conf = *static_cast<datadog_loc_conf_t *>(conf);
-
-  const auto values = static_cast<ngx_str_t *>(cf->args->elts);
-
-  // values[0] is the command name, while values[1] is the single argument.
-  const auto service_name = to_string_view(values[1]);
-  if (service_name.empty()) {
-    return static_cast<char *>(NGX_CONF_ERROR);
-  }
-
-  loc_conf.service_name = std::string(service_name);
-  return NGX_OK;
-}
-
-char *set_datadog_environment(ngx_conf_t *cf, ngx_command_t *command,
-                              void *conf) noexcept {
-  assert(conf != nullptr);
-  auto &loc_conf = *static_cast<datadog_loc_conf_t *>(conf);
-
-  const auto values = static_cast<ngx_str_t *>(cf->args->elts);
-
-  // values[0] is the command name, while values[1] is the single argument.
-  const auto service_env = to_string_view(values[1]);
-  if (service_env.empty()) {
-    return static_cast<char *>(NGX_CONF_ERROR);
-  }
-
-  loc_conf.service_env = std::string(service_env);
-  return NGX_OK;
-}
-
-char *set_datadog_version(ngx_conf_t *cf, ngx_command_t *command,
-                          void *conf) noexcept {
-  assert(conf != nullptr);
-  auto &loc_conf = *static_cast<datadog_loc_conf_t *>(conf);
-
-  const auto values = static_cast<ngx_str_t *>(cf->args->elts);
-
-  // values[0] is the command name, while values[1] is the single argument.
-  const auto service_version = to_string_view(values[1]);
-  if (service_version.empty()) {
-    return static_cast<char *>(NGX_CONF_ERROR);
-  }
-
-  loc_conf.service_version = std::string(service_version);
-  return NGX_OK;
 }
 
 char *set_datadog_agent_url(ngx_conf_t *cf, ngx_command_t *command,

--- a/src/datadog_directive.h
+++ b/src/datadog_directive.h
@@ -23,19 +23,6 @@ char *set_datadog_tag(ngx_conf_t *cf, ngx_command_t *command,
 char *json_config_deprecated(ngx_conf_t *cf, ngx_command_t *command,
                              void *conf) noexcept;
 
-char *set_datadog_operation_name(ngx_conf_t *cf, ngx_command_t *command,
-                                 void *conf) noexcept;
-
-char *set_datadog_location_operation_name(ngx_conf_t *cf,
-                                          ngx_command_t *command,
-                                          void *conf) noexcept;
-
-char *set_datadog_resource_name(ngx_conf_t *cf, ngx_command_t *command,
-                                void *conf) noexcept;
-
-char *set_datadog_location_resource_name(ngx_conf_t *cf, ngx_command_t *command,
-                                         void *conf) noexcept;
-
 char *toggle_opentracing(ngx_conf_t *cf, ngx_command_t *command,
                          void *conf) noexcept;
 
@@ -47,14 +34,6 @@ char *set_datadog_sample_rate(ngx_conf_t *cf, ngx_command_t *command,
 
 char *set_datadog_propagation_styles(ngx_conf_t *cf, ngx_command_t *command,
                                      void *conf) noexcept;
-
-char *set_datadog_service_name(ngx_conf_t *, ngx_command_t *,
-                               void *conf) noexcept;
-
-char *set_datadog_environment(ngx_conf_t *, ngx_command_t *,
-                              void *conf) noexcept;
-
-char *set_datadog_version(ngx_conf_t *, ngx_command_t *, void *conf) noexcept;
 
 char *set_datadog_agent_url(ngx_conf_t *, ngx_command_t *, void *conf) noexcept;
 

--- a/src/datadog_variable.cpp
+++ b/src/datadog_variable.cpp
@@ -163,8 +163,8 @@ static ngx_int_t expand_configuration_variable(
     ngx_str_t res;
     if (ngx_http_complex_value(request, value, &res) == NGX_OK &&
         res.len != 0) {
-      doc.AddMember(rapidjson::Value(key.data(), alloc),
-                    rapidjson::Value((char*)res.data, alloc), alloc);
+      doc.AddMember(rapidjson::Value(key.data(), key.size(), alloc),
+                    rapidjson::Value((char*)res.data, res.len, alloc), alloc);
     }
   };
 

--- a/src/request_tracing.cpp
+++ b/src/request_tracing.cpp
@@ -44,7 +44,7 @@ std::optional<std::string> eval_complex_value(ngx_http_complex_value_t *conf,
   if (conf == nullptr) return std::nullopt;
 
   ngx_str_t res;
-  if (ngx_http_complex_value(request_, conf, &res) != NGX_OK) {
+  if (ngx_http_complex_value(request_, conf, &res) != NGX_OK || res.len == 0) {
     return std::nullopt;
   }
 

--- a/test/cases/configuration/conf/datadog_unified_service_tagging.conf
+++ b/test/cases/configuration/conf/datadog_unified_service_tagging.conf
@@ -23,9 +23,13 @@ http {
     server {
         listen       81;
 
-        datadog_service_name "server1_block";
-        datadog_environment "server1";
-        datadog_version "1.5.0-server1";
+        set $service_name "server1_block";
+        set $service_env "server1";
+        set $service_version "1.5.0-server1";
+
+        datadog_service_name "$service_name";
+        datadog_environment "$service_env";
+        datadog_version "$service_version";
 
         location /http {
             return 200 "$datadog_config_json";


### PR DESCRIPTION
Changes:
  - Replace `NgxScript` with `ngx_http_complex_value`.
  - Use default NGINX conf setter for complex value.

Resolves #173 