### PR TITLE
chore(ingress-nginx): added support for 1.12.1 and 1.11.5

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -294,7 +294,7 @@ jobs:
                 name: Move the module to the system-tests directory
                 working_directory: ./system-tests
             - run:
-                command: ./build.sh cpp
+                command: ./build.sh cpp_nginx
                 name: Build test targets
                 working_directory: ./system-tests
             - run:
@@ -460,7 +460,7 @@ workflows:
                             - amd64
                             - arm64
                         version:
-                            - 1.12.0
+                            - 1.12.1
                 name: build ingress-nginx-<< matrix.version >> on << matrix.arch >>
             - coverage:
                 name: Coverage on 1.27.0 with WAF ON
@@ -538,7 +538,7 @@ workflows:
                         base-image:
                             - registry.k8s.io/ingress-nginx/controller
                         nginx-version:
-                            - 1.12.0
+                            - 1.12.1
                 name: test ingress-nginx-<< matrix.nginx-version >> on << matrix.arch >>
                 requires:
                     - build ingress-nginx-<< matrix.nginx-version >> on << matrix.arch >>
@@ -562,7 +562,9 @@ workflows:
                             - amd64
                             - arm64
                         version:
+                            - 1.12.1
                             - 1.12.0
+                            - 1.11.5
                             - 1.11.4
                             - 1.11.3
                             - 1.11.2
@@ -587,7 +589,9 @@ workflows:
                         base-image:
                             - registry.k8s.io/ingress-nginx/controller
                         nginx-version:
+                            - 1.12.1
                             - 1.12.0
+                            - 1.11.5
                             - 1.11.4
                             - 1.11.3
                             - 1.11.2

--- a/.circleci/src/@jobs.yml
+++ b/.circleci/src/@jobs.yml
@@ -250,7 +250,7 @@ jobs:
       - run:
           name: Build test targets
           working_directory: ./system-tests
-          command: ./build.sh cpp
+          command: ./build.sh cpp_nginx
       - run:
           name: Run DEFAULT scenarios
           working_directory: ./system-tests

--- a/.circleci/src/workflows/build-and-test-all.yml
+++ b/.circleci/src/workflows/build-and-test-all.yml
@@ -14,7 +14,9 @@
             - 'amd64'
             - 'arm64'
             version:
+            - 1.12.1
             - 1.12.0
+            - 1.11.5
             - 1.11.4
             - 1.11.3
             - 1.11.2
@@ -41,7 +43,9 @@
             base-image:
             - registry.k8s.io/ingress-nginx/controller
             nginx-version:
+            - 1.12.1
             - 1.12.0
+            - 1.11.5
             - 1.11.4
             - 1.11.3
             - 1.11.2

--- a/.circleci/src/workflows/build-and-test.yml
+++ b/.circleci/src/workflows/build-and-test.yml
@@ -47,7 +47,7 @@ jobs:
         - 'amd64'
         - 'arm64'
         version:
-        - 1.12.0
+        - 1.12.1
 - coverage:
     name: Coverage on 1.27.0 with WAF ON
 - test:
@@ -131,7 +131,7 @@ jobs:
         base-image:
         - registry.k8s.io/ingress-nginx/controller
         nginx-version:
-        - 1.12.0
+        - 1.12.1
 - system_tests:
     name: Run system tests
     requires:

--- a/bin/ingress_nginx.py
+++ b/bin/ingress_nginx.py
@@ -33,7 +33,9 @@ PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 def get_underlying_nginx_version(controller_version: str) -> str:
     # Map an ingress-nginx version to an NGINX version
     mapping = {
+        "v1.12.1": "1.25.5",
         "v1.12.0": "1.25.5",
+        "v1.11.5": "1.25.5",
         "v1.11.4": "1.25.5",
         "v1.11.3": "1.25.5",
         "v1.11.2": "1.25.5",
@@ -73,7 +75,9 @@ def clone_nginx(version: str, out_dir: str) -> str:
 
 def get_patch_directory(version: str, ingress_rootdir: str) -> str:
     mapping = {
+        "v1.12.1": f"{ingress_rootdir}/images/nginx/rootfs/patches",
         "v1.12.0": f"{ingress_rootdir}/images/nginx/rootfs/patches",
+        "v1.11.5": f"{ingress_rootdir}/images/nginx/rootfs/patches",
         "v1.11.4": f"{ingress_rootdir}/images/nginx/rootfs/patches",
         "v1.11.3": f"{ingress_rootdir}/images/nginx/rootfs/patches",
         "v1.11.2": f"{ingress_rootdir}/images/nginx-1.25/rootfs/patches",


### PR DESCRIPTION
ingress-nginx 1.11.5 and 1.12.1 have been released, following a few CVEs: https://thehackernews.com/2025/03/critical-ingress-nginx-controller.html