### PR TITLE
fix: http.client_ip missing in AppSec events

### DIFF
--- a/src/security/client_ip.cpp
+++ b/src/security/client_ip.cpp
@@ -578,8 +578,7 @@ std::optional<std::string> ClientIp::resolve() const {
     }
   }
 
-  // No public address found yet
-  // Try remote_addr. If it's public we'll use it
+  // No public address found yet. Try remote_addr.
   IpAddr remote_addr{};
   struct sockaddr *sockaddr = request_.connection->sockaddr;
   if (sockaddr->sa_family == AF_INET) {
@@ -591,13 +590,12 @@ std::optional<std::string> ClientIp::resolve() const {
   }
 
   if (!remote_addr.empty()) {
-    if (remote_addr.is_private()) {
-      if (cur_private.empty()) {
-        return {remote_addr.to_string()};
-      } else {
-        return {cur_private.to_string()};
-      }
+    if (!remote_addr.is_private()) {
+      return remote_addr.to_string();
     }
+    if (cur_private.empty()) {
+      return remote_addr.to_string();
+    }  // else cur_private is preferred below
   }
 
   // no remote address

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -9,7 +9,7 @@ if (NGINX_DATADOG_ASM_ENABLED)
 
     FetchContent_MakeAvailable(Catch2)
 
-    add_executable(unit_tests json.cpp multipart.cpp urlencoded.cpp test_limiter.cpp stub_nginx.c)
+    add_executable(unit_tests json.cpp multipart.cpp urlencoded.cpp test_limiter.cpp client_ip.cpp stub_nginx.c)
     add_test(NAME unit_tests COMMAND unit_tests)
     target_link_libraries(unit_tests PRIVATE ngx_http_datadog_static_lib Catch2::Catch2WithMain)
     target_compile_features(unit_tests PRIVATE cxx_std_20)

--- a/test/unit/client_ip.cpp
+++ b/test/unit/client_ip.cpp
@@ -1,0 +1,151 @@
+#include <catch2/catch_test_macros.hpp>
+#include <cstring>
+#include <vector>
+
+extern "C" {
+#include <arpa/inet.h>
+#include <ngx_config.h>
+#include <ngx_core.h>
+#include <ngx_http.h>
+}
+
+#include "security/client_ip.h"
+
+namespace dnsec = datadog::nginx::security;
+
+namespace {
+sockaddr_in create_ipv4_sockaddr(const char* ip_str) {
+  sockaddr_in addr{};
+  addr.sin_family = AF_INET;
+  inet_pton(AF_INET, ip_str, &addr.sin_addr);
+  return addr;
+}
+
+sockaddr_in6 create_ipv6_sockaddr(const char* ip_str) {
+  sockaddr_in6 addr{};
+  addr.sin6_family = AF_INET6;
+  inet_pton(AF_INET6, ip_str, &addr.sin6_addr);
+  return addr;
+}
+
+struct Address {
+  sockaddr* sockaddr_ptr;
+  sockaddr_storage sockaddr_storage;
+
+  Address(const char* ip_str, bool is_ipv6 = false) {
+    if (is_ipv6) {
+      auto addr = create_ipv6_sockaddr(ip_str);
+      std::memcpy(&sockaddr_storage, &addr, sizeof(addr));
+    } else {
+      auto addr = create_ipv4_sockaddr(ip_str);
+      std::memcpy(&sockaddr_storage, &addr, sizeof(addr));
+    }
+    sockaddr_ptr = reinterpret_cast<sockaddr*>(&sockaddr_storage);
+  }
+};
+
+struct StubRequest {
+  ngx_http_request_t request;
+  ngx_connection_t connection;
+  Address address;
+  ngx_pool_t pool;
+  std::vector<ngx_table_elt_t> headers;
+  std::vector<ngx_str_t> header_keys;
+  std::vector<ngx_str_t> header_values;
+
+  StubRequest(const char* remote_ip, bool is_ipv6 = false)
+      : request{}, connection{}, address{remote_ip, is_ipv6}, pool{} {
+    connection.sockaddr = address.sockaddr_ptr;
+    request.connection = &connection;
+    request.pool = &pool;
+
+    request.headers_in.headers.part.elts = nullptr;
+    request.headers_in.headers.part.nelts = 0;
+    request.headers_in.headers.part.next = nullptr;
+    request.headers_in.headers.last = &request.headers_in.headers.part;
+    request.headers_in.headers.pool = &pool;
+  }
+
+  void add_header(const char* key, const char* value) {
+    // Store the key and value strings
+    ngx_str_t key_str;
+    key_str.data = reinterpret_cast<u_char*>(const_cast<char*>(key));
+    key_str.len = std::strlen(key);
+    header_keys.push_back(key_str);
+
+    ngx_str_t value_str;
+    value_str.data = reinterpret_cast<u_char*>(const_cast<char*>(value));
+    value_str.len = std::strlen(value);
+    header_values.push_back(value_str);
+
+    ngx_table_elt_t header{};
+    header.key = header_keys.back();
+    header.value = header_values.back();
+    header.lowcase_key = header.key.data;  // same pointer for simplicity
+    header.hash = ngx_hash_key(header.lowcase_key, header.key.len);
+    headers.push_back(header);
+
+    request.headers_in.headers.part.elts = headers.data();
+    request.headers_in.headers.part.nelts = headers.size();
+  }
+};
+}  // namespace
+
+TEST_CASE("ClientIp priority: public IP in header and public remote_addr",
+          "[client_ip]") {
+  StubRequest stub("8.8.8.8");
+  stub.add_header("x-forwarded-for", "1.1.1.1");
+
+  dnsec::ClientIp client_ip(std::nullopt, stub.request);
+  auto result = client_ip.resolve();
+
+  REQUIRE(result.has_value());
+  REQUIRE(result.value() == "1.1.1.1");  // Header is preferred
+}
+
+TEST_CASE("ClientIp priority: private IP in header and public remote_addr",
+          "[client_ip]") {
+  StubRequest stub("8.8.8.8");
+  stub.add_header("x-forwarded-for", "192.168.1.1");
+
+  dnsec::ClientIp client_ip(std::nullopt, stub.request);
+  auto result = client_ip.resolve();
+
+  REQUIRE(result.has_value());
+  REQUIRE(result.value() == "8.8.8.8");  // Public remote_addr is used
+}
+
+TEST_CASE("ClientIp priority: private IP in header and private remote_addr",
+          "[client_ip]") {
+  StubRequest stub("192.168.1.100");
+  stub.add_header("x-forwarded-for", "10.0.0.5");
+
+  dnsec::ClientIp client_ip(std::nullopt, stub.request);
+  auto result = client_ip.resolve();
+
+  REQUIRE(result.has_value());
+  REQUIRE(result.value() == "10.0.0.5");  // Header is preferred
+}
+
+TEST_CASE("ClientIp fallback: only private remote_addr", "[client_ip]") {
+  StubRequest stub("192.168.1.100");
+
+  dnsec::ClientIp client_ip(std::nullopt, stub.request);
+  auto result = client_ip.resolve();
+
+  REQUIRE(result.has_value());
+  REQUIRE(result.value() == "192.168.1.100");  // Remote_addr is used
+}
+
+TEST_CASE("ClientIp fallback: only private IP in header", "[client_ip]") {
+  StubRequest stub("0.0.0.0");  // Invalid/empty remote_addr
+  // Set af to 0 to simulate no remote address
+  reinterpret_cast<sockaddr_in*>(stub.address.sockaddr_ptr)->sin_family = 0;
+  stub.add_header("x-forwarded-for", "10.0.0.5");
+
+  dnsec::ClientIp client_ip(std::nullopt, stub.request);
+  auto result = client_ip.resolve();
+
+  REQUIRE(result.has_value());
+  REQUIRE(result.value() == "10.0.0.5");  // Header is used
+}

--- a/test/unit/stub_nginx.c
+++ b/test/unit/stub_nginx.c
@@ -1,4 +1,17 @@
 #include <ngx_core.h>
+#include <string.h>
 
 void ngx_log_error_core(ngx_uint_t level, ngx_log_t *log, ngx_err_t err,
                         const char *fmt, ...) {}
+
+ngx_uint_t ngx_hash_key(u_char *data, size_t len) {
+    ngx_uint_t  i, key;
+
+    key = 0;
+
+    for (i = 0; i < len; i++) {
+        key = ngx_hash(key, data[i]);
+    }
+
+    return key;
+}


### PR DESCRIPTION
The fallback logic in ClientIp::resolve() only returned remote_addr if it was private. When remote_addr was public, it returned nullopt, so http.client_ip was never set.  Fix is to return remote_addr when it’s public; keep existing behavior for private IPs (use private fallback if no public headers exist).