### PR TITLE
feat: seed root session ID in master for stable telemetry headers

### DIFF
--- a/src/datadog_conf.h
+++ b/src/datadog_conf.h
@@ -94,6 +94,7 @@ struct datadog_main_conf_t {
   // module configuration, instead we grab the values from the environment
   // of the master process and apply them later in the worker processes after
   // `fork()`.
+  std::string root_session_id;
   std::vector<environment_variable_t> environment_variables;
   // If `propagation_styles` is empty, then use the defaults instead.
   // `propagation_styles` is populated by the "datadog_propagation_styles"

--- a/src/ngx_http_datadog_module.cpp
+++ b/src/ngx_http_datadog_module.cpp
@@ -1,5 +1,7 @@
 #include "ngx_http_datadog_module.h"
 
+#include <datadog/runtime_id.h>
+
 #include <cassert>
 #include <cstdlib>
 #include <exception>
@@ -408,6 +410,7 @@ static void *create_datadog_main_conf(ngx_conf_t *conf) noexcept {
   if (register_destructor(conf->pool, main_conf)) {
     return nullptr;  // error
   }
+  main_conf->root_session_id = dd::RuntimeID::generate().string();
   return main_conf;
 }
 

--- a/src/tracing_library.cpp
+++ b/src/tracing_library.cpp
@@ -55,6 +55,10 @@ dd::Expected<dd::Tracer> TracingLibrary::make_tracer(
   config.integration_version = NGINX_VERSION;
   config.service = "nginx";
 
+  if (!nginx_conf.root_session_id.empty()) {
+    config.root_session_id = nginx_conf.root_session_id;
+  }
+
   if (nginx_conf.apm_tracing_enabled != NGX_CONF_UNSET) {
     config.tracing_enabled = {nginx_conf.apm_tracing_enabled == 1};
   }


### PR DESCRIPTION
## Summary
Seed `root_session_id` in the master process before workers fork, so all workers share the same root session ID for telemetry correlation per the Stable Service Instance Identifier RFC.

### Changes
- Add `root_session_id` field to `datadog_main_conf_t`
- Generate `RuntimeID` in `create_datadog_main_conf` (master process, pre-fork)
- Pass `root_session_id` to `TracerConfig` in `make_tracer` (worker process, post-fork)

### Dependencies
- Requires dd-trace-cpp#295 to be merged first (adds `root_session_id` to `TracerConfig`)

## Related
- dd-trace-cpp PR: https://github.com/DataDog/dd-trace-cpp/pull/295
- httpd-datadog PR: https://github.com/DataDog/httpd-datadog/pull/54
- System tests PR: https://github.com/DataDog/system-tests/pull/6510