### PR TITLE
chore: default variables IDs to 128-bit

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -456,11 +456,11 @@ Note that if `datadog_trace_locations` is `on`, then `$datadog_span_id` will
 refer to the span associated with the location (outbound request), not its
 parent (inbound request).
 
-### `datadog_trace_id_dec`  
+### `datadog_trace_id_64bits_base10`  
 This reflects the legacy behavior prior to `v1.6.0`, where `$datadog_trace_id` evaluated to the decimal representation of the 64-bit trace ID.  
 If there is no currently active span, then the variable expands to a hyphen character (`-`) instead.
 
-### `datadog_span_id_dec`  
+### `datadog_span_id_64bits_base10`  
 This reflects the legacy behavior prior to `v1.6.0`, where `$datadog_span_id` evaluated to the decimal representation of the 64-bit span ID.
 If there is no currently active span, then the variable expands to a hyphen character (`-`) instead.
 

--- a/doc/API.md
+++ b/doc/API.md
@@ -443,12 +443,12 @@ The Datadog nginx module defines additional variables that provide information
 about the currently active trace.
 
 ### `datadog_trace_id`
-`$datadog_trace_id` expands to the decimal representation of the unsigned
-64-bit ID of the currently active trace. If there is no currently active
+`$datadog_trace_id` expands to the hexadecimal representation of the unsigned
+128-bit ID of the currently active trace. If there is no currently active
 trace, then the variable expands to a hyphen character (`-`) instead.
 
 ### `datadog_span_id`
-`$datadog_span_id` expands to the decimal representation of the unsigned 64-bit
+`$datadog_span_id` expands to the hexadecimal representation of the unsigned 128-bit
 ID of the currently active span.If there is no currently active span, then
 the variable expands to a hyphen character (`-`) instead.
 
@@ -456,11 +456,13 @@ Note that if `datadog_trace_locations` is `on`, then `$datadog_span_id` will
 refer to the span associated with the location (outbound request), not its
 parent (inbound request).
 
-### `datadog_trace_id_hex`
-Same as `$datadog_trace_id`, but is the hexadecimal representation of the 128-bit ID. 
+### `datadog_trace_id_dec`  
+This reflects the legacy behavior prior to `v1.6.0`, where `$datadog_trace_id` evaluated to the decimal representation of the 64-bit trace ID.  
+If there is no currently active span, then the variable expands to a hyphen character (`-`) instead.
 
-### `datadog_span_id_hex`
-Same as `$datadog_span_id`, but is the hexadecimal representation.
+### `datadog_span_id_dec`  
+This reflects the legacy behavior prior to `v1.6.0`, where `$datadog_span_id` evaluated to the decimal representation of the 64-bit span ID.
+If there is no currently active span, then the variable expands to a hyphen character (`-`) instead.
 
 ### `datadog_location`
 `$datadog_location` expands to the name or pattern of the `location` block that

--- a/src/datadog_variable.cpp
+++ b/src/datadog_variable.cpp
@@ -274,9 +274,6 @@ ngx_int_t add_variables(ngx_conf_t* cf) noexcept {
   variable->get_handler = expand_location_variable;
   variable->data = 0;
 
-  ngx_log_error(NGX_LOG_WARN, cf->log, 0,
-                "In the next release, $datadog_trace_id and $datadog_span_id "
-                "will return their values in hexadecimal format.");
   return NGX_OK;
 }
 }  // namespace nginx

--- a/src/tracing_library.cpp
+++ b/src/tracing_library.cpp
@@ -155,9 +155,9 @@ std::string span_property(std::string_view key, const dd::Span &span) {
         std::snprintf(buffer, sizeof(buffer), "%016" PRIx64, span.id());
     assert(written == 16);
     return {buffer, static_cast<size_t>(written)};
-  } else if (key == "trace_id_dec") {
+  } else if (key == "trace_id_64bits_base10") {
     return std::to_string(span.trace_id().low);
-  } else if (key == "span_id_dec") {
+  } else if (key == "span_id_64bits_base10") {
     return std::to_string(span.id());
   } else if (key == "json") {
     SpanContextJSONWriter writer;

--- a/src/tracing_library.cpp
+++ b/src/tracing_library.cpp
@@ -147,17 +147,17 @@ class SpanContextJSONWriter : public dd::DictWriter {
 std::string span_property(std::string_view key, const dd::Span &span) {
   const auto not_found = "-";
 
-  if (key == "trace_id_hex") {
+  if (key == "trace_id_hex" || key == "trace_id") {
     return span.trace_id().hex_padded();
-  } else if (key == "span_id_hex") {
+  } else if (key == "span_id_hex" || key == "span_id") {
     char buffer[17];
     int written =
         std::snprintf(buffer, sizeof(buffer), "%016" PRIx64, span.id());
     assert(written == 16);
     return {buffer, static_cast<size_t>(written)};
-  } else if (key == "trace_id") {
+  } else if (key == "trace_id_dec") {
     return std::to_string(span.trace_id().low);
-  } else if (key == "span_id") {
+  } else if (key == "span_id_dec") {
     return std::to_string(span.id());
   } else if (key == "json") {
     SpanContextJSONWriter writer;

--- a/test/cases/variables/conf/in_access_log_format_legacy.conf
+++ b/test/cases/variables/conf/in_access_log_format_legacy.conf
@@ -10,17 +10,12 @@ events {
 http {
     datadog_agent_url http://agent:8126;
 
-    # Enforce tracecontext propagation style to facilitate 128-bit IDs comparison.
-    # Since, Datadog propagation context set the higher bytes in `x-datadog-trace-id` and the lower part 
-    # in `_dd.p.tid`.
-    datadog_propagation_styles "tracecontext";
-
-    log_format wild_and_crazy_128bits escape=none "here is your access record: [\"$datadog_trace_id\", \"$datadog_span_id\", $datadog_json, \"$datadog_location\"]";
+    log_format wild_and_crazy_64bits escape=none "here is your access record: [\"$datadog_trace_id_64bits_base10\", \"$datadog_span_id_64bits_base10\", $datadog_json, \"$datadog_location\"]";
 
     server {
         listen       80;
 
-        access_log /dev/stdout wild_and_crazy_128bits;
+        access_log /dev/stdout wild_and_crazy_64bits;
 
         location ~ /https?[0-9]* {
             proxy_pass http://http:8080;

--- a/test/cases/variables/conf/in_request_headers.conf
+++ b/test/cases/variables/conf/in_request_headers.conf
@@ -10,11 +10,15 @@ events {
 http {
     datadog_agent_url http://agent:8126;
 
+    # Enforce tracecontext propagation style
+    # because Datadog 128-bit trace ID is the composition of the header + `_dd.p.tid`
+    datadog_propagation_styles "tracecontext";
+
     server {
         listen       80;
 
         location ~ /https?[0-9]* {
-            proxy_set_header x-datadog-test-thingy "[$datadog_trace_id, $datadog_span_id, $datadog_json, \"$datadog_location\"]";
+            proxy_set_header x-datadog-test-thingy "[\"$datadog_trace_id\", \"$datadog_span_id\", $datadog_json, \"$datadog_location\"]";
             proxy_pass http://http:8080;
         }
     }

--- a/test/cases/variables/conf/which_span_id_in_access_log_format.conf
+++ b/test/cases/variables/conf/which_span_id_in_access_log_format.conf
@@ -10,7 +10,7 @@ events {
 http {
     datadog_agent_url http://agent:8126;
 
-    log_format wild_and_crazy escape=none "here is your span ID: $datadog_span_id";
+    log_format wild_and_crazy escape=none "here is your span ID: \"$datadog_span_id\"";
 
     server {
         listen       80;


### PR DESCRIPTION
# Description
Since https://github.com/DataDog/nginx-datadog/pull/103 two versions of the module has been released. It is finally the time to default `datadog_*_id` variables to 128-bit IDs by default.