### PR TITLE
Add build job in github action

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -20,6 +20,11 @@ jobs:
       - name: checkout
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       - run: git submodule sync && git submodule update --init --recursive
+      - name: Login to Docker Hub
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: build
         run: 'make build-musl'
         env:


### PR DESCRIPTION
Use the official system-tests workflow to run system-tests

I kept the old job in circle CI because we need its artifact in system-tests repository. Once this PR is merged, I'll change the artifact source and make a second cleanup PR here.


