### PR TITLE
feat(telemetry): include NGINX flavor in telemetry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,6 +153,7 @@ build-openresty-aux:
 		-DNGINX_PATCH_AWAY_LIBC=ON \
 		-DCMAKE_BUILD_TYPE=$(BUILD_TYPE) \
 		-DNGINX_SRC_DIR=/tmp/openresty-${RESTY_VERSION}/build/nginx-${NGINX_VERSION} \
+		-DNGINX_DATADOG_FLAVOR="openresty" \
 		-DNGINX_DATADOG_ASM_ENABLED="$(WAF)" . \
 		&& cmake --build .openresty-build -j $(MAKE_JOB_COUNT) -v --target ngx_http_datadog_module \
 

--- a/src/nginx_flavors.h
+++ b/src/nginx_flavors.h
@@ -14,7 +14,7 @@ inline constexpr flavor from_str(std::string_view in) {
   if (in == "nginx") {
     return flavor::vanilla;
   } else if (in == "openresty") {
-    return flavor::vanilla;
+    return flavor::openresty;
   } else if (in == "ingress-nginx") {
     return flavor::ingress_nginx;
   }

--- a/src/tracing_library.cpp
+++ b/src/tracing_library.cpp
@@ -31,12 +31,27 @@ extern "C" {
 namespace datadog {
 namespace nginx {
 
+inline constexpr std::string_view integration_name_from_flavor(
+    flavor nginx_flavor) {
+  switch (nginx_flavor) {
+    case flavor::vanilla:
+      return "nginx";
+    case flavor::openresty:
+      return "nginx:openresty";
+    case flavor::ingress_nginx:
+      return "nginx:ingress-nginx";
+  }
+
+  static_assert(true, "unknown NGINX flavor");
+  std::abort();
+}
+
 dd::Expected<dd::Tracer> TracingLibrary::make_tracer(
     const datadog_main_conf_t &nginx_conf, std::shared_ptr<dd::Logger> logger) {
   dd::TracerConfig config;
   config.logger = std::move(logger);
   config.agent.event_scheduler = std::make_shared<NgxEventScheduler>();
-  config.integration_name = "nginx";
+  config.integration_name = integration_name_from_flavor(kNginx_flavor);
   config.integration_version = NGINX_VERSION;
   config.service = "nginx";
 


### PR DESCRIPTION
This commit enhances telemetry by adding the NGINX flavor into the integration name reported. This improvement will provide better insights into how the module is utilized.

Changes:
  - Fix reported flavor for openresty.
  - Report integration name depending of the flavor.