### PR TITLE
fix(tests): bump nginx version for amazon linux

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -475,7 +475,7 @@ workflows:
                         base-image:
                             - amazonlinux:2.0.20230418.0
                         nginx-version:
-                            - 1.26.3
+                            - 1.28.0
                         waf:
                             - "ON"
                             - "OFF"

--- a/.circleci/src/workflows/build-and-test.yml
+++ b/.circleci/src/workflows/build-and-test.yml
@@ -117,7 +117,7 @@ jobs:
         base-image:
         - amazonlinux:2.0.20230418.0
         nginx-version:
-        - 1.26.3
+        - 1.28.0
     name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch
       >> WAF << matrix.waf >>
     requires:

--- a/test/cases/orchestration.py
+++ b/test/cases/orchestration.py
@@ -866,7 +866,7 @@ exit "$rcode"
 
                 return check
 
-            wait_until(old_worker_stops(old_worker_pids), timeout_seconds=10.5)
+            wait_until(old_worker_stops(old_worker_pids), timeout_seconds=10)
 
             def new_worker_starts():
                 pids = nginx_worker_pids(nginx_container, self.verbose)

--- a/test/cases/orchestration.py
+++ b/test/cases/orchestration.py
@@ -866,7 +866,7 @@ exit "$rcode"
 
                 return check
 
-            wait_until(old_worker_stops(old_worker_pids), timeout_seconds=10)
+            wait_until(old_worker_stops(old_worker_pids), timeout_seconds=10.5)
 
             def new_worker_starts():
                 pids = nginx_worker_pids(nginx_container, self.verbose)


### PR DESCRIPTION
 amazonlinux:2.0.20230418 tests are failing on master because the amazon linux nginx version was bumped to 1.28.0.
 
 This PR bumps the nginx version of the test to 1.28.0.