### PR TITLE
fix: bypass context propagation if headers are not initialized

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,6 +138,7 @@ target_sources(ngx_http_datadog_objs
   PRIVATE
     src/common/variable.cpp
     src/common/directives.cpp
+    src/common/headers.cpp
     src/array_util.cpp
     src/datadog_conf.cpp
     src/datadog_conf_handler.cpp

--- a/src/common/headers.cpp
+++ b/src/common/headers.cpp
@@ -1,0 +1,68 @@
+#include "headers.h"
+
+#include "string_util.h"
+
+namespace datadog::common {
+
+ngx_table_elt_t *search_header(ngx_list_t &headers, std::string_view key) {
+  ngx_list_part_t *part = &headers.part;
+  auto *h = static_cast<ngx_table_elt_t *>(part->elts);
+
+  for (std::size_t i = 0;; i++) {
+    if (i >= part->nelts) {
+      if (part->next == nullptr) {
+        break;
+      }
+
+      part = part->next;
+      h = static_cast<ngx_table_elt_t *>(part->elts);
+      i = 0;
+    }
+
+    if (key.size() != h[i].key.len ||
+        ngx_strncasecmp((u_char *)key.data(), h[i].key.data, key.size()) != 0) {
+      continue;
+    }
+
+    return &h[i];
+  }
+
+  return nullptr;
+}
+
+bool add_header(ngx_pool_t &pool, ngx_list_t &headers, std::string_view key,
+                std::string_view value) {
+  if (headers.last == nullptr) {
+    // Certainly a bad request (4xx). No need to add HTTP headers.
+    return false;
+  }
+
+  ngx_table_elt_t *h = static_cast<ngx_table_elt_t *>(ngx_list_push(&headers));
+  if (h == nullptr) {
+    return false;
+  }
+
+  const auto key_size = key.size();
+
+  // This trick tells ngx_http_header_module to reflect the header value
+  // in the actual response. Otherwise the header will be ignored and client
+  // will never see it. To date the value must be just non zero.
+  // Source:
+  // <https://web.archive.org/web/20240409072840/https://www.nginx.com/resources/wiki/start/topics/examples/headers_management/>
+  h->hash = 1;
+
+  // HTTP proxy module expects the header to has a lowercased key value
+  // Instead of allocating twice the same key, `h->key` and `h->lowcase_key`
+  // use the same data.
+  h->key.len = key_size;
+  h->key.data = (u_char *)ngx_pnalloc(&pool, sizeof(char) * key_size);
+  for (std::size_t i = 0; i < key_size; ++i) {
+    h->key.data[i] = nginx::to_lower(key[i]);
+  }
+  h->lowcase_key = h->key.data;
+
+  h->value = nginx::to_ngx_str(&pool, value);
+  return true;
+}
+
+}  // namespace datadog::common

--- a/src/common/headers.h
+++ b/src/common/headers.h
@@ -1,0 +1,53 @@
+#pragma once
+
+extern "C" {
+#include <ngx_core.h>
+#include <ngx_hash.h>
+}
+
+#include <string_view>
+
+namespace datadog::common {
+
+/// Searches through an NGINX header list to find a header with a matching key.
+///
+/// @param headers
+///     A reference to an NGINX-style list (`ngx_list_t`) containing
+///     `ngx_table_elt_t` elements, typically representing HTTP headers.
+///
+/// @param key
+///     A string view representing the name of the header to search for.
+///     The comparison is typically case-insensitive.
+///
+/// @return
+///     A pointer to the matching `ngx_table_elt_t` header element if found,
+///     or `nullptr` if no header with the given key exists in the list.
+////
+ngx_table_elt_t *search_header(ngx_list_t &headers, std::string_view key);
+
+/// Adds a new HTTP header to an NGINX-style header list.
+///
+/// @param pool
+///     A reference to the NGINX memory pool (`ngx_pool_t`) used for allocating
+///     memory for the new header and its key/value strings. This pool must
+///     remain valid for the lifetime of the header.
+///
+/// @param headers
+///     A reference to an `ngx_list_t` representing the list of HTTP headers
+///     (`ngx_table_elt_t` elements) to which the new header will be appended.
+///
+/// @param key
+///     A string view representing the header name (e.g., "Content-Type").
+///     This will be copied into the NGINX pool memory before insertion.
+///
+/// @param value
+///     A string view representing the header value (e.g., "application/json").
+///     This will also be copied into the NGINX pool memory.
+///
+/// @return
+///     `true` if the header was successfully added to the list;
+///     `false` if memory allocation failed or the list could not be updated.
+bool add_header(ngx_pool_t &pool, ngx_list_t &headers, std::string_view key,
+                std::string_view value);
+
+}  // namespace datadog::common

--- a/src/ngx_header_writer.h
+++ b/src/ngx_header_writer.h
@@ -2,6 +2,7 @@
 
 #include <datadog/dict_writer.h>
 
+#include "common/headers.h"
 #include "string_util.h"
 
 extern "C" {
@@ -23,65 +24,13 @@ class NgxHeaderWriter : public datadog::tracing::DictWriter {
       : request_(request), pool_(request_->pool) {}
 
   void set(std::string_view key, std::string_view value) override {
-    const auto key_size = key.size();
-
-    ngx_table_elt_t *h = search_header(key);
+    ngx_table_elt_t *h =
+        common::search_header(request_->headers_in.headers, key);
     if (h != nullptr) {
       h->value = to_ngx_str(pool_, value);
     } else {
-      h = static_cast<ngx_table_elt_t *>(
-          ngx_list_push(&request_->headers_in.headers));
-      if (h == nullptr) {
-        return;
-      }
-
-      // This trick tells ngx_http_header_module to reflect the header value
-      // in the actual response. Otherwise the header will be ignored and client
-      // will never see it. To date the value must be just non zero.
-      // Source:
-      // <https://web.archive.org/web/20240409072840/https://www.nginx.com/resources/wiki/start/topics/examples/headers_management/>
-      h->hash = 1;
-
-      // HTTP proxy module expects the header to has a lowercased key value
-      // Instead of allocating twice the same key, `h->key` and `h->lowcase_key`
-      // use the same data.
-      h->key.len = key_size;
-      h->key.data = (u_char *)ngx_pnalloc(pool_, sizeof(char) * key_size);
-      for (std::size_t i = 0; i < key_size; ++i) {
-        h->key.data[i] = to_lower(key[i]);
-      }
-      h->lowcase_key = h->key.data;
-
-      h->value = to_ngx_str(pool_, value);
+      common::add_header(*pool_, request_->headers_in.headers, key, value);
     }
-  }
-
- private:
-  ngx_table_elt_t *search_header(std::string_view key) {
-    ngx_list_part_t *part = &request_->headers_in.headers.part;
-    auto *h = static_cast<ngx_table_elt_t *>(part->elts);
-
-    for (std::size_t i = 0;; i++) {
-      if (i >= part->nelts) {
-        if (part->next == nullptr) {
-          break;
-        }
-
-        part = part->next;
-        h = static_cast<ngx_table_elt_t *>(part->elts);
-        i = 0;
-      }
-
-      if (key.size() != h[i].key.len ||
-          ngx_strncasecmp((u_char *)key.data(), h[i].key.data, key.size()) !=
-              0) {
-        continue;
-      }
-
-      return &h[i];
-    }
-
-    return nullptr;
   }
 };
 

--- a/test/cases/auto_propagation/conf/http_auto.conf
+++ b/test/cases/auto_propagation/conf/http_auto.conf
@@ -13,6 +13,10 @@ http {
 
         proxy_set_header server-block-header not-hidden-by-autoinjection;
 
+        location / {
+            return 200 "Hello, World!";
+        }
+
         location /http {
             proxy_pass http://http:8080;
         }

--- a/test/cases/auto_propagation/test_http.py
+++ b/test/cases/auto_propagation/test_http.py
@@ -69,6 +69,19 @@ class TestHTTP(case.TestCase):
         return self.run_test("./conf/http_without_module.conf",
                              should_propagate=False)
 
+    def test_illformated_request(self):
+        # From: <https://github.com/DataDog/nginx-datadog/issues/212>
+        conf_path = Path(__file__).parent / "./conf/http_auto.conf"
+        conf_text = conf_path.read_text()
+        status, log_lines = self.orch.nginx_replace_config(
+            conf_text, conf_path.name)
+        self.assertEqual(status, 0, log_lines)
+
+        status, response = self.orch.send_nginx_raw_http_request(
+            request_line="GET /\r\n")
+        self.assertEqual(0, status)
+        self.assertEqual("Hello, World!", response)
+
     def run_test(self, conf_relative_path, should_propagate):
         conf_path = Path(__file__).parent / conf_relative_path
         conf_text = conf_path.read_text()

--- a/test/cases/orchestration.py
+++ b/test/cases/orchestration.py
@@ -600,6 +600,30 @@ class Orchestration:
         )
         return result.returncode, result.stdout
 
+    def send_nginx_raw_http_request(self, port=80, request_line=""):
+        """Send the request line to nginx, and return the resulting HTTP
+        status code and response body as a tuple `(status, body)`.
+        """
+        command = docker_compose_command(
+            "exec",
+            "-T",
+            "--",
+            "client",
+            "nc",
+            "nginx",
+            str(port),
+        )
+
+        result = subprocess.run(
+            command,
+            input=request_line,
+            stdout=subprocess.PIPE,
+            env=child_env(),
+            encoding="utf8",
+            check=True,
+        )
+        return result.returncode, result.stdout
+
     def send_nginx_http_request(
         self,
         path,


### PR DESCRIPTION
When processing HTTP/0.9 requests, the HTTP headers data structure is not initialized because this version of HTTP does not support headers. This leads to a crash when the code attempts to add context propagation information to an uninitialized list of headers.

We have implemented a check to bypass context propagation if the headers are not initialized.

Resolves #212

Changes:
  - move headers logic into `common` folder.
  - add integration test with HTTP/0.9.