### PR TITLE
Fix API Doc: swap datadog_environment and datadog_version descriptions back

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -61,7 +61,8 @@ May overwrite `DD_SERVICE` environment variable.
 - **default**: (no value)
 - **context**: `http`, `server`, `location`
 
-Set the service version to associate with each span produce by the `http` or `server` block.
+Set the name of the environment within which nginx is running. Common values
+include `prod`, `dev`, and `staging`.
 May overwrite `DD_ENV` environment variable.
 
 ### `datadog_version`
@@ -69,9 +70,7 @@ May overwrite `DD_ENV` environment variable.
 - **default**: (no value)
 - **context**: `http`, `server`, `location`
 
-Set the name of the environment within which nginx is running. Common values
-include `prod`, `dev`, and `staging`.
-
+Set the service version to associate with each span produce by the `http` or `server` block.
 May overwrite `DD_VERSION` environment variable.
 
 ### `datadog_sample_rate`


### PR DESCRIPTION
The description for datadog_environment was under datadog_version and the description for datadog_version was under datadog_environment. This PR swaps them back so they match the correct directives.