### PR TITLE
build(gcc): fix compilation errors with GCC13

### DIFF
--- a/src/common/directives.cpp
+++ b/src/common/directives.cpp
@@ -7,6 +7,7 @@
 
 namespace datadog::common {
 
+#ifdef WITH_WAF
 char *check_file_exists(ngx_conf_t *cf, void *post, void *data) {
   assert(data != nullptr);
   ngx_str_t *s = (ngx_str_t *)data;
@@ -16,5 +17,6 @@ char *check_file_exists(ngx_conf_t *cf, void *post, void *data) {
   }
   return NGX_CONF_OK;
 }
+#endif
 
 }  // namespace datadog::common

--- a/src/common/directives.h
+++ b/src/common/directives.h
@@ -13,7 +13,9 @@ namespace datadog::common {
 /// directive actually exists on the filesystem.
 char *check_file_exists(ngx_conf_t *cf, void *post, void *data);
 
+#ifdef WITH_WAF
 /// Post handler for checking a filepath exists.
 static ngx_conf_post_t ngx_conf_post_file_exists = {check_file_exists};
+#endif
 
 }  // namespace datadog::common

--- a/src/datadog_directive.h
+++ b/src/datadog_directive.h
@@ -7,6 +7,7 @@ extern "C" {
 #include <ngx_http.h>
 }
 
+#include <array>
 #include <string_view>
 
 #include "string_util.h"

--- a/src/ngx_http_datadog_module.cpp
+++ b/src/ngx_http_datadog_module.cpp
@@ -316,7 +316,7 @@ static ngx_int_t datadog_module_init(ngx_conf_t *cf) noexcept {
   // Add default span tags.
   const auto tags = TracingLibrary::default_tags();
   if (!tags.empty()) {
-    for (const auto [key, value] : tags) {
+    for (const auto &[key, value] : tags) {
       auto ngx_value = to_ngx_str(cf->pool, value);
       auto *complex_value = datadog::common::make_complex_value(cf, ngx_value);
       if (complex_value == nullptr) {


### PR DESCRIPTION
GCC 13 by default enforces stricter check compared to our current Clang configuration. This commit resolves the compilation errors identified by GCC 13, ensuring compatibility until we align our Clang build options.

Changes:
  - fix transitive dependencies
  - add condition on `ngx_conf_post_file_exists`

Resolves #217 