### PR TITLE
chore(ci): use dd-sts for system-tests test optimization

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -47,9 +47,7 @@ jobs:
       DD_API_KEY: ${{ secrets.DD_API_KEY }}
       TEST_OPTIMIZATION_API_KEY: ${{ secrets.DD_API_KEY }}
     permissions:
-      contents: read
       id-token: write
-      packages: write
     with:
       library: cpp_nginx
       binaries_artifact: binaries

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -48,6 +48,7 @@ jobs:
       TEST_OPTIMIZATION_API_KEY: ${{ secrets.DD_API_KEY }}
     permissions:
       contents: read
+      id-token: write
       packages: write
     with:
       library: cpp_nginx
@@ -58,6 +59,7 @@ jobs:
       excluded_scenarios: INTEGRATIONS  # no test activated, and long warm-up
       skip_empty_scenarios: true
       push_to_test_optimization: true
+      dd_sts_policy: nginx-datadog
 
   # Ensure the main job is run to completion
   check:

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -42,7 +42,7 @@ jobs:
   main:
     needs:
     - build
-    uses:  DataDog/system-tests/.github/workflows/system-tests.yml@main
+    uses:  DataDog/system-tests/.github/workflows/system-tests.yml@1e5d6b7096279ca43ce4826fda3cc805635b63c1
     secrets:
       DD_API_KEY: ${{ secrets.DD_API_KEY }}
       TEST_OPTIMIZATION_API_KEY: ${{ secrets.DD_API_KEY }}

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -47,6 +47,7 @@ jobs:
       DD_API_KEY: ${{ secrets.DD_API_KEY }}
       TEST_OPTIMIZATION_API_KEY: ${{ secrets.DD_API_KEY }}
     permissions:
+      contents: read
       id-token: write
     with:
       library: cpp_nginx

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -59,7 +59,6 @@ jobs:
       excluded_scenarios: INTEGRATIONS  # no test activated, and long warm-up
       skip_empty_scenarios: true
       push_to_test_optimization: true
-      dd_sts_policy: nginx-datadog
 
   # Ensure the main job is run to completion
   check:

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -51,6 +51,7 @@ jobs:
       id-token: write
     with:
       library: cpp_nginx
+      ref: 1e5d6b7096279ca43ce4826fda3cc805635b63c1
       binaries_artifact: binaries
       desired_execution_time: 600  # 10 minutes
       scenarios_groups: ${{ (github.event_name == 'schedule' || github.event_name == 'push') && 'tracer_release' || 'appsec' }}


### PR DESCRIPTION
## Summary

Migrates system-tests CI to use [dd-sts](https://github.com/DataDog/dd-sts-action) for Datadog Test Optimization instead of long-lived API keys.

All repositories now share a single `system-tests` policy (see [dd-source#408172](https://github.com/DataDog/dd-source/pull/408172)) — no per-repo policy is needed.

Depends on [DataDog/system-tests#6726](https://github.com/DataDog/system-tests/pull/6726).

### Changes
- Add `id-token: write` permission to the system-tests reusable workflow call so it can obtain short-lived credentials via OIDC
- Pin system-tests to `1e5d6b709` (current `main`, pre-migration) to allow a controlled rollout: repos stay on the pre-migration workflow until their pin is explicitly updated to the post-merge SHA

## How to review

The only functional change is adding `id-token: write`. It has no effect at the pinned SHA (dd-sts is not yet used there) but will be required once each repo's pin is updated after [DataDog/system-tests#6726](https://github.com/DataDog/system-tests/pull/6726) merges.