### PR TITLE
feat(ingress-nginx): add support for `v1.11.6` and `v1.12.2`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -412,7 +412,7 @@ workflows:
                             - amd64
                             - arm64
                         version:
-                            - 1.12.1
+                            - 1.12.2
                 name: build ingress-nginx-<< matrix.version >> on << matrix.arch >>
             - coverage:
                 name: Coverage on 1.27.0 with WAF ON
@@ -507,7 +507,7 @@ workflows:
                         base-image:
                             - registry.k8s.io/ingress-nginx/controller
                         nginx-version:
-                            - 1.12.1
+                            - 1.12.2
                 name: test ingress-nginx-<< matrix.nginx-version >> on << matrix.arch >>
                 requires:
                     - build ingress-nginx-<< matrix.nginx-version >> on << matrix.arch >>
@@ -533,8 +533,10 @@ workflows:
                             - amd64
                             - arm64
                         version:
+                            - 1.12.2
                             - 1.12.1
                             - 1.12.0
+                            - 1.11.6
                             - 1.11.5
                             - 1.11.4
                             - 1.11.3
@@ -560,8 +562,10 @@ workflows:
                         base-image:
                             - registry.k8s.io/ingress-nginx/controller
                         nginx-version:
+                            - 1.12.2
                             - 1.12.1
                             - 1.12.0
+                            - 1.11.6
                             - 1.11.5
                             - 1.11.4
                             - 1.11.3

--- a/.circleci/src/workflows/build-and-test-all.yml
+++ b/.circleci/src/workflows/build-and-test-all.yml
@@ -14,8 +14,10 @@
             - 'amd64'
             - 'arm64'
             version:
+            - 1.12.2
             - 1.12.1
             - 1.12.0
+            - 1.11.6
             - 1.11.5
             - 1.11.4
             - 1.11.3
@@ -43,8 +45,10 @@
             base-image:
             - registry.k8s.io/ingress-nginx/controller
             nginx-version:
+            - 1.12.2
             - 1.12.1
             - 1.12.0
+            - 1.11.6
             - 1.11.5
             - 1.11.4
             - 1.11.3

--- a/.circleci/src/workflows/build-and-test.yml
+++ b/.circleci/src/workflows/build-and-test.yml
@@ -48,7 +48,7 @@ jobs:
         - 'amd64'
         - 'arm64'
         version:
-        - 1.12.1
+        - 1.12.2
 - coverage:
     name: Coverage on 1.27.0 with WAF ON
 - test:
@@ -151,7 +151,7 @@ jobs:
         base-image:
         - registry.k8s.io/ingress-nginx/controller
         nginx-version:
-        - 1.12.1
+        - 1.12.2
 - system_tests:
     name: Run system tests
     requires:

--- a/bin/ingress_nginx.py
+++ b/bin/ingress_nginx.py
@@ -33,8 +33,10 @@ PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 def get_underlying_nginx_version(controller_version: str) -> str:
     # Map an ingress-nginx version to an NGINX version
     mapping = {
+        "v1.12.2": "1.25.5",
         "v1.12.1": "1.25.5",
         "v1.12.0": "1.25.5",
+        "v1.11.6": "1.25.5",
         "v1.11.5": "1.25.5",
         "v1.11.4": "1.25.5",
         "v1.11.3": "1.25.5",
@@ -75,8 +77,10 @@ def clone_nginx(version: str, out_dir: str) -> str:
 
 def get_patch_directory(version: str, ingress_rootdir: str) -> str:
     mapping = {
+        "v1.12.2": f"{ingress_rootdir}/images/nginx/rootfs/patches",
         "v1.12.1": f"{ingress_rootdir}/images/nginx/rootfs/patches",
         "v1.12.0": f"{ingress_rootdir}/images/nginx/rootfs/patches",
+        "v1.11.6": f"{ingress_rootdir}/images/nginx/rootfs/patches",
         "v1.11.5": f"{ingress_rootdir}/images/nginx/rootfs/patches",
         "v1.11.4": f"{ingress_rootdir}/images/nginx/rootfs/patches",
         "v1.11.3": f"{ingress_rootdir}/images/nginx/rootfs/patches",


### PR DESCRIPTION
waiting until `v1.11.6` and `v1.12.2` docker images are available.