### PR TITLE
deps(dd-trace-cpp): bump `dd-trace-cpp` to `83958bc`

### DIFF
--- a/build_env/Dockerfile
+++ b/build_env/Dockerfile
@@ -73,5 +73,5 @@ RUN apk add --no-cache pcre-dev pcre2-dev zlib-dev openssl-dev perl
 
 # Install Rust toolchain
 RUN apk add --no-cache curl
-RUN curl –proto ‘=https’ –tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -yq \
+RUN curl --proto '=https' –tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -yq \
   && ln -s ~/.cargo/bin/cargo /usr/bin/cargo

--- a/build_env/glibc_compat.c
+++ b/build_env/glibc_compat.c
@@ -220,4 +220,15 @@ ssize_t getrandom(void *buf, size_t buflen, unsigned int flags) {
     return (ssize_t)bytes_read;
 }
 
+#ifdef __x86_64__
+#define MEMFD_CREATE_SYSCALL 319
+#elif __aarch64__
+#define MEMFD_CREATE_SYSCALL 279
+#endif
+
+// introduced in glibc 2.27
+int memfd_create(const char *name, unsigned flags) {
+  return syscall(MEMFD_CREATE_SYSCALL, name, flags);
+}
+
 #endif


### PR DESCRIPTION
Bump `dd-trace-cpp` to `83958bc`.

Build using the build image with the fix: https://app.circleci.com/pipelines/github/DataDog/nginx-datadog/1795/workflows/12147d2a-5d02-437c-b98a-2327df71398c