### PR TITLE
Fix certain response headers' tags not being set

### DIFF
--- a/test/cases/orchestration.py
+++ b/test/cases/orchestration.py
@@ -839,6 +839,7 @@ END_CONF
         """Replaces the contents of an arbitrary file in the nginx container."""
 
         script = f"""
+mkdir -p $(dirname "{file}")
 >{file} cat <<'END_CONF'
 {content}
 END_CONF

--- a/test/cases/sec_header_collection/conf/headers.txt
+++ b/test/cases/sec_header_collection/conf/headers.txt
@@ -1,0 +1,1 @@
+File served by /headers

--- a/test/cases/sec_header_collection/conf/http.conf
+++ b/test/cases/sec_header_collection/conf/http.conf
@@ -25,10 +25,13 @@ http {
             # /http/status/5xx (for various values of xx) and verify that the
             # resulting spans sent to the agent are marked as errors.
             proxy_pass http://http:8080;
+        }
 
-            add_header Content-type "text/plain" always;
+        location /headers {
+            root /var/www/html;
             add_header Content-Encoding "identity" always;
             add_header Content-Language "pt_PT" always;
+            try_files /headers.txt =404;
         }
 
         location /sync {

--- a/test/cases/sec_header_collection/test_header_collection.py
+++ b/test/cases/sec_header_collection/test_header_collection.py
@@ -62,6 +62,11 @@ class TestHeaderCollection(case.TestCase):
             waf_text = waf_path.read_text()
             self.orch.nginx_replace_file('/tmp/waf.json', waf_text)
 
+            headers_txt_path = Path(__file__).parent / './conf/headers.txt'
+            headers_txt_text = headers_txt_path.read_text()
+            self.orch.nginx_replace_file('/var/www/html/headers.txt',
+                                         headers_txt_text)
+
             conf_path = Path(__file__).parent / './conf/http.conf'
             conf_text = conf_path.read_text()
 
@@ -150,7 +155,7 @@ class TestHeaderCollection(case.TestCase):
         self.assertIn("http.request.headers.content-length", meta)
 
     def test_resp_no_attack(self):
-        status, _, _ = self.orch.send_nginx_http_request('/http', 80)
+        status, _, _ = self.orch.send_nginx_http_request('/headers', 80)
         self.assertEqual(status, 200)
 
         meta = self.get_meta()
@@ -158,8 +163,7 @@ class TestHeaderCollection(case.TestCase):
         # check each of the headers in resp_headers
         self.assertEqual("text/plain",
                          meta["http.response.headers.content-type"])
-        # content-length is not present in the response
-        # self.assertIn("http.response.headers.content-length", meta)
+        self.assertIn("http.response.headers.content-length", meta)
         self.assertEqual("identity",
                          meta["http.response.headers.content-encoding"])
         self.assertEqual("pt_PT",


### PR DESCRIPTION
Appsec unconditionally adds some tags corresponding to some response headers. However, content-type and content-length are encoded in a specific manner inside the nginx request object and this was not being taken account of.