### PR TITLE
feat: otel drop in support

### DIFF
--- a/src/datadog_directive.cpp
+++ b/src/datadog_directive.cpp
@@ -2,21 +2,73 @@
 
 #include <cassert>
 
+#include "datadog_conf_handler.h"
+
 namespace datadog {
 namespace nginx {
 
-char *warn_deprecated_command_datadog_tracing(ngx_conf_t *cf,
-                                              ngx_command_t * /*command*/,
-                                              void * /*conf*/) noexcept {
+char *silently_ignore_command(ngx_conf_t *cf, ngx_command_t *command, void *) {
+  ngx_conf_log_error(NGX_LOG_DEBUG, cf, 0, "Directive \"%V\" ignored",
+                     &command->name);
+  return NGX_OK;
+}
+
+char *alias_directive(ngx_conf_t *cf, ngx_command_t *command, void *) noexcept {
+  if (command->post == nullptr) {
+    return static_cast<char *>(NGX_CONF_ERROR);
+  }
+
+  auto src_directive = static_cast<char *>(command->post);
+
   const auto elements = static_cast<ngx_str_t *>(cf->args->elts);
   assert(cf->args->nelts >= 1);
 
-  ngx_log_error(
-      NGX_LOG_WARN, cf->log, 0,
-      "Directive \"%V\" is deprecated. Use datadog_tracing on/off instead",
-      &elements[0]);
+  const ngx_str_t new_name_ngx{.len = strlen(src_directive),
+                               .data = (u_char *)src_directive};
+  ngx_conf_log_error(NGX_LOG_DEBUG, cf, 0, "Alias \"%V\" to \"%V\"",
+                     &command->name, &new_name_ngx);
 
+  // Rename the command and let `datadog_conf_handler` dispatch to the
+  // appropriate handler.
+  elements[0] = new_name_ngx;
+  auto rcode = datadog_conf_handler({.conf = cf, .skip_this_module = false});
+  if (rcode != NGX_OK) {
+    return static_cast<char *>(NGX_CONF_ERROR);
+  }
+
+  return static_cast<char *>(NGX_CONF_OK);
+}
+
+char *warn_deprecated_command(ngx_conf_t *cf, ngx_command_t *command,
+                              void *) noexcept {
+  u_char buf[NGX_MAX_ERROR_STR] = {0};
+  u_char *last = buf + NGX_MAX_ERROR_STR;
+  u_char *p =
+      ngx_slprintf(buf, last, "Directive \"%V\" is deprecated", &command->name);
+
+  if (command->post != nullptr) {
+    auto reason = static_cast<char *>(command->post);
+    ngx_slprintf(p, last, ". %s", reason);
+  }
+
+  ngx_conf_log_error(NGX_LOG_WARN, cf, 0, "%s", buf);
   return NGX_OK;
+}
+
+char *err_deprecated_command(ngx_conf_t *cf, ngx_command_t *command,
+                             void *) noexcept {
+  u_char buf[NGX_MAX_ERROR_STR] = {0};
+  u_char *last = buf + NGX_MAX_ERROR_STR;
+  u_char *p =
+      ngx_slprintf(buf, last, "Directive \"%V\" is deprecated", &command->name);
+
+  if (command->post != nullptr) {
+    auto reason = static_cast<char *>(command->post);
+    ngx_slprintf(p, last, ". %s", reason);
+  }
+
+  ngx_conf_log_error(NGX_LOG_WARN, cf, 0, "%s", buf);
+  return static_cast<char *>(NGX_CONF_ERROR);
 }
 
 }  // namespace nginx

--- a/src/datadog_directive.h
+++ b/src/datadog_directive.h
@@ -75,10 +75,10 @@ constexpr auto generate_directives(const T &...directives) {
 #define IGNORE_COMMAND(NAME, TYPE) \
   { NAME, TYPE, silently_ignore_command, NGX_HTTP_LOC_CONF_OFFSET, 0, nullptr }
 
-#define ALIAS_COMMAND(SRC_DIR, TARGET_DIR, TYPE)                    \
-  {                                                                 \
-    TARGET_DIR, TYPE, alias_directive, NGX_HTTP_LOC_CONF_OFFSET, 0, \
-        (void *)SRC_DIR                                             \
+#define ALIAS_COMMAND(SRC_DIRECTIVE, TARGET_DIRECTIVE, TYPE)              \
+  {                                                                       \
+    TARGET_DIRECTIVE, TYPE, alias_directive, NGX_HTTP_LOC_CONF_OFFSET, 0, \
+        (void *)SRC_DIRECTIVE                                             \
   }
 
 #define WARN_DEPRECATED_COMMAND(NAME, TYPE, MSG)                      \

--- a/src/datadog_directive.h
+++ b/src/datadog_directive.h
@@ -72,11 +72,39 @@ constexpr auto generate_directives(const T &...directives) {
   return merge_directives(directives...);
 }
 
+#define IGNORE_COMMAND(NAME, TYPE) \
+  { NAME, TYPE, silently_ignore_command, NGX_HTTP_LOC_CONF_OFFSET, 0, nullptr }
+
+#define ALIAS_COMMAND(SRC_DIR, TARGET_DIR, TYPE)                    \
+  {                                                                 \
+    TARGET_DIR, TYPE, alias_directive, NGX_HTTP_LOC_CONF_OFFSET, 0, \
+        (void *)SRC_DIR                                             \
+  }
+
+#define WARN_DEPRECATED_COMMAND(NAME, TYPE, MSG)                      \
+  {                                                                   \
+    NAME, TYPE, warn_deprecated_command, NGX_HTTP_LOC_CONF_OFFSET, 0, \
+        (void *)MSG                                                   \
+  }
+
+#define ERROR_DEPRECATED_COMMAND(NAME, TYPE, MSG)                    \
+  {                                                                  \
+    NAME, TYPE, err_deprecated_command, NGX_HTTP_LOC_CONF_OFFSET, 0, \
+        (void *)MSG                                                  \
+  }
+
+char *silently_ignore_command(ngx_conf_t *, ngx_command_t *, void *);
+
+char *alias_directive(ngx_conf_t *cf, ngx_command_t *command,
+                      void *conf) noexcept;
+
 char *set_datadog_agent_url(ngx_conf_t *, ngx_command_t *, void *conf) noexcept;
 
-char *warn_deprecated_command_datadog_tracing(ngx_conf_t *cf,
-                                              ngx_command_t * /*command*/,
-                                              void * /*conf*/) noexcept;
+char *warn_deprecated_command(ngx_conf_t *cf, ngx_command_t *command,
+                              void *conf) noexcept;
+
+char *err_deprecated_command(ngx_conf_t *cf, ngx_command_t *command,
+                             void *) noexcept;
 
 }  // namespace nginx
 }  // namespace datadog

--- a/src/datadog_variable.cpp
+++ b/src/datadog_variable.cpp
@@ -19,8 +19,8 @@ namespace {
 
 // Return whether the specified `request` is a subrequest for which tracing
 // ("logging") is disabled.
-bool is_untraced_subrequest(ngx_http_request_t* request) {
-  auto core_loc_conf = static_cast<ngx_http_core_loc_conf_t*>(
+bool is_untraced_subrequest(ngx_http_request_t *request) {
+  auto core_loc_conf = static_cast<ngx_http_core_loc_conf_t *>(
       ngx_http_get_module_loc_conf(request, ngx_http_core_module));
 
   return request->parent != nullptr && !core_loc_conf->log_subrequest;
@@ -33,13 +33,9 @@ bool is_untraced_subrequest(ngx_http_request_t* request) {
 // if valid, will resolve to some property on the active span, i.e.
 // `datadog_trace_id` resolves to a string containing the trace ID.  Return
 // `NGX_OK` on success or another value if an error occurs.
-static ngx_int_t expand_span_variable(ngx_http_request_t* request,
-                                      ngx_http_variable_value_t* variable_value,
+static ngx_int_t expand_span_variable(ngx_http_request_t *request,
+                                      ngx_http_variable_value_t *variable_value,
                                       uintptr_t data) noexcept try {
-  auto variable_name = to_string_view(*reinterpret_cast<ngx_str_t*>(data));
-  auto prefix_length = TracingLibrary::span_variables().prefix.size();
-  auto suffix = slice(variable_name, prefix_length);
-
   auto context = get_datadog_context(request);
   // Context can be null if tracing is disabled.
   if (context == nullptr || is_untraced_subrequest(request)) {
@@ -52,16 +48,29 @@ static ngx_int_t expand_span_variable(ngx_http_request_t* request,
     return NGX_OK;
   }
 
-  auto span_variable_value =
-      context->lookup_span_variable_value(request, suffix);
-  variable_value->len = span_variable_value.len;
-  variable_value->valid = true;
-  variable_value->no_cacheable = true;
-  variable_value->not_found = false;
-  variable_value->data = span_variable_value.data;
+  auto set_variable = [&](std::string_view suffix) {
+    auto span_variable_value =
+        context->lookup_span_variable_value(request, suffix);
+    variable_value->len = span_variable_value.len;
+    variable_value->valid = true;
+    variable_value->no_cacheable = true;
+    variable_value->not_found = false;
+    variable_value->data = span_variable_value.data;
+  };
+
+  auto variable_name = to_string_view(*reinterpret_cast<ngx_str_t *>(data));
+  if (variable_name.starts_with("datadog_")) {
+    auto suffix =
+        slice(variable_name, TracingLibrary::span_variables().prefix.size());
+    set_variable(suffix);
+  } else if (std::string_view otel("opentelemetry_");
+             variable_name.starts_with(otel)) {
+    auto suffix = slice(variable_name, otel.size());
+    set_variable(suffix);
+  }
 
   return NGX_OK;
-} catch (const std::exception& e) {
+} catch (const std::exception &e) {
   ngx_log_error(NGX_LOG_ERR, request->connection->log, 0,
                 "failed to expand %V"
                 " for request %p: %s",
@@ -79,9 +88,9 @@ static ngx_int_t expand_span_variable(ngx_http_request_t* request,
 // `TracingLibrary::environment_variable_names`.  Return `NGX_OK` on success or
 // another value if an error occurs.
 static ngx_int_t expand_environment_variable(
-    ngx_http_request_t* request, ngx_http_variable_value_t* variable_value,
+    ngx_http_request_t *request, ngx_http_variable_value_t *variable_value,
     uintptr_t data) noexcept {
-  auto variable_name = to_string_view(*reinterpret_cast<ngx_str_t*>(data));
+  auto variable_name = to_string_view(*reinterpret_cast<ngx_str_t *>(data));
   auto prefix_length =
       TracingLibrary::environment_variable_name_prefix().size();
   auto suffix = slice(variable_name, prefix_length);
@@ -91,7 +100,7 @@ static ngx_int_t expand_environment_variable(
                  to_upper);
 
   const auto allow_list = TracingLibrary::environment_variable_names();
-  const char* env_value = nullptr;
+  const char *env_value = nullptr;
   if (std::find(allow_list.begin(), allow_list.end(), env_var_name) !=
       allow_list.end()) {
     env_value = std::getenv(env_var_name.c_str());
@@ -123,13 +132,13 @@ static ngx_int_t expand_environment_variable(
 // evaluates to a JSON representation of the tracer configuration.  Return
 // `NGX_OK` on success or another value if an error occurs.
 static ngx_int_t expand_configuration_variable(
-    ngx_http_request_t* request, ngx_http_variable_value_t* variable_value,
+    ngx_http_request_t *request, ngx_http_variable_value_t *variable_value,
     uintptr_t /*data*/) noexcept {
   variable_value->valid = true;
   variable_value->no_cacheable = true;
   variable_value->not_found = false;
 
-  const dd::Tracer* tracer = global_tracer();
+  const dd::Tracer *tracer = global_tracer();
   if (tracer == nullptr) {
     // No tracer, no config. Evaluate to "-" (hyphen).
     const ngx_str_t not_found_str = ngx_string("-");
@@ -150,21 +159,21 @@ static ngx_int_t expand_configuration_variable(
     variable_value->data = json_str.data;
   }
 
-  auto& alloc = doc.GetAllocator();
+  auto &alloc = doc.GetAllocator();
 
   // override
-  const auto& loc_conf = *static_cast<datadog::nginx::datadog_loc_conf_t*>(
+  const auto &loc_conf = *static_cast<datadog::nginx::datadog_loc_conf_t *>(
       ngx_http_get_module_loc_conf(request, ngx_http_datadog_module));
 
   auto append_to_doc = [&](std::string_view key,
-                           ngx_http_complex_value_t* value) {
+                           ngx_http_complex_value_t *value) {
     if (value == nullptr) return;
 
     ngx_str_t res;
     if (ngx_http_complex_value(request, value, &res) == NGX_OK &&
         res.len != 0) {
       doc.AddMember(rapidjson::Value(key.data(), key.size(), alloc),
-                    rapidjson::Value((char*)res.data, res.len, alloc), alloc);
+                    rapidjson::Value((char *)res.data, res.len, alloc), alloc);
     }
   };
 
@@ -215,9 +224,9 @@ static ngx_int_t expand_configuration_variable(
 //
 // Return `NGX_OK` on success or another value if an error occurs.
 static ngx_int_t expand_location_variable(
-    ngx_http_request_t* request, ngx_http_variable_value_t* variable_value,
+    ngx_http_request_t *request, ngx_http_variable_value_t *variable_value,
     uintptr_t /*data*/) noexcept {
-  const auto core_loc_conf = static_cast<ngx_http_core_loc_conf_t*>(
+  const auto core_loc_conf = static_cast<ngx_http_core_loc_conf_t *>(
       ngx_http_get_module_loc_conf(request, ngx_http_core_module));
 
   if (core_loc_conf == nullptr) {
@@ -240,9 +249,9 @@ static ngx_int_t expand_location_variable(
   return NGX_OK;
 }
 
-ngx_int_t add_variables(ngx_conf_t* cf) noexcept {
+ngx_int_t add_variables(ngx_conf_t *cf) noexcept {
   ngx_str_t prefix;
-  ngx_http_variable_t* variable;
+  ngx_http_variable_t *variable;
 
   // Register the variable name prefix for span variables.
   prefix = to_ngx_str(TracingLibrary::span_variables().prefix);
@@ -259,6 +268,15 @@ ngx_int_t add_variables(ngx_conf_t* cf) noexcept {
       cf, &prefix,
       NGX_HTTP_VAR_NOCACHEABLE | NGX_HTTP_VAR_NOHASH | NGX_HTTP_VAR_PREFIX);
   variable->get_handler = expand_environment_variable;
+  variable->data = 0;
+
+  // Register the variable name prefix for OpenTelemetry-relevant environment
+  // variables.
+  prefix = ngx_string("opentelemetry_");
+  variable = ngx_http_add_variable(
+      cf, &prefix,
+      NGX_HTTP_VAR_NOCACHEABLE | NGX_HTTP_VAR_NOHASH | NGX_HTTP_VAR_PREFIX);
+  variable->get_handler = expand_span_variable;
   variable->data = 0;
 
   // Register the variable name for getting the tracer configuration.

--- a/src/ngx_http_datadog_module.cpp
+++ b/src/ngx_http_datadog_module.cpp
@@ -52,18 +52,13 @@ static char *merge_datadog_loc_conf(ngx_conf_t *, void *parent, void *child) noe
 
 using namespace datadog::nginx;
 
-#define DEFINE_DEPRECATED_COMMAND_DATADOG_TRACING(NAME, TYPE) \
-  {                                                           \
-    NAME, TYPE, warn_deprecated_command_datadog_tracing,      \
-        NGX_HTTP_LOC_CONF_OFFSET, 0, NULL                     \
-  }
-
 constexpr datadog::nginx::directive module_directives[] = {
-    DEFINE_DEPRECATED_COMMAND_DATADOG_TRACING("datadog_enable",
-                                              anywhere | NGX_CONF_NOARGS),
+    WARN_DEPRECATED_COMMAND("datadog_enable", anywhere | NGX_CONF_NOARGS,
+                            "Use datadog_tracing instead"),
 
-    DEFINE_DEPRECATED_COMMAND_DATADOG_TRACING("datadog_disable",
-                                              anywhere | NGX_CONF_NOARGS),
+    WARN_DEPRECATED_COMMAND("datadog_disable", anywhere | NGX_CONF_NOARGS,
+                            "Use datadog_tracing instead"),
+
     {"datadog_service_name",
      NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF |
          NGX_CONF_TAKE1,
@@ -84,6 +79,12 @@ constexpr datadog::nginx::directive module_directives[] = {
 
     {"datadog_agent_url", NGX_HTTP_MAIN_CONF | NGX_CONF_TAKE1,
      set_datadog_agent_url, NGX_HTTP_MAIN_CONF_OFFSET, 0, nullptr},
+
+    // aliases
+    ALIAS_COMMAND("datadog_service_name", "opentelemetry_service_name",
+                  NGX_HTTP_MAIN_CONF | NGX_CONF_TAKE1),
+    ALIAS_COMMAND("datadog_agent_url", "opentelemetry_otlp_traces_endpoint",
+                  NGX_HTTP_MAIN_CONF | NGX_CONF_TAKE1),
 };
 
 static auto datadog_commands =

--- a/test/cases/deprecations/test_deprecation_errors.py
+++ b/test/cases/deprecations/test_deprecation_errors.py
@@ -13,21 +13,22 @@ class TestDeprecationErrors(case.TestCase):
 
     def test_opentracing_load_tracer(self):
         return self.run_test_for_config(
-            config_relative_path='conf/opentracing_load_tracer.conf',
+            config_relative_path="conf/opentracing_load_tracer.conf",
             diagnostic_excerpt=
-            'The "opentracing_load_tracer" directive is no longer necessary.')
+            'Directive "opentracing_load_tracer" is deprecated',
+        )
 
     def test_datadog_load_tracer(self):
         return self.run_test_for_config(
-            config_relative_path='conf/datadog_load_tracer.conf',
-            diagnostic_excerpt=
-            'The "datadog_load_tracer" directive is no longer necessary.')
+            config_relative_path="conf/datadog_load_tracer.conf",
+            diagnostic_excerpt='Directive "datadog_load_tracer" is deprecated',
+        )
 
     def test_datadog(self):
         return self.run_test_for_config(
-            config_relative_path='conf/datadog.conf',
-            diagnostic_excerpt=
-            'The datadog { ... } block directive is no longer supported.')
+            config_relative_path="conf/datadog.conf",
+            diagnostic_excerpt='Directive "datadog" is deprecated',
+        )
 
     def run_test_for_config(self, config_relative_path, diagnostic_excerpt):
         config_path = Path(__file__).parent / config_relative_path
@@ -37,8 +38,10 @@ class TestDeprecationErrors(case.TestCase):
 
         self.assertNotEqual(status, 0)
 
-        self.assertTrue(any(diagnostic_excerpt in line for line in log_lines),
-                        {
-                            'diagnostic_excerpt': diagnostic_excerpt,
-                            'log_lines': log_lines
-                        })
+        self.assertTrue(
+            any(diagnostic_excerpt in line for line in log_lines),
+            {
+                "diagnostic_excerpt": diagnostic_excerpt,
+                "log_lines": log_lines
+            },
+        )

--- a/test/cases/deprecations/test_deprecation_warnings.py
+++ b/test/cases/deprecations/test_deprecation_warnings.py
@@ -11,17 +11,17 @@ class TestDeprecationWarnings(case.TestCase):
 
     def test_opentracing_propagate_context(self):
         directive = "opentracing_propagate_context"
-        return self.run_test_deprecated_1_2_0_directive(
+        return self.run_test_deprecated_datadog_tracing_directive(
             f"conf/{directive}.conf", directive)
 
     def test_opentracing_fastcgi_propagate_context(self):
         directive = "opentracing_fastcgi_propagate_context"
-        return self.run_test_deprecated_1_2_0_directive(
+        return self.run_test_deprecated_datadog_tracing_directive(
             f"conf/{directive}.conf", directive)
 
     def test_opentracing_grpc_propagate_context(self):
         directive = "opentracing_grpc_propagate_context"
-        return self.run_test_deprecated_1_2_0_directive(
+        return self.run_test_deprecated_datadog_tracing_directive(
             f"conf/{directive}.conf", directive)
 
     def test_opentracing_operation_name(self):
@@ -53,42 +53,9 @@ class TestDeprecationWarnings(case.TestCase):
     def run_test_for_config(self, config_relative_path, directive):
         config_path = Path(__file__).parent / config_relative_path
         config_text = config_path.read_text()
-        status, log_lines = self.orch.nginx_test_config(
-            config_text, config_path.name)
+        status, _ = self.orch.nginx_test_config(config_text, config_path.name)
 
         self.assertEqual(status, 0)
-
-        # old ="opentracing_something"
-        # new = "datadog_something"
-        old = directive
-        new = directive.replace("opentracing_", "datadog_")
-        expected = f'Backward compatibility with the "{old}" configuration directive is deprecated.  Please use "{new}" instead.'
-        self.assertTrue(
-            any(expected in line for line in log_lines),
-            {
-                "expected": expected,
-                "log_lines": log_lines
-            },
-        )
-
-    def run_test_deprecated_1_2_0_directive(self, config_relative_path,
-                                            directive):
-        config_path = Path(__file__).parent / config_relative_path
-        config_text = config_path.read_text()
-        status, log_lines = self.orch.nginx_test_config(
-            config_text, config_path.name)
-
-        self.assertEqual(status, 0)
-
-        old = directive
-        expected = f'Directive "{old}" is deprecated and can be removed since v1.2.0'
-        self.assertTrue(
-            any(expected in line for line in log_lines),
-            {
-                "expected": expected,
-                "log_lines": log_lines
-            },
-        )
 
     def run_test_deprecated_datadog_tracing_directive(self,
                                                       config_relative_path,
@@ -101,7 +68,7 @@ class TestDeprecationWarnings(case.TestCase):
         self.assertEqual(status, 0)
 
         old = directive
-        expected = f'Directive "{old}" is deprecated. Use datadog_tracing on/off instead'
+        expected = f'Directive "{old}" is deprecated'
         self.assertTrue(
             any(expected in line for line in log_lines),
             {

--- a/test/cases/variables/conf/otel_drop_in_support.conf
+++ b/test/cases/variables/conf/otel_drop_in_support.conf
@@ -1,0 +1,27 @@
+# "/datadog-tests" is a directory created by the docker build
+# of the nginx test image. It contains the module, the
+# nginx config, and "index.html".
+load_module /datadog-tests/ngx_http_datadog_module.so;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    datadog_agent_url http://agent:8126;
+
+    # Enforce tracecontext propagation style to facilitate 128-bit IDs comparison.
+    # Since, Datadog propagation context set the higher bytes in `x-datadog-trace-id` and the lower part 
+    # in `_dd.p.tid`.
+    datadog_propagation_styles "tracecontext";
+
+    server {
+        listen       80;
+
+        location ~ /https?[0-9]* {
+            proxy_set_header x-datadog-test-thingy "[\"$opentelemetry_trace_id\", \"$opentelemetry_span_id\"]";
+            proxy_pass http://http:8080;
+        }
+    }
+}
+


### PR DESCRIPTION
# Description
This PR introduces the ability to replace the OpenTelemetry (oTel) module`otel_ngx_module` with `nginx-datadog` without requiring any changes to the existing oTel directives. This enhancement aims to simplify the migration process for ingress-nginx users, enabling them to switch from the `otel_ngx_module` to `nginx-datadog` or the opposite seamlessly, without the need to modify their kubernetes CRD/resources.

### Changes
- Introduced aliases for compatible `otel_ngx_module` directives, ensuring they are ignored when no corresponding `nginx-datadog` equivalent exists.
- Added aliases for compatible `otel_ngx_module` variables to match their `nginx-datadog` equivalents.
- Included several helper directives.
- Replaced instances of `ngx_log_error` with `ngx_conf_log_error` where applicable. This change simplifies the code by leveraging `ngx_conf_log_error`'s ability to automatically print the file and location of the error in the configuration file.
