### PR TITLE
slo: Tighten expected throughput for nginx macrobenchmark

### DIFF
--- a/.gitlab/bp-runner.fail-on-breach.yml
+++ b/.gitlab/bp-runner.fail-on-breach.yml
@@ -11,7 +11,7 @@ experiments:
         scenarios:
           - name: high_load/only-tracing
             thresholds:
-              - throughput > 3426.8 op/s
+              - throughput > 3700 op/s
           - name: normal_operation/only-tracing
             thresholds:
               - agg_http_req_duration_p50 < 0.11617 ms


### PR DESCRIPTION
Based on our latest report, we see that throughput SLO for high_load--only-tracing can be tightened slightly to 3700 op/s to get diff between SLI and SLO to less than 20%, but more than 10% threshold. This will help to detect any issues with throughput earlier.