### PR TITLE
Adds a weekly scheduled job to the CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -367,13 +367,6 @@ parameters:
 version: 2.1
 workflows:
     build-and-test:
-        triggers:
-            - schedule:
-                cron: "0 3 * * 1"
-                filters:
-                    branches:
-                        only:
-                            - master
         jobs:
             - check-ci-definition
             - format:
@@ -507,6 +500,13 @@ workflows:
                 name: Run system tests
                 requires:
                     - build 1.25.4 on amd64 WAF ON
+        triggers:
+            - schedule:
+                cron: 0 3 * * 1
+                filters:
+                    branches:
+                        only:
+                            - master
         when:
             and:
                 - not: << pipeline.git.tag >>

--- a/.circleci/src/workflows/build-and-test.yml
+++ b/.circleci/src/workflows/build-and-test.yml
@@ -1,3 +1,10 @@
+triggers:
+    - schedule:
+        cron: "0 3 * * 1"
+        filters:
+            branches:
+                only:
+                    - master
 when:
   and:
     - not: << pipeline.git.tag >>


### PR DESCRIPTION
system-tests requires an artifact to execute test. CircleCI gots an artifact's retention period of 9 days, so if there is no activity on the repo for 9 days, one needs to manually re-run the job.

This PR automate this by adding a weekly scheduled job.