### PR TITLE
Version 1.15.0 with support of Nginx 1.29.8 and OpenResty 1.29.2.3

### DIFF
--- a/.gitlab/build-and-test-all.yml
+++ b/.gitlab/build-and-test-all.yml
@@ -56,6 +56,7 @@ build-nginx-all:
           - "1.29.5"
           - "1.29.6"
           - "1.29.7"
+          - "1.29.8"
         WAF: ["ON", "OFF"]
 
 build-nginx-rum-all:
@@ -95,6 +96,7 @@ build-nginx-rum-all:
           - "1.29.5"
           - "1.29.6"
           - "1.29.7"
+          - "1.29.8"
         WAF: ["OFF"]
 
 build-ingress-nginx-all:
@@ -162,6 +164,7 @@ build-openresty-all:
           - "1.27.1.1"
           - "1.27.1.2"
           - "1.29.2.1"
+          - "1.29.2.3"
         WAF: ["ON", "OFF"]
 
 test-nginx-all:
@@ -295,6 +298,10 @@ test-nginx-all-bis:
         NGINX_VERSION: ["1.29.7"]
         WAF: ["ON", "OFF"]
       - ARCH: ["amd64", "arm64"]
+        BASE_IMAGE: ["nginx:1.29.8", "nginx:1.29.8-alpine"]
+        NGINX_VERSION: ["1.29.8"]
+        WAF: ["ON", "OFF"]
+      - ARCH: ["amd64", "arm64"]
         BASE_IMAGE: ["amazonlinux:2023.3.20240219.0"]
         NGINX_VERSION: ["1.24.0"]
         WAF: ["ON", "OFF"]
@@ -421,6 +428,10 @@ test-nginx-rum-all:
         BASE_IMAGE: ["nginx:1.29.7"]
         NGINX_VERSION: ["1.29.7"]
         WAF: ["OFF"]
+      - ARCH: ["amd64", "arm64"]
+        BASE_IMAGE: ["nginx:1.29.8"]
+        NGINX_VERSION: ["1.29.8"]
+        WAF: ["OFF"]
 
 test-ingress-nginx-all:
   extends:
@@ -487,4 +498,5 @@ test-openresty-all:
           - "1.27.1.1"
           - "1.27.1.2"
           - "1.29.2.1"
+          - "1.29.2.3"
         WAF: ["ON", "OFF"]

--- a/.gitlab/build-and-test-fast.yml
+++ b/.gitlab/build-and-test-fast.yml
@@ -55,6 +55,7 @@ build-nginx-fast:
         # The version used by System Tests, in
         # https://github.com/DataDog/system-tests/blob/main/utils/build/docker/cpp_nginx/nginx.Dockerfile#L3
         # must be one of the ones below (and must match the one set in .github/workflows/system-tests.yml).
+        # (This is why a latest but one version can be in build-nginx-fast but not in test-nginx-fast.)
         NGINX_VERSION:
           - "1.24.0"
           - "1.25.5"
@@ -62,6 +63,7 @@ build-nginx-fast:
           - "1.27.5"
           - "1.28.3"
           - "1.29.7"
+          - "1.29.8"
         WAF: ["ON", "OFF"]
 
 build-ingress-nginx-fast:
@@ -85,7 +87,7 @@ build-openresty-fast:
       - ARCH: ["amd64", "arm64"]
         RESTY_VERSION:
           - "1.27.1.2"
-          - "1.29.2.1"
+          - "1.29.2.3"
         WAF: ["ON", "OFF"]
 
 build-nginx-rum-fast:
@@ -101,7 +103,7 @@ build-nginx-rum-fast:
           - "1.26.3"
           - "1.27.5"
           - "1.28.3"
-          - "1.29.7"
+          - "1.29.8"
         WAF: ["OFF"]
 
 test-nginx-fast:
@@ -132,8 +134,8 @@ test-nginx-fast:
         NGINX_VERSION: ["1.28.3"]
         WAF: ["ON", "OFF"]
       - ARCH: ["amd64", "arm64"]
-        BASE_IMAGE: ["nginx:1.29.7", "nginx:1.29.7-alpine"]
-        NGINX_VERSION: ["1.29.7"]
+        BASE_IMAGE: ["nginx:1.29.8", "nginx:1.29.8-alpine"]
+        NGINX_VERSION: ["1.29.8"]
         WAF: ["ON", "OFF"]
       - ARCH: ["amd64", "arm64"]
         BASE_IMAGE: ["amazonlinux:2023.3.20240219.0"]
@@ -163,7 +165,7 @@ test-openresty-fast:
       - ARCH: ["amd64", "arm64"]
         RESTY_VERSION:
           - "1.27.1.2"
-          - "1.29.2.1"
+          - "1.29.2.3"
         WAF: ["ON", "OFF"]
 
 test-nginx-rum-fast:
@@ -194,8 +196,8 @@ test-nginx-rum-fast:
         NGINX_VERSION: ["1.28.3"]
         WAF: ["OFF"]
       - ARCH: ["amd64", "arm64"]
-        BASE_IMAGE: ["nginx:1.29.7"]
-        NGINX_VERSION: ["1.29.7"]
+        BASE_IMAGE: ["nginx:1.29.8"]
+        NGINX_VERSION: ["1.29.8"]
         WAF: ["OFF"]
 
 coverage:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 cmake_policy(SET CMP0068 NEW)
 cmake_policy(SET CMP0135 NEW)
 
-set(NGINX_DATADOG_VERSION 1.14.0)
+set(NGINX_DATADOG_VERSION 1.15.0)
 project(ngx_http_datadog_module VERSION ${NGINX_DATADOG_VERSION})
 
 option(NGINX_DATADOG_ASM_ENABLED "Build with libddwaf" ON)


### PR DESCRIPTION
Add support for latest version:

- [Nginx 1.29.8](https://github.com/nginx/nginx/releases/tag/release-1.29.8) (released on April 7th).
- [OpenResty 1.29.2.3](https://openresty.org/en/ann-1029002003.html) (released on March 25th).

Bump version to `1.15.0`.