### PR TITLE
Use a local nginx_musl_toolchain Docker image for CircleCI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ NGINX_VERSION ?= $(if $(RESTY_VERSION),$(shell echo $(RESTY_VERSION) | awk -F. '
 ARCH ?= $(shell arch)
 COVERAGE ?= OFF
 BUILD_TESTING ?= ON
-DOCKER_REPOS ?= public.ecr.aws/b1o7r7e0/nginx_musl_toolchain
+DOCKER_IMAGE ?= nginx_musl_toolchain
 CIRCLE_CFG ?= .circleci/config.yml
 ifneq ($(PCRE2_PATH),)
 	CMAKE_PCRE_OPTIONS := -DCMAKE_C_FLAGS=-I$(PCRE2_PATH)/include/ -DCMAKE_CXX_FLAGS=-I$(PCRE2_PATH)/include/ -DCMAKE_LDFLAGS=-L$(PCRE2_PATH)/lib
@@ -70,20 +70,10 @@ endif
 # For testing changes to the build image
 .PHONY: build-musl-toolchain
 build-musl-toolchain:
-	docker build --progress=plain --platform $(DOCKER_PLATFORM) --build-arg ARCH=$(ARCH) -t $(DOCKER_REPOS) build_env
-
-.PHONY: build-push-musl-toolchain
-build-push-musl-toolchain:
-	docker build --progress=plain --platform linux/amd64 --build-arg ARCH=x86_64 -t $(DOCKER_REPOS):latest-amd64 build_env
-	docker push $(DOCKER_REPOS):latest-amd64
-	docker build --progress=plain --platform linux/arm64 --build-arg ARCH=aarch64 -t $(DOCKER_REPOS):latest-arm64 build_env
-	docker push $(DOCKER_REPOS):latest-arm64
-	docker buildx imagetools create -t $(DOCKER_REPOS):latest \
-		$(DOCKER_REPOS):latest-amd64 \
-		$(DOCKER_REPOS):latest-arm64
+	docker build --progress=plain --platform $(DOCKER_PLATFORM) --build-arg ARCH=$(ARCH) -t $(DOCKER_IMAGE) build_env
 
 .PHONY: build-musl build-musl-cov
-build-musl build-musl-cov:
+build-musl build-musl-cov: build-musl-toolchain
 ifndef NGINX_VERSION
 	$(error NGINX_VERSION is not set. Please set NGINX_VERSION environment variable)
 endif
@@ -97,7 +87,7 @@ endif
 		--env RUM=$(RUM) \
 		--env COVERAGE=$(COVERAGE) \
 		--mount "type=bind,source=$(dir $(lastword $(MAKEFILE_LIST))),destination=/mnt/repo" \
-		$(DOCKER_REPOS):latest \
+		$(DOCKER_IMAGE) \
 		make -C /mnt/repo $@-aux
 
 # this is what's run inside the container nginx_musl_toolchain
@@ -115,7 +105,7 @@ build-musl-aux build-musl-cov-aux:
 		$(if $(filter build-musl-cov-aux,$@),&& cmake --build .musl-build -j $(MAKE_JOB_COUNT) -v --target unit_tests)
 
 .PHONY: build-openresty
-build-openresty:
+build-openresty: build-musl-toolchain
 ifndef RESTY_VERSION
 	$(error RESTY_VERSION is not set. Please set RESTY_VERSION environment variable)
 endif
@@ -128,7 +118,7 @@ endif
 		--env NGINX_VERSION=$(NGINX_VERSION) \
 		--env WAF=$(WAF) \
 		--mount type=bind,source="$(PWD)",target=/mnt/repo \
-		$(DOCKER_REPOS):latest \
+		$(DOCKER_IMAGE) \
 		bash -c "cd /mnt/repo && ./bin/openresty/build_openresty.sh && make build-openresty-aux"
 
 .PHONY: build-openresty-aux
@@ -166,21 +156,21 @@ example-openresty: build-openresty
 	./example/openresty/bin/run
 
 .PHONY: coverage
-coverage:
+coverage: build-musl-toolchain
 	COVERAGE=ON BUILD_TESTING=ON $(MAKE) build-musl-cov
 	docker run --init --rm --platform $(DOCKER_PLATFORM) \
 		--mount "type=bind,source=$(PWD),destination=/mnt/repo" \
-		$(DOCKER_REPOS):latest \
+		$(DOCKER_IMAGE) \
 		/bin/sh -c 'cd /mnt/repo/.musl-build; LLVM_PROFILE_FILE=unit_tests.profraw test/unit/unit_tests'
 	rm -f test/coverage_data.tar.gz
 	python3 test/bin/run.py --platform $(DOCKER_PLATFORM) --image ${BASE_IMAGE} --module-path .musl-build/ngx_http_datadog_module.so -- --verbose --failfast
 	docker run --init --rm --platform $(DOCKER_PLATFORM) \
 		--mount "type=bind,source=$(PWD),destination=/mnt/repo" \
-		$(DOCKER_REPOS):latest \
+		$(DOCKER_IMAGE) \
 		tar -C /mnt/repo/.musl-build -xzf /mnt/repo/test/coverage_data.tar.gz
 	docker run --init --rm --platform $(DOCKER_PLATFORM) \
 		--mount "type=bind,source=$(PWD),destination=/mnt/repo" \
-		$(DOCKER_REPOS):latest \
+		$(DOCKER_IMAGE) \
 		bin/sh -c 'cd /mnt/repo/.musl-build; llvm-profdata merge -sparse *.profraw -o default.profdata && llvm-cov export ./ngx_http_datadog_module.so -format=lcov -instr-profile=default.profdata -ignore-filename-regex=/mnt/repo/src/coverage_fixup\.c > coverage.lcov'
 
 
@@ -197,7 +187,7 @@ circleci-config:
 	circleci config validate $(CIRCLE_CFG)
 
 .PHONY: build-ingress-nginx
-build-ingress-nginx:
+build-ingress-nginx: build-musl-toolchain
 	python3 bin/ingress_nginx.py prepare --ingress-nginx-version v$(INGRESS_NGINX_VERSION) --output nginx-controller-$(INGRESS_NGINX_VERSION)
 	docker run --init --rm \
 		--platform $(DOCKER_PLATFORM) \
@@ -207,7 +197,7 @@ build-ingress-nginx:
 		--env WAF=$(WAF) \
 		--env COVERAGE=$(COVERAGE) \
 		--mount "type=bind,source=$(PWD),destination=/mnt/repo" \
-		$(DOCKER_REPOS):latest \
+		$(DOCKER_IMAGE) \
 		make -C /mnt/repo build-musl-aux-ingress
 
 .PHONY: build-musl-aux-ingress


### PR DESCRIPTION
We used (since May 2024) to use  ad hoc `public.ecr.aws/b1o7r7e0/nginx_musl_toolchain` Docker repository, but it is no more available because it depended on a test AWS account which has been deleted.

Since there is no easy way to access another Docker repository from CircleCI, and since we are about to migrate to GitLab, here is a short term workaround: rebuild the needed Docker image in the CI wherever needed.