### PR TITLE
waf: implement response body collection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,6 +173,7 @@ if(NGINX_DATADOG_ASM_ENABLED)
     src/security/directives.cpp
     src/security/context.cpp
     src/security/ddwaf_obj.cpp
+    src/security/ddwaf_req.cpp
     src/security/decode.cpp
     src/security/header_tags.cpp
     src/security/library.cpp

--- a/src/datadog_conf.h
+++ b/src/datadog_conf.h
@@ -141,6 +141,13 @@ struct datadog_main_conf_t {
   // before we stall the output filter chain with busy buffers
   std::size_t appsec_max_saved_output_data{NGX_CONF_UNSET_SIZE};
 
+  // (only nginx configuration: datadog_appsec_test_task_post_failure_mask)
+  // For testing: bitmap to simulate ngx_thread_task_post failures
+  // Bit 0: initial WAF task (Pol1stWafCtx)
+  // Bit 1: request body WAF task (PolReqBodyWafCtx)
+  // Bit 2: final WAF task (PolFinalWafCtx)
+  ngx_int_t appsec_test_task_post_failure_mask{NGX_CONF_UNSET};
+
   // TODO: missing settings and their functionality
   // DD_TRACE_CLIENT_IP_RESOLVER_ENABLED (whether to collect headers and run the
   // client ip resolution. Also requires AppSec to be enabled or

--- a/src/ngx_http_datadog_module.cpp
+++ b/src/ngx_http_datadog_module.cpp
@@ -90,7 +90,7 @@ static auto datadog_commands =
     generate_directives(tracing_directives, module_directives
 #ifdef WITH_WAF
                         ,
-                        datadog::nginx::security::appsec_directives
+                        datadog::nginx::security::kAppsecDirectives
 #endif
 
 #ifdef WITH_RUM

--- a/src/security/body_parse/body_json.h
+++ b/src/security/body_parse/body_json.h
@@ -9,7 +9,7 @@ extern "C" {
 
 namespace datadog::nginx::security {
 
-bool parse_json(ddwaf_obj &slot, ngx_http_request_t &req,
-                const ngx_chain_t &chain, DdwafMemres &memres);
+bool parse_json(ddwaf_obj &slot, const ngx_http_request_t &req,
+                const ngx_chain_t &chain, size_t limit, DdwafMemres &memres);
 
 }  // namespace datadog::nginx::security

--- a/src/security/body_parse/body_multipart.cpp
+++ b/src/security/body_parse/body_multipart.cpp
@@ -144,7 +144,7 @@ void remove_final_crlf(std::string &content) {
 
 namespace datadog::nginx::security {
 
-bool parse_multipart(ddwaf_obj &slot, ngx_http_request_t &req,
+bool parse_multipart(ddwaf_obj &slot, const ngx_http_request_t &req,
                      HttpContentType &ct, const ngx_chain_t &chain,
                      DdwafMemres &memres) {
   if (ct.boundary.size() == 0) {

--- a/src/security/body_parse/body_multipart.h
+++ b/src/security/body_parse/body_multipart.h
@@ -10,7 +10,7 @@ extern "C" {
 
 namespace datadog::nginx::security {
 
-bool parse_multipart(ddwaf_obj &slot, ngx_http_request_t &req,
+bool parse_multipart(ddwaf_obj &slot, const ngx_http_request_t &req,
                      HttpContentType &ct, const ngx_chain_t &chain,
                      DdwafMemres &memres);
 

--- a/src/security/body_parse/body_parsing.cpp
+++ b/src/security/body_parse/body_parsing.cpp
@@ -195,7 +195,7 @@ bool is_body_resp_parseable(const ngx_http_request_t &req) {
 }
 
 // chain may be longer than size, so size can act as a limit too
-// the limit can't be smaller than the size of the chain though
+// size (size/limit) <= chain size
 bool parse_body_resp(ddwaf_obj &slot, const ngx_http_request_t &req,
                      const ngx_chain_t &chain, std::size_t size,
                      DdwafMemres &memres) {

--- a/src/security/body_parse/body_parsing.cpp
+++ b/src/security/body_parse/body_parsing.cpp
@@ -1,6 +1,7 @@
 #include "body_parsing.h"
 
 #include <ddwaf.h>
+#include <ngx_string.h>
 
 #include <cstddef>
 #include <unordered_map>
@@ -25,7 +26,7 @@ namespace {
 
 bool is_content_type(std::string_view actual, std::string_view tested) {
   auto sv = actual;
-  while (sv.front() == ' ' || sv.front() == '\t') {
+  while (!sv.empty() && (sv.front() == ' ' || sv.front() == '\t')) {
     sv.remove_prefix(1);
   }
 
@@ -44,44 +45,125 @@ bool is_content_type(std::string_view actual, std::string_view tested) {
          sv.front() == '\t';
 }
 
-bool is_json(const ngx_http_request_t &req) {
+bool is_req_json(const ngx_http_request_t &req) {
   const ngx_table_elt_t *ct = req.headers_in.content_type;
   // don't look at ct->next; consider only the first value
   return ct && is_content_type(datadog::nginx::to_string_view(ct->value),
                                "application/json"sv);
 }
 
-bool is_multipart(const ngx_http_request_t &req) {
+bool is_resp_json(const ngx_http_request_t &req) {
+  const ngx_str_t ct = req.headers_out.content_type;
+  return is_content_type(datadog::nginx::to_string_view(ct),
+                         "application/json"sv);
+}
+
+bool is_req_multipart(const ngx_http_request_t &req) {
   const ngx_table_elt_t *ct = req.headers_in.content_type;
   return ct && is_content_type(datadog::nginx::to_string_view(ct->value),
                                "multipart/form-data"sv);
 }
 
-bool is_urlencoded(const ngx_http_request_t &req) {
+bool is_req_urlencoded(const ngx_http_request_t &req) {
   const ngx_table_elt_t *ct = req.headers_in.content_type;
   return ct && is_content_type(datadog::nginx::to_string_view(ct->value),
                                "application/x-www-form-urlencoded"sv);
 }
-bool is_text_plain(const ngx_http_request_t &req) {
+bool is_req_text_plain(const ngx_http_request_t &req) {
   const ngx_table_elt_t *ct = req.headers_in.content_type;
   return ct && is_content_type(datadog::nginx::to_string_view(ct->value),
                                "text/plain"sv);
+}
+
+bool is_resp_text_plain(const ngx_http_request_t &req) {
+  const ngx_str_t ct = req.headers_out.content_type;
+  return is_content_type(datadog::nginx::to_string_view(ct), "text/plain"sv);
+}
+
+char *linearize_chain(const ngx_chain_t &chain, std::size_t size,
+                      dnsec::DdwafMemres &memres) {
+  char *buf = memres.allocate_string(size);
+  dnsec::NgxChainInputStream stream{&chain};
+  auto read = stream.read(reinterpret_cast<std::uint8_t *>(buf), size);
+  if (read < size) {
+    throw std::runtime_error(
+        "mismatch between declared size and read size (read is smaller than "
+        "declared)");
+  }
+  return buf;
+}
+
+bool parse_plain(dnsec::ddwaf_obj &slot, const ngx_chain_t &chain,
+                 std::size_t size, dnsec::DdwafMemres &memres) {
+  char *buf = linearize_chain(chain, size, memres);
+
+  slot.make_string(std::string_view{buf, size});
+  return true;
+}
+
+bool parse_urlencoded(dnsec::ddwaf_obj &slot, const ngx_chain_t &chain,
+                      std::size_t size, dnsec::DdwafMemres &memres) {
+  char *buf = linearize_chain(chain, size, memres);
+
+  dnsec::QueryStringIter it{
+      {buf, size}, memres, '&', dnsec::QueryStringIter::trim_mode::no_trim};
+
+  // count key occurrences
+  union count_or_ddobj {
+    std::size_t count;
+    dnsec::ddwaf_obj *dobj;
+  };
+  std::unordered_map<std::string_view, count_or_ddobj> key_index;
+  for (; !it.ended(); ++it) {
+    std::string_view cur_key = it.cur_key();
+    key_index[cur_key].count++;
+  }
+
+  // allocate all ddwaf_obj, set keys
+  dnsec::ddwaf_map_obj slot_map = slot.make_map(key_index.size(), memres);
+  std::size_t i = 0;
+  for (auto &&[key, count_or_arr] : key_index) {
+    dnsec::ddwaf_obj &cur = slot_map.at_unchecked(i++);
+    cur.set_key(key);
+    if (count_or_arr.count == 1) {
+      cur.make_string(""sv);  // to be filled later
+    } else {
+      cur.make_array(count_or_arr.count, memres);
+      cur.nbEntries = 0;  // fixed later
+    }
+    count_or_arr.dobj = &cur;
+  }
+
+  // set values
+  it.reset();
+  for (it.reset(); !it.ended(); ++it) {
+    auto [cur_key, cur_value] = *it;
+    dnsec::ddwaf_obj &cur = *key_index.at(cur_key).dobj;
+    if (cur.is_string()) {
+      cur.make_string(cur_value);
+    } else {
+      dnsec::ddwaf_arr_obj &cur_arr = static_cast<dnsec::ddwaf_arr_obj &>(cur);
+      cur_arr.at_unchecked(cur_arr.nbEntries++).make_string(cur_value);
+    }
+  }
+
+  return true;
 }
 
 }  // namespace
 
 namespace datadog::nginx::security {
 
-bool parse_body(ddwaf_obj &slot, ngx_http_request_t &req,
-                const ngx_chain_t &chain, std::size_t size,
-                DdwafMemres &memres) {
-  if (is_json(req)) {
+bool parse_body_req(ddwaf_obj &slot, const ngx_http_request_t &req,
+                    const ngx_chain_t &chain, std::size_t size,
+                    DdwafMemres &memres) {
+  if (is_req_json(req)) {
     // use rapidjson to parse:
-    bool success = parse_json(slot, req, chain, memres);
+    bool success = parse_json(slot, req, chain, size, memres);
     if (success) {
       return true;
     }
-  } else if (is_multipart(req)) {
+  } else if (is_req_multipart(req)) {
     std::optional<HttpContentType> ct = HttpContentType::for_string(
         to_string_view(req.headers_in.content_type->value));
     if (!ct) {
@@ -93,75 +175,39 @@ bool parse_body(ddwaf_obj &slot, ngx_http_request_t &req,
     return parse_multipart(slot, req, *ct, chain, memres);
   }
 
-  bool ct_plain = is_text_plain(req);
-  bool ct_urlencoded = !ct_plain && is_urlencoded(req);
-
-  if (!ct_plain && !ct_urlencoded) {
-    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, req.connection->log, 0,
-                   "unsupported content-type: %V",
-                   &req.headers_in.content_type->value);
-    return false;
+  if (is_req_text_plain(req)) {
+    return parse_plain(slot, chain, size, memres);
   }
 
-  // linearize the input
-  char *buf = memres.allocate_string(size);
-  NgxChainInputStream stream{&chain};
-  auto read = stream.read(reinterpret_cast<std::uint8_t *>(buf), size);
-  if (read < size) {
-    throw std::runtime_error(
-        "mismatch between declared size and read size (read is smaller than "
-        "declared)");
+  if (is_req_urlencoded(req)) {
+    return parse_urlencoded(slot, chain, size, memres);
   }
 
-  if (ct_urlencoded) {
-    QueryStringIter it{
-        {buf, size}, memres, '&', QueryStringIter::trim_mode::no_trim};
+  ngx_log_debug1(NGX_LOG_DEBUG_HTTP, req.connection->log, 0,
+                 "unsupported content-type: %V",
+                 &req.headers_in.content_type->value);
+  return false;
+}
 
-    // count key occurrences
-    union count_or_ddobj {
-      std::size_t count;
-      ddwaf_obj *dobj;
-    };
-    std::unordered_map<std::string_view, count_or_ddobj> key_index;
-    for (; !it.ended(); ++it) {
-      std::string_view cur_key = it.cur_key();
-      key_index[cur_key].count++;
-    }
+bool is_body_resp_parseable(const ngx_http_request_t &req) {
+  return !req.header_only && req.headers_out.content_length_n != 0 &&
+         (is_resp_json(req) || is_resp_text_plain(req));
+}
 
-    // allocate all ddwaf_obj, set keys
-    ddwaf_map_obj slot_map = slot.make_map(key_index.size(), memres);
-    std::size_t i = 0;
-    for (auto &&[key, count_or_arr] : key_index) {
-      ddwaf_obj &cur = slot_map.at_unchecked(i++);
-      cur.set_key(key);
-      if (count_or_arr.count == 1) {
-        cur.make_string(""sv);  // to be filled later
-      } else {
-        cur.make_array(count_or_arr.count, memres);
-        cur.nbEntries = 0;  // fixed later
-      }
-      count_or_arr.dobj = &cur;
-    }
-
-    // set values
-    it.reset();
-    for (it.reset(); !it.ended(); ++it) {
-      auto [cur_key, cur_value] = *it;
-      ddwaf_obj &cur = *key_index.at(cur_key).dobj;
-      if (cur.is_string()) {
-        cur.make_string(cur_value);
-      } else {
-        ddwaf_arr_obj &cur_arr = static_cast<ddwaf_arr_obj &>(cur);
-        cur_arr.at_unchecked(cur_arr.nbEntries++).make_string(cur_value);
-      }
-    }
-
-    return true;
+// chain may be longer than size, so size can act as a limit too
+// the limit can't be smaller than the size of the chain though
+bool parse_body_resp(ddwaf_obj &slot, const ngx_http_request_t &req,
+                     const ngx_chain_t &chain, std::size_t size,
+                     DdwafMemres &memres) {
+  if (is_resp_json(req)) {
+    return parse_json(slot, req, chain, size, memres);
   }
 
-  slot.make_string(std::string_view{buf, size});
+  if (is_resp_text_plain(req)) {
+    return parse_plain(slot, chain, size, memres);
+  }
 
-  return true;
+  return false;
 }
 
 }  // namespace datadog::nginx::security

--- a/src/security/body_parse/body_parsing.h
+++ b/src/security/body_parse/body_parsing.h
@@ -8,8 +8,14 @@ extern "C" {
 
 namespace datadog::nginx::security {
 
-bool parse_body(ddwaf_obj &slot, ngx_http_request_t &req,
-                const ngx_chain_t &chain, std::size_t size,
-                DdwafMemres &memres);
+bool parse_body_req(ddwaf_obj &slot, const ngx_http_request_t &req,
+                    const ngx_chain_t &chain, std::size_t size,
+                    DdwafMemres &memres);
+
+bool is_body_resp_parseable(const ngx_http_request_t &req);
+
+bool parse_body_resp(ddwaf_obj &slot, const ngx_http_request_t &req,
+                     const ngx_chain_t &chain, std::size_t size,
+                     DdwafMemres &memres);
 
 }  // namespace datadog::nginx::security

--- a/src/security/collection.h
+++ b/src/security/collection.h
@@ -16,5 +16,6 @@ ddwaf_object *collect_request_data(const ngx_http_request_t &request,
                                    const std::optional<std::string> &client_ip,
                                    DdwafMemres &memres);
 ddwaf_object *collect_response_data(const ngx_http_request_t &request,
-                                    DdwafMemres &memres);
+                                    ngx_chain_t *body_chain,
+                                    std::size_t body_size, DdwafMemres &memres);
 }  // namespace datadog::nginx::security

--- a/src/security/context.cpp
+++ b/src/security/context.cpp
@@ -1,10 +1,9 @@
 #include "context.h"
 
 #include <atomic>
-#include <charconv>
+#include <climits>
 #include <optional>
 #include <stdexcept>
-#include <string>
 #include <type_traits>
 #include <utility>
 
@@ -52,125 +51,6 @@ namespace {
 
 namespace dnsec = datadog::nginx::security;
 
-std::size_t chain_length(ngx_chain_t const *ch) {
-  std::size_t len = 0;
-  for (ngx_chain_t const *cl = ch; cl; cl = cl->next) {
-    len++;
-  }
-  return len;
-}
-std::size_t chain_size(ngx_chain_t const *ch) {
-  std::size_t size = 0;
-  for (ngx_chain_t const *cl = ch; cl; cl = cl->next) {
-    size += ngx_buf_size(cl->buf);
-  }
-  return size;
-}
-std::size_t has_special(ngx_chain_t const *ch) {
-  for (ngx_chain_t const *cl = ch; cl; cl = cl->next) {
-    return ngx_buf_special(cl->buf);
-  }
-  return false;
-}
-std::size_t has_last(ngx_chain_t const *ch) {
-  for (ngx_chain_t const *cl = ch; cl; cl = cl->next) {
-    if (cl->buf->last) {
-      return true;
-    }
-  }
-  return false;
-}
-
-class JsonWriter : public rapidjson::Writer<rapidjson::StringBuffer> {
-  using rapidjson::Writer<rapidjson::StringBuffer>::Writer;
-
- public:
-  // NOLINTNEXTLINE(readability-identifier-naming)
-  bool ConstLiteralKey(std::string_view sv) {
-    return String(sv.data(), sv.length(), false);
-  }
-};
-
-void ddwaf_object_to_json(JsonWriter &w, const ddwaf_object &dobj);
-
-void report_match(const ngx_http_request_t &req, dd::TraceSegment &seg,
-                  dd::Span &span,
-                  std::vector<dnsec::OwnedDdwafResult> &results) {
-  if (results.empty()) {
-    return;
-  }
-
-  seg.override_sampling_priority(2);  // USER-KEEP
-  span.set_tag("appsec.event"sv, "true");
-
-  rapidjson::StringBuffer buffer;
-  JsonWriter w(buffer);
-  w.StartObject();
-  w.ConstLiteralKey("triggers"sv);
-
-  w.StartArray();
-  for (auto &&result : results) {
-    auto events = dnsec::ddwaf_arr_obj{(*result).events};
-    for (auto &&evt : events) {
-      ddwaf_object_to_json(w, evt);
-    }
-  }
-  w.EndArray(results.size());
-
-  w.EndObject(1);
-  w.Flush();
-
-  std::string_view const json{buffer.GetString(), buffer.GetLength()};
-
-  ngx_str_t json_ns{dnsec::ngx_stringv(json)};
-  ngx_log_error(NGX_LOG_INFO, req.connection->log, 0, "appsec event: %V",
-                &json_ns);
-
-  span.set_tag("_dd.appsec.json"sv, json);
-}
-
-// NOLINTNEXTLINE(misc-no-recursion)
-void ddwaf_object_to_json(JsonWriter &w, const ddwaf_object &dobj) {
-  switch (dobj.type) {
-    case DDWAF_OBJ_MAP:
-      w.StartObject();
-      for (std::size_t i = 0; i < dobj.nbEntries; i++) {
-        auto &&e = dobj.array[i];
-        w.Key(e.parameterName, e.parameterNameLength, false);
-        ddwaf_object_to_json(w, e);
-      }
-      w.EndObject(dobj.nbEntries);
-      break;
-    case DDWAF_OBJ_ARRAY:
-      w.StartArray();
-      for (std::size_t i = 0; i < dobj.nbEntries; i++) {
-        auto &&e = dobj.array[i];
-        ddwaf_object_to_json(w, e);
-      }
-      w.EndArray(dobj.nbEntries);
-      break;
-    case DDWAF_OBJ_STRING:
-      w.String(dobj.stringValue, dobj.nbEntries, false);
-      break;
-    case DDWAF_OBJ_SIGNED:
-      w.Int64(dobj.intValue);
-      break;
-    case DDWAF_OBJ_UNSIGNED:
-      w.Uint64(dobj.uintValue);
-      break;
-    case DDWAF_OBJ_FLOAT:
-      w.Double(dobj.f64);
-      break;
-    case DDWAF_OBJ_BOOL:
-      w.Bool(dobj.boolean);
-      break;
-    case DDWAF_OBJ_INVALID:
-    case DDWAF_OBJ_NULL:
-      w.Null();
-      break;
-  }
-}
-
 template <
     typename Callable, typename Ret = decltype(std::declval<Callable>()()),
     typename DefType =  // can't have void arguments. Have a dummy parameter for
@@ -197,17 +77,19 @@ auto catch_exceptions(std::string_view name, const ngx_http_request_t &req,
 
 namespace datadog::nginx::security {
 
-Context::Context(std::shared_ptr<OwnedDdwafHandle> handle,
-                 bool apm_tracing_enabled)
+// Bit flags for testing ngx_thread_task_post failures
+constexpr ngx_int_t kTaskPostFailureMaskInitialWaf = 1;
+constexpr ngx_int_t kTaskPostFailureMaskReqBodyWaf = 2;
+constexpr ngx_int_t kTaskPostFailureMaskFinalWaf = 4;
+
+Context::Context(std::shared_ptr<OwnedDdwafHandle> handle)
     : stage_{new std::atomic<stage>{}},
-      waf_handle_{std::move(handle)},
       apm_tracing_enabled_{apm_tracing_enabled} {
-  if (!waf_handle_) {
+  if (!handle) {
     return;
   }
 
-  ddwaf_handle ddwaf_h = waf_handle_->get();
-  ctx_ = ddwaf_context_init(ddwaf_h);
+  waf_ctx_ = std::make_unique<DdwafContext>(handle);
 
   stage_->store(stage::START, std::memory_order_relaxed);
 }
@@ -257,12 +139,23 @@ class PolTaskCtx {
     return *task_ctx;
   }
 
-  bool submit(ngx_thread_pool_t *pool) noexcept {
+  bool submit(ngx_thread_pool_t *pool) &&noexcept {
     as_self().replace_handlers();
 
     req_.main->count++;
 
-    if (ngx_thread_task_post(pool, &get_task()) != NGX_OK) {
+    bool simulate_task_post_failure = false;
+    auto *main_conf = static_cast<datadog_main_conf_t *>(
+        ngx_http_get_module_main_conf(&req_, ngx_http_datadog_module));
+    if (main_conf &&
+        main_conf->appsec_test_task_post_failure_mask != NGX_CONF_UNSET &&
+        main_conf->appsec_test_task_post_failure_mask &
+            Self::get_task_failure_flag()) {
+      simulate_task_post_failure = true;
+    }
+
+    if (simulate_task_post_failure ||
+        ngx_thread_task_post(pool, &get_task()) != NGX_OK) {
       ngx_log_error(NGX_LOG_ERR, req_.connection->log, 0,
                     "failed to post task %p", &get_task());
 
@@ -409,6 +302,10 @@ class PolTaskCtx {
 class Pol1stWafCtx : public PolTaskCtx<Pol1stWafCtx> {
   using PolTaskCtx::PolTaskCtx;
 
+  static ngx_int_t get_task_failure_flag() noexcept {
+    return kTaskPostFailureMaskInitialWaf;
+  }
+
   std::optional<BlockSpecification> do_handle(ngx_log_t &tp_log) {
     return ctx_.run_waf_start(req_, span_);
   }
@@ -462,7 +359,7 @@ bool Context::on_request_start(ngx_http_request_t &request,
 }
 
 bool Context::do_on_request_start(ngx_http_request_t &request, dd::Span &span) {
-  if (ctx_.resource == nullptr) {
+  if (!waf_ctx_) {
     return false;
   }
 
@@ -494,184 +391,13 @@ bool Context::do_on_request_start(ngx_http_request_t &request, dd::Span &span) {
 
   auto &task_ctx = Pol1stWafCtx::create(request, *this, span);
 
-  if (task_ctx.submit(conf->waf_pool)) {
+  if (std::move(task_ctx).submit(conf->waf_pool)) {
     ngx_log_debug(NGX_LOG_DEBUG_HTTP, request.connection->log, 0,
                   "posted initial waf task");
     return true;
   }
   return false;
 }
-
-namespace {
-
-class Action {
- public:
-  enum class type : unsigned char {
-    BLOCK_REQUEST,
-    REDIRECT_REQUEST,
-    GENERATE_STACK,
-    GENERATE_SCHEMA,
-    UNKNOWN,
-  };
-
-  Action(ddwaf_map_obj action) : action_{action} {}
-
-  auto type() const {
-    auto key = action_.key();
-    if (key == "block_request"sv) {
-      return type::BLOCK_REQUEST;
-    } else if (key == "redirect_request"sv) {
-      return type::REDIRECT_REQUEST;
-    } else if (key == "generate_stack"sv) {
-      return type::GENERATE_STACK;
-    } else if (key == "generate_schema"sv) {
-      return type::GENERATE_SCHEMA;
-    } else {
-      return type::UNKNOWN;
-    }
-  }
-
-  auto raw_type() const { return action_.key(); }
-
-  int get_int_param(std::string_view k) const {
-    ddwaf_obj v = action_.get(k);
-
-    if (v.is_numeric()) {
-      return v.numeric_val<int>();
-    }
-
-    if (!v.is_string()) {
-      throw std::runtime_error{"expected numeric value for action parameter " +
-                               std::string{k}};
-    }
-
-    // try to convert to number
-    std::string_view const sv{v.string_val_unchecked()};
-    int n;
-    auto [ptr, ec] = std::from_chars(sv.data(), sv.data() + sv.size(), n);
-    if (ec == std::errc{} && ptr == sv.data() + sv.size()) {
-      return n;
-    }
-    throw std::runtime_error{"expected numeric value for action parameter " +
-                             std::string{k} + ", got " + std::string{sv}};
-  }
-
-  std::string_view get_string_param(std::string_view k) const {
-    ddwaf_obj v = action_.get(k);
-
-    if (v.is_string()) {
-      return v.string_val_unchecked();
-    }
-
-    throw std::runtime_error{"expected string value for action parameter " +
-                             std::string{k}};
-  }
-
- private:
-  ddwaf_map_obj action_;
-};
-
-class ActionsResult {
- public:
-  ActionsResult(ddwaf_map_obj actions) : actions_{actions} {}
-
-  class Iterator {
-   public:
-    using difference_type = ddwaf_obj::nb_entries_t;      // NOLINT
-    using value_type = Action;                            // NOLINT
-    using pointer = value_type *;                         // NOLINT
-    using reference = value_type &;                       // NOLINT
-    using iterator_category = std::forward_iterator_tag;  // NOLINT
-
-    Iterator(ddwaf_map_obj actions, ddwaf_obj::nb_entries_t i)
-        : actions_{actions}, i_{i} {}
-    Iterator &operator++() {
-      ++i_;
-      return *this;
-    }
-
-    bool operator!=(const Iterator &other) const { return i_ != other.i_; }
-
-    Action operator*() const {
-      return Action{actions_.at_unchecked<ddwaf_map_obj>(i_)};
-    }
-
-   private:
-    ddwaf_map_obj actions_;
-    ddwaf_obj::nb_entries_t i_;
-  };
-
-  Iterator begin() const { return Iterator{ddwaf_map_obj{actions_}, 0}; }
-  Iterator end() const {
-    return Iterator{ddwaf_map_obj{actions_}, actions_.size()};
-  }
-
- private:
-  ddwaf_map_obj actions_;
-};
-
-BlockSpecification create_block_request_action(const Action &action) {
-  enum BlockSpecification::ContentType ct{
-      BlockSpecification::ContentType::AUTO};
-  int status = action.get_int_param("status_code"sv);
-
-  std::string_view const ct_sv = action.get_string_param("type"sv);
-  if (ct_sv == "auto"sv) {
-    ct = BlockSpecification::ContentType::AUTO;
-  } else if (ct_sv == "html"sv) {
-    ct = BlockSpecification::ContentType::HTML;
-  } else if (ct_sv == "json"sv) {
-    ct = BlockSpecification::ContentType::JSON;
-  } else if (ct_sv == "none"sv) {
-    ct = BlockSpecification::ContentType::NONE;
-  }
-
-  return BlockSpecification{status, ct};
-}
-
-BlockSpecification create_redirect_request_action(const Action &action) {
-  int status = action.get_int_param("status_code"sv);
-  std::string_view const loc = action.get_string_param("location"sv);
-  return {status, BlockSpecification::ContentType::NONE, loc};
-}
-
-std::optional<BlockSpecification> resolve_block_spec(
-    const ActionsResult &actions, ngx_log_t &log) {
-  for (Action act : actions) {
-    auto type = act.type();
-
-    if (type == Action::type::UNKNOWN) {
-      std::string_view raw_type = act.raw_type();
-      ngx_str_t raw_type_ns{dnsec::ngx_stringv(raw_type)};
-      ngx_log_error(NGX_LOG_WARN, &log, 0,
-                    "WAF indicated action %V, but such action id is unknown",
-                    &raw_type_ns);
-      continue;
-    }
-
-    if (type == Action::type::GENERATE_STACK ||
-        type == Action::type::GENERATE_SCHEMA) {
-      std::string_view raw_type = act.raw_type();
-      ngx_str_t raw_type_ns{dnsec::ngx_stringv(raw_type)};
-      ngx_log_error(NGX_LOG_NOTICE, &log, 0,
-                    "WAF indicated action %V, but this action is "
-                    "not supported. Ignoring.",
-                    &raw_type_ns);
-      continue;
-    }
-
-    if (type == Action::type::BLOCK_REQUEST) {
-      return {create_block_request_action(act)};
-    }
-
-    if (type == Action::type::REDIRECT_REQUEST) {
-      return {create_redirect_request_action(act)};
-    }
-  }
-
-  return std::nullopt;
-}
-}  // namespace
 
 std::optional<BlockSpecification> Context::run_waf_start(
     ngx_http_request_t &req, dd::Span &span) {
@@ -692,21 +418,7 @@ std::optional<BlockSpecification> Context::run_waf_start(
 
   client_ip_ = std::move(client_ip);
 
-  ddwaf_result result;
-  auto code =
-      ddwaf_run(ctx_.resource, data, nullptr, &result, Library::waf_timeout());
-
-  std::optional<BlockSpecification> block_spec;
-  if (code == DDWAF_MATCH) {
-    results_.emplace_back(result);
-    ddwaf_map_obj actions_arr{result.actions};
-    if (!actions_arr.empty()) {
-      ActionsResult actions_res{actions_arr};
-      block_spec = resolve_block_spec(actions_arr, *req.connection->log);
-    }
-  } else {
-    ddwaf_result_free(&result);
-  }
+  auto [_, block_spec] = waf_ctx_->run(*data);
 
   if (block_spec) {
     stage_->store(stage::AFTER_BEGIN_WAF_BLOCK, std::memory_order_release);
@@ -745,6 +457,10 @@ ngx_int_t Context::output_body_filter(ngx_http_request_t &request,
 
 class PolReqBodyWafCtx : public PolTaskCtx<PolReqBodyWafCtx> {
   using PolTaskCtx::PolTaskCtx;
+
+  static ngx_int_t get_task_failure_flag() noexcept {
+    return kTaskPostFailureMaskReqBodyWaf;
+  }
 
   std::optional<BlockSpecification> do_handle(ngx_log_t &tp_log) {
     return ctx_.run_waf_req_post(req_, span_);
@@ -797,6 +513,10 @@ class PolReqBodyWafCtx : public PolTaskCtx<PolReqBodyWafCtx> {
 
 class PolFinalWafCtx : public PolTaskCtx<PolFinalWafCtx> {
   using PolTaskCtx::PolTaskCtx;
+
+  static ngx_int_t get_task_failure_flag() noexcept {
+    return kTaskPostFailureMaskFinalWaf;
+  }
 
   std::optional<BlockSpecification> do_handle(ngx_log_t &tp_log) {
     return ctx_.run_waf_end(req_, span_);
@@ -873,12 +593,42 @@ class PolFinalWafCtx : public PolTaskCtx<PolFinalWafCtx> {
   friend PolTaskCtx;
 
  public:
-  bool submit(ngx_thread_pool_t *pool) noexcept {
-    bool submitted =
-        static_cast<PolTaskCtx<PolFinalWafCtx> *>(this)->submit(pool);
-    if (submitted) {
-      req_.header_sent = 1;  // skip/alert when attempting to sent headers
+  bool submit(ngx_thread_pool_t *pool, bool from_header_filter) noexcept {
+    // if submission fails, the destructor is called, so save these
+    Context &ctx = ctx_;
+    ngx_http_request_t &req = req_;
+
+    // with header_only, generally the body filter is not called and the
+    // request is synchronously finalized after the header filter is called.
+    // We need to be called from the body filter because that's where we
+    // flush the buffered header.
+    // (If the submission fails, this is not strictly required, because we could
+    // flush the buffered header synchronously, but do it all the same to avoid
+    // multiplying code paths)
+    if (from_header_filter && req.header_only) {
+      ngx_log_debug(NGX_LOG_DEBUG_HTTP, req.connection->log, 0,
+                    "suppressing req.header_only");
+      req.header_only = 0;
     }
+    req.header_sent = 1;  // skip/alert when attempting to sent headers
+
+    // call super implementation
+    bool submitted =
+        static_cast<PolTaskCtx<PolFinalWafCtx> &&>(*this).submit(pool);
+    if (!submitted) {
+      ngx_log_debug(NGX_LOG_DEBUG_HTTP, req.connection->log, 0,
+                    "submission of final waf task failed; moving directly to "
+                    "stage AFTER_RUN_WAF_END and triggering write event on "
+                    "connection");
+      ctx.waf_final_done(req, false);
+      ngx_post_event(req.connection->write, &ngx_posted_events);
+      if (req.upstream) {
+        // it may be that the body filter is never called again, so we have
+        // no chance to send the buffered data.
+        ctx.prepare_drain_buffered_header(req);
+      }
+    }
+
     return submitted;
   }
 };
@@ -962,7 +712,7 @@ ngx_int_t Context::do_request_body_filter(ngx_http_request_t &request,
       auto *conf = static_cast<datadog_loc_conf_t *>(
           ngx_http_get_module_loc_conf(&request, ngx_http_datadog_module));
 
-      if (task_ctx.submit(conf->waf_pool)) {
+      if (std::move(task_ctx).submit(conf->waf_pool)) {
         ngx_log_debug(NGX_LOG_DEBUG_HTTP, request.connection->log, 0,
                       "posted request body waf req post task");
       } else {
@@ -1015,7 +765,7 @@ ngx_int_t Context::do_request_body_filter(ngx_http_request_t &request,
         && st != stage::ENTERED_ON_START /* could not submit 1st WAF task */
         && st != stage::AFTER_BEGIN_WAF_BLOCK /* blocked by 1st WAF task */) {
       ngx_log_error(NGX_LOG_NOTICE, request.connection->log, 0,
-                    "unexpected filter call in stage %d", st);
+                    "unexpected filter call in stage %V", to_ngx_str(st));
     }
     return ngx_http_next_request_body_filter(&request, in);
   }
@@ -1029,7 +779,7 @@ ngx_int_t Context::buffer_chain(FilterCtx &filter_ctx, ngx_pool_t &pool,
   ngx_log_debug(
       NGX_LOG_DEBUG_HTTP, pool.log, 0,
       "buffer_chain: in=%p, chain_len=%uz, chain_size=%uz, consume=%d", in,
-      chain_length(in), chain_size(in), consume);
+      chain::length(in), chain::size(in), consume);
   if (pool.log->log_level >= NGX_LOG_DEBUG) {
     for (auto *in_ch = in; in_ch; in_ch = in_ch->next) {
       const auto &buf = *in_ch->buf;
@@ -1142,17 +892,17 @@ ngx_int_t Context::buffer_header_output(ngx_pool_t &pool,
   ngx_log_debug(NGX_LOG_DEBUG_HTTP, pool.log, 0,
                 "buffer_header_output: saved_(len,size)=(%uz,%uz), "
                 "in_(len,size)=(%uz,%uz)",
-                chain_length(header_filter_ctx_.out),
-                chain_size(header_filter_ctx_.out), chain_length(chain),
-                chain_size(chain));
+                chain::length(header_filter_ctx_.out),
+                chain::size(header_filter_ctx_.out), chain::length(chain),
+                chain::size(chain));
 
   ngx_int_t res = buffer_chain(header_filter_ctx_, pool, chain, true);
 
   ngx_log_debug(NGX_LOG_DEBUG_HTTP, pool.log, 0,
                 "buffer_header_output: buffer_chain output was %d, "
                 "saved_(len,size)=(%uz,%uz)",
-                res, chain_length(header_filter_ctx_.out),
-                chain_size(header_filter_ctx_.out));
+                res, chain::length(header_filter_ctx_.out),
+                chain::size(header_filter_ctx_.out));
 
   return res;
 }
@@ -1160,8 +910,8 @@ ngx_int_t Context::buffer_header_output(ngx_pool_t &pool,
 ngx_int_t Context::send_buffered_header(ngx_http_request_t &request) noexcept {
   ngx_log_debug(NGX_LOG_DEBUG_HTTP, request.connection->log, 0,
                 "send_buffered_header: buffered_(len,size)=(%uz,%uz)",
-                chain_length(header_filter_ctx_.out),
-                chain_size(header_filter_ctx_.out));
+                chain::length(header_filter_ctx_.out),
+                chain::size(header_filter_ctx_.out));
 
   if (!request.stream) {
     ngx_int_t rc = ngx_http_write_filter(&request, header_filter_ctx_.out);
@@ -1186,7 +936,7 @@ ngx_int_t Context::send_buffered_header(ngx_http_request_t &request) noexcept {
 
   ngx_log_debug(NGX_LOG_DEBUG_HTTP, c.log, 0,
                 "send_buffered_header: remaining chain_(len,size)=(%uz,%uz)",
-                chain_length(rem_chain), chain_size(rem_chain));
+                chain::length(rem_chain), chain::size(rem_chain));
   for (ngx_chain_t *cl = header_filter_ctx_.out; cl && cl != rem_chain;) {
     ngx_chain_t *ln = cl;
     cl = cl->next;
@@ -1306,8 +1056,8 @@ void Context::prepare_drain_buffered_header(
 
   ngx_log_debug(NGX_LOG_DEBUG_HTTP, request.connection->log, 0,
                 "prepare_drain_buffered_header: buffered_(len,size)=(%uz,%uz)",
-                chain_length(header_filter_ctx_.out),
-                chain_size(header_filter_ctx_.out));
+                chain::length(header_filter_ctx_.out),
+                chain::size(header_filter_ctx_.out));
 
   prev_req_write_evt_handler_ = request.write_event_handler;
   request.write_event_handler = drain_buffered_data_write_handler;
@@ -1372,7 +1122,7 @@ class Http1TemporarySendChain {
       ngx_log_debug(NGX_LOG_DEBUG_HTTP, request.connection->log, 0,
                     "temporary send_chain: uncommitted data in output chain "
                     "(%uz bytes); adding it to the header output buffer",
-                    chain_size(request.out));
+                    chain::size(request.out));
       ctx->buffer_header_output(*request.pool, request.out);
       for (auto *cl = request.out; cl;) {
         auto *next = cl->next;
@@ -1453,8 +1203,8 @@ class Http2TemporarySendChain {
                     "temporary send_chain: found header frame in uncommitted "
                     "h2c connection data frame_(len,size)=(%uz,%uz bytes); "
                     "adding it to the header output buffer and unqueuing it",
-                    chain_length(header_frame.first),
-                    chain_size(header_frame.first));
+                    chain::length(header_frame.first),
+                    chain::size(header_frame.first));
       ctx->buffer_header_output(*request.pool, header_frame.first);
       ngx_http_v2_connection_t *h2c = request.stream->connection;
       // calls ngx_http_v2_data_frame_handler:
@@ -1500,26 +1250,26 @@ ngx_int_t Context::do_header_filter(ngx_http_request_t &request,
                                     dd::Span &span) {
   auto st = stage_->load(std::memory_order_acquire);
   ngx_log_debug4(NGX_LOG_DEBUG_HTTP, request.connection->log, 0,
-                 "waf header filter in stage %d, header_sent=%d, "
+                 "waf header filter in stage %V, header_sent=%d, "
                  "buf_header_data_(len,size)=(%uz,%uz)",
-                 st, request.header_sent, chain_length(header_filter_ctx_.out),
-                 chain_size(header_filter_ctx_.out));
+                 to_ngx_str(st), request.header_sent,
+                 chain::length(header_filter_ctx_.out),
+                 chain::size(header_filter_ctx_.out));
 
   if (st != stage::AFTER_BEGIN_WAF && st != stage::AFTER_ON_REQ_WAF) {
     return ngx_http_next_header_filter(&request);
   }
 
-  PolFinalWafCtx &task_ctx = PolFinalWafCtx::create(request, *this, span);
-
-  auto *conf = static_cast<datadog_loc_conf_t *>(
-      ngx_http_get_module_loc_conf(&request, ngx_http_datadog_module));
-
-  transition_to_stage(stage::PENDING_WAF_END);
-
   ngx_log_debug(NGX_LOG_DEBUG_HTTP, request.connection->log, 0,
-                "waf header filter: waf end task; replacing send_chain handler "
+                "waf header filter: replacing send_chain handler "
                 "and invoking the next header filter");
 
+  if (request.header_only) {
+    header_only_ =
+        true;  // save it; we'll change req.header_only upon waf task submission
+  }
+
+  // first, buffer the header data
   ngx_int_t rc;
   if (request.stream) {
     // http/2
@@ -1537,25 +1287,41 @@ ngx_int_t Context::do_header_filter(ngx_http_request_t &request,
                   "waf header filter: downstream filters returned %d", rc);
     transition_to_stage(stage::AFTER_RUN_WAF_END);
     return rc;
-  } else {
-    ngx_log_debug(NGX_LOG_DEBUG_HTTP, request.connection->log, 0,
-                  "waf header filter: downstream filters returned NGX_OK; "
-                  "attempting to submit WAF task");
   }
 
-  if (task_ctx.submit(conf->waf_pool)) {
-    return NGX_OK;
-  } else {
-    ngx_log_error(NGX_LOG_NOTICE, request.connection->log, 0,
-                  "failed to post waf end task; sending down the header data "
-                  "immediately");
-    transition_to_stage(stage::AFTER_RUN_WAF_END);
-    ngx_int_t rc = ngx_http_write_filter(&request, header_filter_ctx_.out);
-    header_filter_ctx_.clear(*request.pool);
+  // If no body (or we're ignoring it), start the WAF
+  // Afterwards, we transition to PENDING_WAF_END (or AFTER_RUN_WAF_END if we
+  // were unable to submit the WAF task)
+  waf_send_resp_body_ = waf_send_resp_body_ && is_body_resp_parseable(request);
+  if (!waf_send_resp_body_) {
     ngx_log_debug(NGX_LOG_DEBUG_HTTP, request.connection->log, 0,
-                  "waf header filter: ngx_http_write_filter returned %d", rc);
-    return rc;
+                  "waf header filter: downstream filters returned NGX_OK; "
+                  "attempting to submit WAF task (waf_send_resp_body=%d, "
+                  "header_only=%d, content_length=%d)",
+                  waf_send_resp_body_, request.header_only,
+                  request.headers_out.content_length_n);
+
+    PolFinalWafCtx &task_ctx = PolFinalWafCtx::create(request, *this, span);
+    auto *conf = static_cast<datadog_loc_conf_t *>(
+        ngx_http_get_module_loc_conf(&request, ngx_http_datadog_module));
+
+    transition_to_stage(stage::PENDING_WAF_END);
+
+    if (task_ctx.submit(conf->waf_pool, true /* from_header_filter */)) {
+      return NGX_OK;
+    } else {
+      ngx_log_error(NGX_LOG_NOTICE, request.connection->log, 0,
+                    "waf header filter: failed to post waf end task");
+
+      return NGX_OK;
+    }
   }
+
+  ngx_log_debug(
+      NGX_LOG_DEBUG_HTTP, request.connection->log, 0,
+      "waf header filter: waiting for enough body data to do final WAF run");
+  transition_to_stage(stage::COLLECTING_ON_RESP_DATA);
+  return NGX_OK;
 }
 
 ngx_int_t Context::do_output_body_filter(ngx_http_request_t &request,
@@ -1564,15 +1330,25 @@ ngx_int_t Context::do_output_body_filter(ngx_http_request_t &request,
   auto st = stage_->load(std::memory_order_acquire);
   ngx_log_debug(
       NGX_LOG_DEBUG_HTTP, request.connection->log, 0,
-      "waf output body filter: in stage %d, header_sent=%d, "
+      "waf output body filter: in stage %V, header_sent=%d, "
       "header_(len_sized)=(%uz,%uz), out_(len,size,copied)=(%uz,%uz,%uz), "
       "in_chain_(len,size)=(%uz,%uz), l:%d, s:%d",
-      st, request.header_sent, chain_length(header_filter_ctx_.out),
-      chain_size(header_filter_ctx_.out), chain_length(out_filter_ctx_.out),
-      chain_size(out_filter_ctx_.out), out_filter_ctx_.copied_total,
-      chain_length(in), chain_size(in), has_last(in), has_special(in));
+      to_ngx_str(st), request.header_sent,
+      chain::length(header_filter_ctx_.out),
+      chain::size(header_filter_ctx_.out), chain::length(out_filter_ctx_.out),
+      chain::size(out_filter_ctx_.out), out_filter_ctx_.copied_total,
+      chain::length(in), chain::size(in), chain::has_last(in),
+      chain::has_special(in));
 
-  const bool buffering = st == stage::PENDING_WAF_END;
+  if (header_only_ && !request.header_only) {
+    ngx_log_debug(NGX_LOG_DEBUG_HTTP, request.connection->log, 0,
+                  "waf output body filter: restoring to 1 the value of "
+                  "request.header_only");
+    request.header_only = 1;
+  }
+
+  const bool buffering =
+      st == stage::PENDING_WAF_END || st == stage::COLLECTING_ON_RESP_DATA;
   if (buffering) {
     request.buffered |= 0x08;
 
@@ -1581,7 +1357,7 @@ ngx_int_t Context::do_output_body_filter(ngx_http_request_t &request,
       ngx_log_debug(NGX_LOG_DEBUG_HTTP, request.connection->log, 0,
                     "waf output body filter: too much copied data (%uz bytes "
                     ">= %uz), avoiding consuming more",
-                    out_filter_ctx_.out_total, max_saved_output_data_);
+                    out_filter_ctx_.copied_total, max_saved_output_data_);
       consume = false;
     } else {
       consume = true;
@@ -1596,8 +1372,39 @@ ngx_int_t Context::do_output_body_filter(ngx_http_request_t &request,
                    "accumulated output data (%uz copied)",
                    out_filter_ctx_.out_total, out_filter_ctx_.copied_total);
 
+    const bool start_waf =
+        st == stage::COLLECTING_ON_RESP_DATA &&
+        (out_filter_ctx_.out_total >= kMaxFilterData || chain::has_last(in));
+
+    if (start_waf) {
+      if (out_filter_ctx_.out_total == 0) {
+        ngx_log_debug(NGX_LOG_DEBUG_HTTP, request.connection->log, 0,
+                      "waf output body filter: no data accumulated; "
+                      "running WAF end without body");
+        waf_send_resp_body_ = false;
+      } else {
+        ngx_log_debug(NGX_LOG_DEBUG_HTTP, request.connection->log, 0,
+                      "waf output body filter: enough data to do final WAF run "
+                      "(out total is %uz, has_last=%d)",
+                      out_filter_ctx_.out_total, chain::has_last(in));
+      }
+
+      PolFinalWafCtx &task_ctx = PolFinalWafCtx::create(request, *this, span);
+      auto *conf = static_cast<datadog_loc_conf_t *>(
+          ngx_http_get_module_loc_conf(&request, ngx_http_datadog_module));
+      transition_to_stage(stage::PENDING_WAF_END);
+      if (task_ctx.submit(conf->waf_pool, false /* from_header_filter */)) {
+        ngx_log_debug(NGX_LOG_DEBUG_HTTP, request.connection->log, 0,
+                      "waf output body filter: submitted waf end task; "
+                      "transitioning to PENDING_WAF_END");
+      } else {
+        ngx_log_error(NGX_LOG_NOTICE, request.connection->log, 0,
+                      "waf output body filter: failed to post waf end task");
+      }
+    }
+
     return consume ? NGX_OK : NGX_AGAIN;
-  }
+  }  // if (buffering)
 
   // !buffering
   request.buffered &= ~0x08;
@@ -1679,8 +1486,8 @@ std::optional<BlockSpecification> Context::run_waf_req_post(
   ddwaf_obj &entry = input_map.at_unchecked(0);
   entry.set_key("server.request.body"sv);
 
-  bool success = parse_body(entry, request, *filter_ctx_.out,
-                            filter_ctx_.out_total, memres_);
+  bool success = parse_body_req(entry, request, *filter_ctx_.out,
+                                filter_ctx_.out_total, memres_);
 
   if (!success) {
     ngx_log_debug0(NGX_LOG_DEBUG_HTTP, request.connection->log, 0,
@@ -1688,23 +1495,7 @@ std::optional<BlockSpecification> Context::run_waf_req_post(
     return std::nullopt;
   }
 
-  ddwaf_result result;
-  DDWAF_RET_CODE const code = ddwaf_run(ctx_.resource, &input, nullptr, &result,
-                                        Library::waf_timeout());
-  if (code != DDWAF_MATCH) {
-    ddwaf_result_free(&result);
-    return std::nullopt;
-  }
-
-  results_.emplace_back(result);
-
-  std::optional<BlockSpecification> block_spec;
-  ddwaf_map_obj actions_arr{result.actions};
-  if (!actions_arr.empty()) {
-    ActionsResult actions_res{actions_arr};
-    block_spec = resolve_block_spec(actions_arr, *request.connection->log);
-  }
-
+  auto [_, block_spec] = waf_ctx_->run(input);
   return block_spec;
 }
 
@@ -1728,7 +1519,7 @@ void Context::waf_final_done(ngx_http_request_t &request, bool blocked) {
   if (!res) {
     ngx_log_error(NGX_LOG_ERR, request.connection->log, 0,
                   "call to waf_final_done without current stage being "
-                  "BEFORE_RUN_WAF_END");
+                  "PENDING_WAF_END");
     return;
   }
 }
@@ -1740,24 +1531,20 @@ std::optional<BlockSpecification> Context::run_waf_end(
     return std::nullopt;
   }
 
-  ddwaf_object *resp_data = collect_response_data(request, memres_);
-
-  ddwaf_result result;
-  DDWAF_RET_CODE const code = ddwaf_run(ctx_.resource, resp_data, nullptr,
-                                        &result, Library::waf_timeout());
-  if (code == DDWAF_MATCH) {
-    results_.emplace_back(result);
+  ngx_chain_t *body_chain;
+  size_t body_size;
+  if (waf_send_resp_body_) {
+    body_chain = out_filter_ctx_.out;
+    body_size = std::min(out_filter_ctx_.out_total, kMaxFilterData);
   } else {
-    ddwaf_result_free(&result);
+    body_chain = nullptr;
+    body_size = 0;
   }
 
-  std::optional<BlockSpecification> block_spec;
-  ddwaf_map_obj actions_arr{result.actions};
-  if (!actions_arr.empty()) {
-    ActionsResult actions_res{actions_arr};
-    block_spec = resolve_block_spec(actions_arr, *request.connection->log);
-  }
+  ddwaf_object *resp_data =
+      collect_response_data(request, body_chain, body_size, memres_);
 
+  auto [_, block_spec] = waf_ctx_->run(*resp_data);
   return block_spec;
 }
 
@@ -1776,20 +1563,26 @@ void Context::do_on_main_log_request(ngx_http_request_t &request,
     return;
   }
 
-  set_header_tags(has_matches(), request, span);
+  set_header_tags(waf_ctx_->has_matches(), request, span);
   report_matches(request, span);
   report_client_ip(span);
 }
 
-bool Context::has_matches() const noexcept { return !results_.empty(); }
-
 void Context::report_matches(ngx_http_request_t &request, dd::Span &span) {
-  if (results_.empty()) {
-    return;
-  }
+  auto &&trace_segment = span.trace_segment();
 
-  report_match(request, span.trace_segment(), span, results_);
-  results_.clear();
+  bool did_report = waf_ctx_->report_matches([&](std::string_view json) {
+    ngx_str_t json_ns{dnsec::ngx_stringv(json)};
+    ngx_log_error(NGX_LOG_INFO, request.connection->log, 0, "appsec event: %V",
+                  &json_ns);
+
+    span.set_tag("_dd.appsec.json"sv, json);
+  });
+
+  if (did_report) {
+    trace_segment.override_sampling_priority(2);  // USER-KEEP
+    span.set_tag("appsec.event"sv, "true");
+  }
 
   if (!apm_tracing_enabled_) {
     span.set_source(tracing::Source::appsec);

--- a/src/security/context.h
+++ b/src/security/context.h
@@ -79,6 +79,7 @@ class Context {
   void report_matches(ngx_http_request_t &request, dd::Span &span);
   void report_client_ip(dd::Span &span) const;
 
+  // clang-format off
   /*
     Initial path:
     ┌───────┐   on_request_start   ┌──────────────────┐  1st WAF task   ┌─────────────────┐
@@ -143,6 +144,7 @@ class Context {
                          ▲                                       │
                          └── ( block response sent)──────────────┘
   */
+  // clang-format on
   enum class stage {
     /* Set on on_request_start (NGX_HTTP_ACCESS_PHASE) if there's no thread
      * pool mapped for the request.

--- a/src/security/ddwaf_req.cpp
+++ b/src/security/ddwaf_req.cpp
@@ -1,0 +1,308 @@
+#include "ddwaf_req.h"
+
+#include <rapidjson/document.h>
+#include <rapidjson/encodings.h>
+#include <rapidjson/prettywriter.h>
+
+#include <charconv>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "ddwaf_obj.h"
+#include "security/blocking.h"
+
+using namespace std::literals;
+
+namespace {
+
+namespace dnsec = datadog::nginx::security;
+using dnsec::BlockSpecification;
+using dnsec::ddwaf_map_obj;
+using dnsec::ddwaf_obj;
+
+class JsonWriter : public rapidjson::Writer<rapidjson::StringBuffer> {
+  using rapidjson::Writer<rapidjson::StringBuffer>::Writer;
+
+ public:
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  bool ConstLiteralKey(std::string_view sv) {
+    return String(sv.data(), sv.length(), false);
+  }
+};
+
+void ddwaf_object_to_json(JsonWriter &w, const ddwaf_object &dobj);
+
+// NOLINTNEXTLINE(misc-no-recursion)
+void ddwaf_object_to_json(JsonWriter &w, const ddwaf_object &dobj) {
+  switch (dobj.type) {
+    case DDWAF_OBJ_MAP:
+      w.StartObject();
+      for (std::size_t i = 0; i < dobj.nbEntries; i++) {
+        auto &&e = dobj.array[i];
+        w.Key(e.parameterName, e.parameterNameLength, false);
+        ddwaf_object_to_json(w, e);
+      }
+      w.EndObject(dobj.nbEntries);
+      break;
+    case DDWAF_OBJ_ARRAY:
+      w.StartArray();
+      for (std::size_t i = 0; i < dobj.nbEntries; i++) {
+        auto &&e = dobj.array[i];
+        ddwaf_object_to_json(w, e);
+      }
+      w.EndArray(dobj.nbEntries);
+      break;
+    case DDWAF_OBJ_STRING:
+      w.String(dobj.stringValue, dobj.nbEntries, false);
+      break;
+    case DDWAF_OBJ_SIGNED:
+      w.Int64(dobj.intValue);
+      break;
+    case DDWAF_OBJ_UNSIGNED:
+      w.Uint64(dobj.uintValue);
+      break;
+    case DDWAF_OBJ_FLOAT:
+      w.Double(dobj.f64);
+      break;
+    case DDWAF_OBJ_BOOL:
+      w.Bool(dobj.boolean);
+      break;
+    case DDWAF_OBJ_INVALID:
+    case DDWAF_OBJ_NULL:
+      w.Null();
+      break;
+  }
+}
+
+class Action {
+ public:
+  enum class type : unsigned char {
+    BLOCK_REQUEST,
+    REDIRECT_REQUEST,
+    GENERATE_STACK,
+    GENERATE_SCHEMA,
+    UNKNOWN,
+  };
+
+  Action(dnsec::ddwaf_map_obj action) : action_{action} {}
+
+  auto type() const {
+    auto key = action_.key();
+    if (key == "block_request"sv) {
+      return type::BLOCK_REQUEST;
+    } else if (key == "redirect_request"sv) {
+      return type::REDIRECT_REQUEST;
+    } else if (key == "generate_stack"sv) {
+      return type::GENERATE_STACK;
+    } else if (key == "generate_schema"sv) {
+      return type::GENERATE_SCHEMA;
+    } else {
+      return type::UNKNOWN;
+    }
+  }
+
+  auto raw_type() const { return action_.key(); }
+
+  int get_int_param(std::string_view k) const {
+    ddwaf_obj v = action_.get(k);
+
+    if (v.is_numeric()) {
+      return v.numeric_val<int>();
+    }
+
+    if (!v.is_string()) {
+      throw std::runtime_error{"expected numeric value for action parameter " +
+                               std::string{k}};
+    }
+
+    // try to convert to number
+    std::string_view const sv{v.string_val_unchecked()};
+    int n;
+    auto [ptr, ec] = std::from_chars(sv.data(), sv.data() + sv.size(), n);
+    if (ec == std::errc{} && ptr == sv.data() + sv.size()) {
+      return n;
+    }
+    throw std::runtime_error{"expected numeric value for action parameter " +
+                             std::string{k} + ", got " + std::string{sv}};
+  }
+
+  std::string_view get_string_param(std::string_view k) const {
+    ddwaf_obj v = action_.get(k);
+
+    if (v.is_string()) {
+      return v.string_val_unchecked();
+    }
+
+    throw std::runtime_error{"expected string value for action parameter " +
+                             std::string{k}};
+  }
+
+ private:
+  ddwaf_map_obj action_;
+};
+
+class ActionsResult {
+ public:
+  ActionsResult(ddwaf_map_obj actions) : actions_{actions} {}
+
+  class Iterator {
+   public:
+    using difference_type = ddwaf_obj::nb_entries_t;      // NOLINT
+    using value_type = Action;                            // NOLINT
+    using pointer = value_type *;                         // NOLINT
+    using reference = value_type &;                       // NOLINT
+    using iterator_category = std::forward_iterator_tag;  // NOLINT
+
+    Iterator(ddwaf_map_obj actions, ddwaf_obj::nb_entries_t i)
+        : actions_{actions}, i_{i} {}
+    Iterator &operator++() {
+      ++i_;
+      return *this;
+    }
+
+    bool operator!=(const Iterator &other) const { return i_ != other.i_; }
+
+    Action operator*() const {
+      return Action{actions_.at_unchecked<ddwaf_map_obj>(i_)};
+    }
+
+   private:
+    ddwaf_map_obj actions_;
+    ddwaf_obj::nb_entries_t i_;
+  };
+
+  Iterator begin() const { return Iterator{ddwaf_map_obj{actions_}, 0}; }
+  Iterator end() const {
+    return Iterator{ddwaf_map_obj{actions_}, actions_.size()};
+  }
+
+ private:
+  ddwaf_map_obj actions_;
+};
+
+BlockSpecification create_block_request_action(const Action &action) {
+  enum BlockSpecification::ContentType ct{
+      BlockSpecification::ContentType::AUTO};
+  int status = action.get_int_param("status_code"sv);
+
+  std::string_view const ct_sv = action.get_string_param("type"sv);
+  if (ct_sv == "auto"sv) {
+    ct = BlockSpecification::ContentType::AUTO;
+  } else if (ct_sv == "html"sv) {
+    ct = BlockSpecification::ContentType::HTML;
+  } else if (ct_sv == "json"sv) {
+    ct = BlockSpecification::ContentType::JSON;
+  } else if (ct_sv == "none"sv) {
+    ct = BlockSpecification::ContentType::NONE;
+  }
+
+  return BlockSpecification{status, ct};
+}
+
+BlockSpecification create_redirect_request_action(const Action &action) {
+  int status = action.get_int_param("status_code"sv);
+  std::string_view const loc = action.get_string_param("location"sv);
+  return {status, BlockSpecification::ContentType::NONE, loc};
+}
+
+std::optional<BlockSpecification> resolve_block_spec(
+    const ActionsResult &actions) {
+  for (Action act : actions) {
+    auto type = act.type();
+
+    if (type == Action::type::UNKNOWN) {
+      continue;
+    }
+
+    if (type == Action::type::GENERATE_STACK ||
+        type == Action::type::GENERATE_SCHEMA) {
+      continue;
+    }
+
+    if (type == Action::type::BLOCK_REQUEST) {
+      return {create_block_request_action(act)};
+    }
+
+    if (type == Action::type::REDIRECT_REQUEST) {
+      return {create_redirect_request_action(act)};
+    }
+  }
+
+  return std::nullopt;
+}
+
+}  // namespace
+
+namespace datadog::nginx::security {
+
+DdwafContext::DdwafContext(std::shared_ptr<OwnedDdwafHandle> &handle)
+    : ctx_{nullptr} {
+  if (!handle) {
+    throw std::runtime_error{"invalid WAF handle"};
+  }
+
+  ddwaf_handle ddwaf_h = handle->get();
+  ctx_ = ddwaf_context_init(ddwaf_h);
+  if (!ctx_.resource) {
+    throw std::runtime_error{"failed to initialize WAF context"};
+  }
+}
+
+DdwafContext::WafRunResult DdwafContext::run(ddwaf_object &persistent_data) {
+  ddwaf_result result;
+  DDWAF_RET_CODE const code =
+      ddwaf_run(ctx_.resource, &persistent_data, nullptr, &result,
+                Library::waf_timeout());
+
+  WafRunResult waf_result;
+  waf_result.ret_code = code;
+
+  if (code == DDWAF_MATCH) {
+    results_.emplace_back(result);
+
+    ddwaf_map_obj actions_arr{result.actions};
+    if (!actions_arr.empty()) {
+      ActionsResult actions_res{actions_arr};
+      waf_result.block_spec = resolve_block_spec(actions_res);
+    }
+  } else {
+    ddwaf_result_free(&result);
+  }
+
+  return waf_result;
+}
+
+bool DdwafContext::report_matches(
+    const std::function<void(std::string_view)> &f) {
+  if (results_.empty()) {
+    return false;
+  }
+
+  rapidjson::StringBuffer buffer;
+  JsonWriter w(buffer);
+  w.StartObject();
+  w.ConstLiteralKey("triggers"sv);
+
+  w.StartArray();
+  for (auto &&result : results_) {
+    auto events = dnsec::ddwaf_arr_obj{(*result).events};
+    for (auto &&evt : events) {
+      ddwaf_object_to_json(w, evt);
+    }
+  }
+  w.EndArray(results_.size());
+
+  w.EndObject(1);
+  w.Flush();
+
+  std::string_view const json{buffer.GetString(), buffer.GetLength()};
+  f(json);
+
+  results_.clear();
+  return true;
+}
+
+}  // namespace datadog::nginx::security

--- a/src/security/ddwaf_req.h
+++ b/src/security/ddwaf_req.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <ddwaf.h>
+
+#include <functional>
+#include <vector>
+
+#include "blocking.h"
+#include "library.h"
+#include "util.h"
+
+namespace datadog::nginx::security {
+
+class DdwafContext {
+ public:
+  explicit DdwafContext(std::shared_ptr<OwnedDdwafHandle>& handle);
+
+  DdwafContext(DdwafContext&&) = delete;
+  DdwafContext& operator=(DdwafContext&&) = delete;
+  DdwafContext(const DdwafContext&) = delete;
+  DdwafContext& operator=(const DdwafContext&) = delete;
+
+  struct WafRunResult {
+    DDWAF_RET_CODE ret_code;
+    std::optional<BlockSpecification> block_spec;
+  };
+
+  WafRunResult run(ddwaf_object& persistent_data);
+
+  bool has_matches() const { return !results_.empty(); }
+
+  // if there are matches, calls the function with the desired contents for
+  // _dd.appsec.json and returns true. O/wise returns false.
+  bool report_matches(const std::function<void(std::string_view)>& f);
+
+ private:
+  struct DdwafContextFreeFunctor {
+    void operator()(ddwaf_context ctx) { ddwaf_context_destroy(ctx); }
+  };
+  struct OwnedDdwafContext
+      : FreeableResource<ddwaf_context, DdwafContextFreeFunctor> {
+    using FreeableResource::FreeableResource;
+    explicit OwnedDdwafContext(std::nullptr_t) : FreeableResource{nullptr} {}
+    OwnedDdwafContext& operator=(ddwaf_context ctx) {
+      if (resource) {
+        ddwaf_context_destroy(resource);
+      }
+      resource = ctx;
+      return *this;
+    }
+  };
+
+  struct DdwafResultFreeFunctor {
+    void operator()(ddwaf_result result) { ddwaf_result_free(&result); }
+  };
+  struct OwnedDdwafResult
+      : FreeableResource<ddwaf_result, DdwafResultFreeFunctor> {
+    using FreeableResource::FreeableResource;
+    explicit OwnedDdwafResult(ddwaf_result result) : FreeableResource{result} {}
+  };
+
+  OwnedDdwafContext ctx_;
+  std::vector<OwnedDdwafResult> results_;
+};
+}  // namespace datadog::nginx::security

--- a/src/security/directives.h
+++ b/src/security/directives.h
@@ -15,7 +15,7 @@ namespace datadog::nginx::security {
 char *waf_thread_pool_name(ngx_conf_t *cf, ngx_command_t *command,
                            void *conf) noexcept;
 
-constexpr directive appsec_directives[] = {
+constexpr directive kAppsecDirectives[] = {
     {"datadog_waf_thread_pool_name",
      NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF |
          NGX_CONF_TAKE1,
@@ -100,6 +100,15 @@ constexpr directive appsec_directives[] = {
         ngx_conf_set_size_slot,
         NGX_HTTP_MAIN_CONF_OFFSET,
         offsetof(datadog_main_conf_t, appsec_max_saved_output_data),
+        nullptr,
+    },
+
+    {
+        "datadog_appsec_test_task_post_failure_mask",
+        NGX_HTTP_MAIN_CONF | NGX_CONF_TAKE1,
+        ngx_conf_set_num_slot,
+        NGX_HTTP_MAIN_CONF_OFFSET,
+        offsetof(datadog_main_conf_t, appsec_test_task_post_failure_mask),
         nullptr,
     },
 };

--- a/src/security/util.h
+++ b/src/security/util.h
@@ -186,4 +186,35 @@ inline ngx_str_t ngx_stringv(std::string_view sv) noexcept {
           const_cast<u_char *>(reinterpret_cast<const u_char *>(sv.data()))};
 }
 
+namespace chain {
+inline std::size_t length(ngx_chain_t const *ch) {
+  std::size_t len = 0;
+  for (ngx_chain_t const *cl = ch; cl; cl = cl->next) {
+    len++;
+  }
+  return len;
+}
+inline std::size_t size(ngx_chain_t const *ch) {
+  std::size_t size = 0;
+  for (ngx_chain_t const *cl = ch; cl; cl = cl->next) {
+    size += ngx_buf_size(cl->buf);
+  }
+  return size;
+}
+inline std::size_t has_special(ngx_chain_t const *ch) {
+  for (ngx_chain_t const *cl = ch; cl; cl = cl->next) {
+    return ngx_buf_special(cl->buf);
+  }
+  return false;
+}
+inline std::size_t has_last(ngx_chain_t const *ch) {
+  for (ngx_chain_t const *cl = ch; cl; cl = cl->next) {
+    if (cl->buf->last) {
+      return true;
+    }
+  }
+  return false;
+}
+}  // namespace chain
+
 }  // namespace datadog::nginx::security

--- a/src/security/util.h
+++ b/src/security/util.h
@@ -203,7 +203,9 @@ inline std::size_t size(ngx_chain_t const *ch) {
 }
 inline std::size_t has_special(ngx_chain_t const *ch) {
   for (ngx_chain_t const *cl = ch; cl; cl = cl->next) {
-    return ngx_buf_special(cl->buf);
+    if (ngx_buf_special(cl->buf)) {
+      return true;
+    }
   }
   return false;
 }

--- a/test/cases/orchestration.py
+++ b/test/cases/orchestration.py
@@ -369,6 +369,11 @@ def curl(url, headers, stderr=None, method="GET", body=None, http_version=1):
         # read data from stdin
         body_args = ["--data-binary", "@-"]
 
+    if method == "HEAD":
+        method_args = ["--head"]
+    else:
+        method_args = [f"-X{method}"]
+
     # "-T" means "don't allocate a TTY".  This prevents `jq` from outputting in
     # color.
     command = docker_compose_command(
@@ -377,7 +382,7 @@ def curl(url, headers, stderr=None, method="GET", body=None, http_version=1):
         "--",
         "client",
         "curljson.sh",
-        f"-X{method}",
+        *method_args,
         *header_args(),
         "-k",
         version_arg,

--- a/test/cases/sec_addresses/conf/waf.json
+++ b/test/cases/sec_addresses/conf/waf.json
@@ -29,6 +29,9 @@
               },
               {
                 "address": "server.request.body"
+              },
+              {
+                "address": "server.response.body"
               }
             ],
             "regex": "^(?:%(?:a)?)?matched[ -]key(?:%(?:a)?)?$"
@@ -65,6 +68,9 @@
               },
               {
                 "address": "server.request.body"
+              },
+              {
+                "address": "server.response.body"
               }
             ],
             "regex": "^(?:%(?:a)?)?matched value(?:%(?:a)?)?$$"
@@ -92,6 +98,30 @@
               }
             ],
             "regex": ".*matched\\+partial\\+value.*"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": [
+        "values_only"
+      ]
+    },
+    {
+      "id": "response_body_trigger",
+      "name": "Response body trigger test",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.response.body"
+              }
+            ],
+            "regex": "response_body_trigger"
           },
           "operator": "match_regex"
         }
@@ -184,7 +214,10 @@
           "parameters": {
             "inputs": [
               {
-                "address": "server.response.headers.upgrade"
+                "address": "server.response.headers.no_cookies",
+                "key_path": [
+                  "upgrade"
+                ]
               }
             ],
             "regex": "^websocket$"

--- a/test/cases/sec_blocking/conf/waf.json
+++ b/test/cases/sec_blocking/conf/waf.json
@@ -64,6 +64,9 @@
               },
               {
                 "address": "server.request.body"
+              },
+              {
+                "address": "server.response.body"
               }
             ],
             "regex": "^block_default$"
@@ -226,6 +229,30 @@
               }
             ],
             "regex": "^block me$"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "on_match": [
+        "block_501"
+      ]
+    },
+    {
+      "id": "block_response_body",
+      "name": "Block based on response body content",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.response.body"
+              }
+            ],
+            "regex": "block_response_body"
           },
           "operator": "match_regex"
         }

--- a/test/cases/sec_blocking/test_task_post_failure.py
+++ b/test/cases/sec_blocking/test_task_post_failure.py
@@ -1,0 +1,200 @@
+import json
+from pathlib import Path
+
+from .. import case
+
+
+class TestTaskPostFailure(case.TestCase):
+    requires_waf = True
+    min_nginx_version = '1.26.0'
+
+    def setUp(self):
+        super().setUp()
+        # Set up WAF configuration - reuse from sec_blocking tests
+        waf_path = Path(__file__).parent / './conf/waf.json'
+        waf_text = waf_path.read_text()
+        self.orch.nginx_replace_file('/tmp/waf.json', waf_text)
+
+        crt_path = Path(__file__).parent / './cert/example.com.crt'
+        crt_text = crt_path.read_text()
+        self.orch.nginx_replace_file('/tmp/example.com.crt', crt_text)
+
+        key_path = Path(__file__).parent / './cert/example.com.key'
+        key_text = key_path.read_text()
+        self.orch.nginx_replace_file('/tmp/example.com.key', key_text)
+
+        # Consume any previous logging from the agent
+        self.orch.sync_service('agent')
+
+    def base_config_template(self, failure_mask=None):
+        """Generate base nginx configuration with optional task post failure mask."""
+        failure_line = ""
+        if failure_mask is not None:
+            failure_line = f"    datadog_appsec_test_task_post_failure_mask {failure_mask};"
+
+        return f"""
+thread_pool waf_thread_pool threads=2 max_queue=5;
+
+load_module /datadog-tests/ngx_http_datadog_module.so;
+
+events {{
+    worker_connections  1024;
+}}
+
+http {{
+    datadog_agent_url http://agent:8126;
+    datadog_appsec_enabled on;
+    datadog_appsec_ruleset_file /tmp/waf.json;
+    datadog_appsec_waf_timeout 2s;
+    datadog_waf_thread_pool_name waf_thread_pool;
+    datadog_appsec_max_saved_output_data 64k;
+{failure_line}
+
+    client_max_body_size 10m;
+
+    server {{
+        listen              80;
+        listen              443 quic reuseport;
+        listen              443 ssl;
+        http2               on;
+        ssl_certificate     /tmp/example.com.crt;
+        ssl_certificate_key /tmp/example.com.key;
+
+        location /http {{
+            proxy_pass http://http:8080;
+        }}
+    }}
+}}
+"""
+
+    def run_request_with_failure(self, failure_mask, *req_args, **req_kwargs):
+        config_with_failure = self.base_config_template(failure_mask)
+        status, log_lines = self.orch.nginx_replace_config(
+            config_with_failure, 'task_post_failure.conf')
+        self.assertEqual(0, status, log_lines)
+
+        status, resp_headers, body = self.orch.send_nginx_http_request(
+            *req_args, **req_kwargs)
+
+        self.orch.reload_nginx()
+        log_lines = self.orch.sync_service('agent')
+
+        # With task post failure, should get 200/410 (no blocking)
+        if status != 200 and status != 410:
+            self.fail(
+                f"Expected 200 or 410 with failure mask {failure_mask}, got {status}"
+            )
+
+        # Should not have appsec.blocked tag since WAF didn't run
+        traces = [
+            json.loads(line) for line in log_lines if line.startswith('[[{')
+        ]
+        blocked_traces = [
+            trace for trace in traces
+            if any(span[0]['meta'].get('appsec.blocked') == 'true'
+                   for span in trace)
+        ]
+        self.assertEqual(
+            len(blocked_traces), 0,
+            f"Expected no blocked traces with failure mask {failure_mask}")
+
+        return status, resp_headers, body, log_lines
+
+    def run_request_without_failure(self, expected_status, *req_args,
+                                    **req_kwargs):
+        # Test without failure mask to verify blocking would occur
+        config_normal = self.base_config_template()
+        status, log_lines = self.orch.nginx_replace_config(
+            config_normal, 'normal.conf')
+        self.assertEqual(0, status, log_lines)
+
+        status, resp_headers, body = self.orch.send_nginx_http_request(
+            *req_args, **req_kwargs)
+
+        self.orch.reload_nginx()
+        log_lines = self.orch.sync_service('agent')
+
+        # Without failure mask, should get blocked
+        self.assertEqual(
+            expected_status, status,
+            f"Expected blocking ({expected_status}) without failure mask, got {status}"
+        )
+
+        return status, resp_headers, body, log_lines
+
+    def test_initial_waf_task_post_failure(self):
+        """Test that initial WAF task post failure prevents blocking."""
+        headers = {'User-Agent': 'block_json', 'Accept': '*/*'}
+        # Test with failure mask (bit 0 = 1)
+        self.run_request_with_failure(1, '/http', 80, headers=headers)
+
+        # Verify that without failure mask, blocking would occur
+        self.run_request_without_failure(403, '/http', 80, headers=headers)
+
+    def test_request_body_waf_task_post_failure(self):
+        """Test that request body WAF task post failure prevents blocking."""
+        # Test with failure mask (bit 1 = 2)
+        headers = {'Content-type': 'application/json'}
+        req_body = '{"test": "block_default"}'
+        self.run_request_with_failure(2,
+                                      '/http',
+                                      80,
+                                      headers=headers,
+                                      req_body=req_body)
+
+        # Verify that without failure mask, blocking would occur
+        self.run_request_without_failure(403,
+                                         '/http',
+                                         80,
+                                         headers=headers,
+                                         req_body=req_body)
+
+    def test_final_waf_task_post_failure_head_request(self):
+        """Test that final WAF task post failure prevents blocking on HEAD request."""
+        # Test with failure mask (bit 2 = 4)
+        self.run_request_with_failure(4, '/http/status/410', 80, method="HEAD")
+
+        # Verify that without failure mask, blocking would occur
+        self.run_request_without_failure(501,
+                                         '/http/status/410',
+                                         method="HEAD")
+
+    def test_final_waf_task_post_failure_head_request_unparseable_body(self):
+        """Test that final WAF task post failure prevents blocking on HEAD request (early final WAF run variant)."""
+        # Verify that without failure mask, blocking would occur
+        self.run_request_without_failure(
+            501,
+            '/http/response_body_test?trigger=safe&status=410&format=html',
+            method="HEAD")
+        # Test with failure mask (bit 2 = 4)
+        self.run_request_with_failure(
+            4,
+            '/http/response_body_test?trigger=safe&status=410&format=html',
+            80,
+            method="HEAD")
+
+    def test_final_waf_task_post_failure_non_parseable_content(self):
+        """Test that final WAF task post failure prevents blocking on non-parseable response content
+           (early waf submissions)."""
+        # Test with failure mask (bit 2 = 4)
+        # Use an endpoint that returns text/plain with blocking trigger
+        self.run_request_with_failure(
+            4, '/http/response_body_test?trigger=safe&format=html&status=410',
+            80)
+
+        # Verify that without failure mask, blocking would occur
+        self.run_request_without_failure(
+            501,
+            '/http/response_body_test?trigger=safe&format=html&status=410', 80)
+
+    def test_final_waf_task_post_failure_json_output(self):
+        """Test that final WAF task post failure prevents blocking on JSON response content."""
+        # Test with failure mask (bit 2 = 4)
+        # Use an endpoint that returns JSON with blocking trigger
+        self.run_request_with_failure(
+            4, '/http/response_body_test?trigger=blo_res_bod&format=json', 80)
+
+        # Verify that without failure mask, blocking would occur
+        self.run_request_without_failure(
+            501, '/http/response_body_test?trigger=blo_res_bod&format=json',
+            80)

--- a/test/unit/json.cpp
+++ b/test/unit/json.cpp
@@ -24,7 +24,7 @@ std::optional<ddwaf_obj> parse(std::vector<std::string_view> parts,
   ddwaf_obj slot;
 
   test::ManagedChain chain{parts};
-  bool success = datadog::nginx::security::parse_body(slot, req, chain,
+  bool success = datadog::nginx::security::parse_body_req(slot, req, chain,
                                                       chain.size(), memres);
 
   if (!success) {

--- a/test/unit/urlencoded.cpp
+++ b/test/unit/urlencoded.cpp
@@ -24,8 +24,8 @@ std::optional<ddwaf_obj> parse(std::vector<std::string_view> parts,
   ddwaf_obj slot;
 
   test::ManagedChain chain{parts};
-  bool success = datadog::nginx::security::parse_body(slot, req, chain,
-                                                      chain.size(), memres);
+  bool success = datadog::nginx::security::parse_body_req(slot, req, chain,
+                                                          chain.size(), memres);
 
   if (!success) {
     return std::nullopt;


### PR DESCRIPTION
Submit response body to the WAF (if it's available and parseable). In this case, the final WAF run is delayed until enough data is gotten.

Also do some light refactoring: in security/context.cpp, move some ddwaf functionality to a new file.