### PR TITLE
Fix WAF stalling websocket requests

### DIFF
--- a/src/datadog_context.h
+++ b/src/datadog_context.h
@@ -56,6 +56,10 @@ class DatadogContext {
 
   RequestTracing& single_trace();
 
+#ifdef WITH_WAF
+  security::Context* get_security_context() { return sec_ctx_.get(); }
+#endif
+
  private:
   std::vector<RequestTracing> traces_;
 #ifdef WITH_WAF

--- a/src/security/context.h
+++ b/src/security/context.h
@@ -215,9 +215,14 @@ class Context {
   static ngx_int_t buffer_chain(FilterCtx &filter_ctx, ngx_pool_t &pool,
                                 ngx_chain_t const *in, bool consume) noexcept;
 
+  ngx_http_event_handler_pt prev_req_write_evt_handler_;
+  static void drain_buffered_data_write_handler(ngx_http_request_t *r) noexcept;
+
  public:
   ngx_int_t buffer_header_output(ngx_pool_t &pool, ngx_chain_t *chain) noexcept;
   ngx_int_t send_buffered_header(ngx_http_request_t &request) noexcept;
+
+  void prepare_drain_buffered_header(ngx_http_request_t &request) noexcept;
 };
 
 }  // namespace datadog::nginx::security

--- a/test/cases/sec_addresses/conf/http.conf
+++ b/test/cases/sec_addresses/conf/http.conf
@@ -27,6 +27,15 @@ http {
             proxy_pass http://http:8080;
         }
 
+        location /ws {
+            proxy_pass http://http:8080;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "Upgrade";
+            proxy_set_header Host $host;
+            proxy_cache_bypass $http_upgrade;
+        }
+
         location /sync {
             return 200;
         }

--- a/test/cases/sec_addresses/conf/waf.json
+++ b/test/cases/sec_addresses/conf/waf.json
@@ -171,6 +171,44 @@
       "transformers": [
         "values_only"
       ]
+    },
+    {
+      "id": "block_websocket_upgrade_response",
+      "name": "Block WebSocket upgrade responses on specific path",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.response.headers.upgrade"
+              }
+            ],
+            "regex": "^websocket$"
+          },
+          "operator": "match_regex"
+        },
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.uri.raw"
+              }
+            ],
+            "regex": "/ws/blocked-ws"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "on_match": [
+        "block"
+      ],
+      "transformers": [
+        "lowercase"
+      ]
     }
   ]
 }

--- a/test/cases/sec_blocking/conf/http.conf
+++ b/test/cases/sec_blocking/conf/http.conf
@@ -39,6 +39,15 @@ http {
             add_header 'foo' 'block me' always;
             proxy_pass http://http:8080;
         }
+
+        location /ws {
+            proxy_pass http://http:8080;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "Upgrade";
+            proxy_set_header Host $host;
+            proxy_cache_bypass $http_upgrade;
+        }
     }
 }
 

--- a/test/cases/sec_blocking/conf/waf.json
+++ b/test/cases/sec_blocking/conf/waf.json
@@ -287,6 +287,47 @@
       "on_match": [
         "redirect"
       ]
+    },
+    {
+      "id": "block_websocket_upgrade_response",
+      "name": "Block WebSocket upgrade responses on specific path",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.response.headers.no_cookies",
+                "key_path": [
+                  "upgrade"
+                ]
+              }
+            ],
+            "regex": "^websocket$"
+          },
+          "operator": "match_regex"
+        },
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.uri.raw"
+              }
+            ],
+            "regex": "/ws/blocked-ws"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "on_match": [
+        "block_html"
+      ],
+      "transformers": [
+        "lowercase"
+      ]
     }
   ]
 }

--- a/test/services/client/install-tools.sh
+++ b/test/services/client/install-tools.sh
@@ -4,9 +4,11 @@ set -e
 case "$(uname -m)" in
   aarch64)
     ARCH="arm64"
+    ARCH_WEBSOCAT=aarch64
     ;;
   *)
     ARCH="$(uname -m)"
+    ARCH_WEBSOCAT=$ARCH
     ;;
 esac
 
@@ -21,3 +23,7 @@ wget https://github.com/fullstorydev/grpcurl/releases/download/v1.8.6/"${GRPCURL
 tar -xzf "${GRPCURL_TAR}"
 mv grpcurl /usr/local/bin
 rm "${GRPCURL_TAR}"
+
+wget -O /usr/local/bin/websocat \
+  https://github.com/vi/websocat/releases/download/v4.0.0-alpha2/websocat."${ARCH_WEBSOCAT}"-unknown-linux-musl
+chmod +x /usr/local/bin/websocat

--- a/test/services/http/Dockerfile
+++ b/test/services/http/Dockerfile
@@ -8,6 +8,7 @@ WORKDIR /opt/app
 
 RUN apk update && apk add nodejs npm
 RUN npm install dd-trace
+RUN npm install ws
 
 COPY ./http.js /opt/app/http.js
 

--- a/test/services/http/http.js
+++ b/test/services/http/http.js
@@ -3,6 +3,7 @@
 
 const http = require('http');
 const process = require('process');
+const WebSocket = require('ws');
 
 // In order for the span(s) associated with an HTTP request to be considered
 // finished, the body of the response corresponding to the request must have
@@ -79,9 +80,28 @@ const requestListener = function (request, response) {
   response.end(responseBody);
 }
 
+function reverseBytes(str) {
+  return str.split('').reverse().join('');
+}
+
 console.log('http node.js web server is running');
 const server = http.createServer(requestListener);
 server.listen(8080);
+
+const wss = new WebSocket.Server({ server });
+
+wss.on('connection', (ws) => {
+  ws.on('message', (message) => {
+    const messageStr = message.toString();
+
+    if (messageStr.length > 1024 || messageStr.length < 1) {
+      return;
+    }
+
+    const reversed = reverseBytes(messageStr);
+    ws.send(reversed);
+  });
+});
 
 process.on('SIGTERM', function () {
   console.log('Received SIGTERM');


### PR DESCRIPTION
Our body handler suppresses the flush of the upgrade response header, and the calling code ignores NGX_AGAIN (so it's pointless to change the body handler return code to it in that case).

When we finish the WAF run, we call call the write handler on the request, but the upstream connection write handler doesn't do anything because there is no data from upstream waiting to be sent.

And since we don't send the response header,  the client never sends any data, so the request stalls.

So, if we have an upstream connection (this could be generalized), replace the write handler before triggering it. This substitute write handler will attempt to flush the headers and the body filter chain before restoring the write handler.