### PR TITLE
Add support for Nginx 1.29.4 and 1.28.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -393,8 +393,8 @@ workflows:
                         nginx-version:
                             - 1.24.0
                             - 1.25.4
-                            - 1.28.0
-                            - 1.29.2
+                            - 1.28.1
+                            - 1.29.4
                         waf:
                             - "ON"
                             - "OFF"
@@ -430,10 +430,10 @@ workflows:
                             - amd64
                             - arm64
                         base-image:
-                            - nginx:1.28.0-alpine
-                            - nginx:1.28.0
+                            - nginx:1.28.1-alpine
+                            - nginx:1.28.1
                         nginx-version:
-                            - 1.28.0
+                            - 1.28.1
                         waf:
                             - "ON"
                             - "OFF"
@@ -447,10 +447,10 @@ workflows:
                             - amd64
                             - arm64
                         base-image:
-                            - nginx:1.29.2-alpine
-                            - nginx:1.29.2
+                            - nginx:1.29.4-alpine
+                            - nginx:1.29.4
                         nginx-version:
-                            - 1.29.2
+                            - 1.29.4
                         waf:
                             - "ON"
                             - "OFF"
@@ -629,10 +629,12 @@ workflows:
                             - 1.27.4
                             - 1.27.5
                             - 1.28.0
+                            - 1.28.1
                             - 1.29.0
                             - 1.29.1
                             - 1.29.2
                             - 1.29.3
+                            - 1.29.4
                         waf:
                             - "ON"
                             - "OFF"
@@ -668,6 +670,26 @@ workflows:
                             - amazonlinux:2023.3.20240219.0
                         nginx-version:
                             - 1.24.0
+                        waf:
+                            - "ON"
+                            - "OFF"
+                name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
+                requires:
+                    - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>
+            - test:
+                filters:
+                    tags:
+                        only: /^v.*/
+                matrix:
+                    parameters:
+                        arch:
+                            - amd64
+                            - arm64
+                        base-image:
+                            - nginx:1.29.4-alpine
+                            - nginx:1.29.4
+                        nginx-version:
+                            - 1.29.4
                         waf:
                             - "ON"
                             - "OFF"
@@ -748,6 +770,26 @@ workflows:
                             - nginx:1.29.0
                         nginx-version:
                             - 1.29.0
+                        waf:
+                            - "ON"
+                            - "OFF"
+                name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
+                requires:
+                    - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>
+            - test:
+                filters:
+                    tags:
+                        only: /^v.*/
+                matrix:
+                    parameters:
+                        arch:
+                            - amd64
+                            - arm64
+                        base-image:
+                            - nginx:1.28.1-alpine
+                            - nginx:1.28.1
+                        nginx-version:
+                            - 1.28.1
                         waf:
                             - "ON"
                             - "OFF"

--- a/.circleci/src/workflows/build-and-test-all.yml
+++ b/.circleci/src/workflows/build-and-test-all.yml
@@ -118,10 +118,12 @@
             - 1.27.4
             - 1.27.5
             - 1.28.0
+            - 1.28.1
             - 1.29.0
             - 1.29.1
             - 1.29.2
             - 1.29.3
+            - 1.29.4
             waf:
             - 'ON'
             - 'OFF'
@@ -160,6 +162,26 @@
             - amazonlinux:2023.3.20240219.0
             nginx-version:
             - 1.24.0
+        name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
+        requires:
+        - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>
+    - test:
+        filters:
+          tags:
+            only: /^v.*/
+        matrix:
+          parameters:
+            arch:
+            - amd64
+            - arm64
+            waf:
+            - 'ON'
+            - 'OFF'
+            base-image:
+            - nginx:1.29.4-alpine
+            - nginx:1.29.4
+            nginx-version:
+            - 1.29.4
         name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
         requires:
         - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>
@@ -240,6 +262,26 @@
             - nginx:1.29.0
             nginx-version:
             - 1.29.0
+        name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
+        requires:
+        - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>
+    - test:
+        filters:
+          tags:
+            only: /^v.*/
+        matrix:
+          parameters:
+            arch:
+            - amd64
+            - arm64
+            waf:
+            - 'ON'
+            - 'OFF'
+            base-image:
+            - nginx:1.28.1-alpine
+            - nginx:1.28.1
+            nginx-version:
+            - 1.28.1
         name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch >> WAF << matrix.waf >>
         requires:
         - build << matrix.nginx-version >> on << matrix.arch >> WAF << matrix.waf >>

--- a/.circleci/src/workflows/build-and-test.yml
+++ b/.circleci/src/workflows/build-and-test.yml
@@ -21,8 +21,8 @@ jobs:
         nginx-version:
         - 1.24.0
         - 1.25.4
-        - 1.28.0
-        - 1.29.2
+        - 1.28.1
+        - 1.29.4
         waf:
         - 'ON'
         - 'OFF'
@@ -61,10 +61,10 @@ jobs:
         - 'ON'
         - 'OFF'
         base-image:
-        - nginx:1.28.0-alpine
-        - nginx:1.28.0
+        - nginx:1.28.1-alpine
+        - nginx:1.28.1
         nginx-version:
-        - 1.28.0
+        - 1.28.1
     name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch
       >> WAF << matrix.waf >>
     requires:
@@ -80,10 +80,10 @@ jobs:
         - 'ON'
         - 'OFF'
         base-image:
-        - nginx:1.29.2-alpine
-        - nginx:1.29.2
+        - nginx:1.29.4-alpine
+        - nginx:1.29.4
         nginx-version:
-        - 1.29.2
+        - 1.29.4
     name: test << matrix.nginx-version >> on << matrix.base-image >>:<< matrix.arch
       >> WAF << matrix.waf >>
     requires:

--- a/bin/generate_jobs_yaml.rb
+++ b/bin/generate_jobs_yaml.rb
@@ -2,6 +2,8 @@
 
 nginx_version_table = <<-TAB
 amazonlinux:2023.3.20240219.0 1.24.0
+nginx:1.29.4-alpine 1.29.4
+nginx:1.29.4 1.29.4
 nginx:1.29.3-alpine 1.29.3
 nginx:1.29.3 1.29.3
 nginx:1.29.2-alpine 1.29.2
@@ -10,6 +12,8 @@ nginx:1.29.1-alpine 1.29.1
 nginx:1.29.1 1.29.1
 nginx:1.29.0-alpine 1.29.0
 nginx:1.29.0 1.29.0
+nginx:1.28.1-alpine 1.28.1
+nginx:1.28.1 1.28.1
 nginx:1.28.0-alpine 1.28.0
 nginx:1.28.0 1.28.0
 nginx:1.27.5-alpine 1.27.5
@@ -138,4 +142,3 @@ all_resty_specs.group_by(&:version).each do |version, specs|
       - build openresty << matrix.resty-version >> on << matrix.arch >> WAF << matrix.waf >>
   YAML
 end
-


### PR DESCRIPTION
Add support for Nginx [1.29.4](https://github.com/nginx/nginx/releases/tag/release-1.29.4) (released on December 9th 2025) and [1.28.1](https://github.com/nginx/nginx/releases/tag/release-1.28.1) (released on December 23rd 2025).