### PR TITLE
chore(benchmarks): run macrobenchmark on last changes

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -23,7 +23,7 @@ build-nginx-module:
     COVERAGE: OFF
     RUM: OFF
     BUILD_TYPE: Release
-    ARCH: amd64
+    ARCH: x86_64
   script:
     - git submodule sync && git submodule update --init --recursive
     - export NGINX_SRC_DIR="$PWD/nginx"

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -1,4 +1,5 @@
 stages:
+  - build
   - run-benchmarks
   - gate
   - notify
@@ -9,9 +10,35 @@ include:
 
 variables:
   MACROBENCHMARKS_CI_IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/benchmarking-platform:cpp-nginx
+  BUILD_IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/images/mirror/b1o7r7e0/nginx_musl_toolchain
+  NGINX_VERSION: 1.26.0
+
+build-nginx-module:
+  stage: build
+  tags: ["arch:amd64"]
+  timeout: 20min
+  image: $BUILD_IMAGE
+  variables:
+    WAF: OFF
+    COVERAGE: OFF
+    RUM: OFF
+    BUILD_TYPE: Release
+    ARCH: amd64
+  script:
+    - git submodule sync && git submodule update --init --recursive
+    - export NGINX_SRC_DIR="$PWD/nginx"
+    - make build-musl-aux
+  artifacts:
+    name: "artifacts"
+    when: always
+    paths:
+      - platform/artifacts/
+    expire_in: 3 months
+
 
 .benchmarks:
   stage: run-benchmarks
+  needs: ["build-nginx-module"]
   tags: ["runner:apm-k8s-same-cpu"]
   timeout: 1h
   image: $MACROBENCHMARKS_CI_IMAGE
@@ -29,7 +56,7 @@ variables:
     DD_TRACE_DEBUG: "false"
     DD_RUNTIME_METRICS_ENABLED: "true"
 
-    DD_BENCHMARKS_NGINX_IMAGE_TAG: amd64-1.26.0
+    DD_BENCHMARKS_NGINX_IMAGE_TAG: amd64-${NGINX_VERSION}
 
     K6_OPTIONS_NORMAL_OPERATION_RATE: 1000
     K6_OPTIONS_NORMAL_OPERATION_DURATION: 5m

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -32,7 +32,7 @@ build-nginx-module:
     name: "artifacts"
     when: always
     paths:
-      - platform/artifacts/
+      - .musl-build/
     expire_in: 3 months
 
 

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -32,7 +32,7 @@ build-nginx-module:
     name: "artifacts"
     when: always
     paths:
-      - .musl-build/nginx_http_datadog_module.so
+      - .musl-build/ngx_http_datadog_module.so
     expire_in: 3 months
 
 
@@ -43,7 +43,7 @@ build-nginx-module:
   timeout: 1h
   image: $MACROBENCHMARKS_CI_IMAGE
   script:
-    - cp .musl-build/nginx_http_datadog_module /usr/lib/nginx/modules/nginx_http_datadog_module.so
+    - cp .musl-build/ngx_http_datadog_module.so /usr/lib/nginx/modules/ngx_http_datadog_module.so
     - git clone --branch cpp/nginx https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform platform && cd platform
     - bp-runner bp-runner.yml --debug
   artifacts:

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -32,7 +32,7 @@ build-nginx-module:
     name: "artifacts"
     when: always
     paths:
-      - .musl-build/
+      - .musl-build/nginx_http_datadog_module.so
     expire_in: 3 months
 
 
@@ -43,6 +43,7 @@ build-nginx-module:
   timeout: 1h
   image: $MACROBENCHMARKS_CI_IMAGE
   script:
+    - cp .musl-build/nginx_http_datadog_module /usr/lib/nginx/modules/nginx_http_datadog_module.so
     - git clone --branch cpp/nginx https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform platform && cd platform
     - bp-runner bp-runner.yml --debug
   artifacts:


### PR DESCRIPTION
Before this PR, the macrobenchmarks were run only on the latest release which is highly reducing their utility.

This PR runs the macrobenchmarks on the latest changes. 

**Important**: macrobenchmarks will fail until this PR is merged because changes were made also in the benchmarking-platform repo.