### PR TITLE
chore(ci): build for nginx@1.26.3 for AL2

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -433,7 +433,7 @@ workflows:
                             - amd64
                             - arm64
                         nginx-version:
-                            - 1.22.1
+                            - 1.26.3
                             - 1.24.0
                             - 1.25.4
                             - 1.27.4
@@ -506,7 +506,7 @@ workflows:
                         base-image:
                             - amazonlinux:2.0.20230418.0
                         nginx-version:
-                            - 1.22.1
+                            - 1.26.3
                         waf:
                             - "ON"
                             - "OFF"

--- a/.circleci/src/workflows/build-and-test.yml
+++ b/.circleci/src/workflows/build-and-test.yml
@@ -19,7 +19,7 @@ jobs:
         - amd64
         - arm64
         nginx-version:
-        - 1.22.1
+        - 1.26.3
         - 1.24.0
         - 1.25.4
         - 1.27.4
@@ -97,7 +97,7 @@ jobs:
         base-image:
         - amazonlinux:2.0.20230418.0
         nginx-version:
-        - 1.22.1
+        - 1.26.3
     name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch
       >> WAF << matrix.waf >>
     requires:


### PR DESCRIPTION
## Description
AmazonLinux2 (AL2) silently upgraded from nginx@1.22.1 to nginx@1.26.3 which lead to an error while 
testing on AL2. This commit change the version of nginx to build for AL2.

NOTE: AL2 extra list (https://docs.aws.amazon.com/linux/al2/ug/al2-extras-list.html)

### Note to reviewer
This is a bandaid. A better approach is to find the version of NGINX for AmazonLinux and build the module for the corresponding version.