### PR TITLE
IDMPL-350 Improve example scripts to simplify smoke tests procedure

### DIFF
--- a/example/ingress-nginx/README.md
+++ b/example/ingress-nginx/README.md
@@ -13,10 +13,11 @@ Add the `ingress-nginx` repository in your local Helm configuration:
 helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
 ```
 
-In Docker Desktop, go the 'Kubernetes' tab, and create a cluster. Then use it:
+Get a local Kubernetes cluster, then use it. For example, with Colima:
 
 ```shell
-kubectl config use-context docker-desktop
+colima start --cpu 4 --memory 16 --vm-type=vz --vz-rosetta `--kubernetes
+kubectl config use-context colima
 ```
 
 Install `ingress-nginx` (with the Datadog module):

--- a/example/ingress-nginx/README.md
+++ b/example/ingress-nginx/README.md
@@ -16,7 +16,7 @@ helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
 Get a local Kubernetes cluster, then use it. For example, with Colima:
 
 ```shell
-colima start --cpu 4 --memory 16 --vm-type=vz --vz-rosetta `--kubernetes
+colima start --cpu 4 --memory 16 --vm-type=vz --vz-rosetta --kubernetes
 kubectl config use-context colima
 ```
 

--- a/example/install_datadog_utils.sh
+++ b/example/install_datadog_utils.sh
@@ -1,8 +1,20 @@
 #!/bin/sh
 # Shared utility functions for install_datadog.sh scripts.
 
-is_installed() {
-  command -v "$1" > /dev/null 2>&1
+detect_arch() {
+  arch="$(uname -m)"
+  case "$arch" in
+      aarch64)
+        arch="arm64"
+        ;;
+      x86_64)
+        arch="amd64"
+        ;;
+      *)
+        >&2 echo "Platform ${arch} is not supported."
+        exit 1
+        ;;
+  esac
 }
 
 get_latest_release() {
@@ -12,4 +24,26 @@ get_latest_release() {
     exit 1
   fi
   echo "$tag"
+}
+
+install_packages() {
+  # Install the requested list of packages.
+  # `apt-get` (Debian, Ubuntu), `apk` (Alpine), and `yum` (Amazon Linux) are supported.
+  if is_installed apt-get; then
+      apt-get update
+      DEBIAN_FRONTEND=noninteractive apt-get install -y "$@"
+  elif is_installed apk; then
+      apk update
+      apk add "$@"
+  elif is_installed yum; then
+      yum update -y
+      yum install -y "$@"
+  else
+      >&2 printf 'Did not find a supported package manager.\n'
+      exit 3
+  fi
+}
+
+is_installed() {
+  command -v "$1" > /dev/null 2>&1
 }

--- a/example/install_datadog_utils.sh
+++ b/example/install_datadog_utils.sh
@@ -2,16 +2,16 @@
 # Shared utility functions for install_datadog.sh scripts.
 
 detect_arch() {
-  arch="$(uname -m)"
-  case "$arch" in
+  raw_arch="$(uname -m)"
+  case "$raw_arch" in
       aarch64)
-        arch="arm64"
+        echo "arm64"
         ;;
       x86_64)
-        arch="amd64"
+        echo "amd64"
         ;;
       *)
-        >&2 echo "Platform ${arch} is not supported."
+        >&2 echo "Platform ${raw_arch} is not supported."
         exit 1
         ;;
   esac

--- a/example/install_datadog_utils.sh
+++ b/example/install_datadog_utils.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# Shared utility functions for install_datadog.sh scripts.
+
+is_installed() {
+  command -v "$1" > /dev/null 2>&1
+}
+
+get_latest_release() {
+  tag=$(curl --silent --fail "https://api.github.com/repos/$1/releases/latest" | jq --raw-output .tag_name)
+  if [ -z "$tag" ] || [ "$tag" = "null" ]; then
+    >&2 echo "Failed to fetch latest release tag for $1. Check network and GitHub API rate limits."
+    exit 1
+  fi
+  echo "$tag"
+}

--- a/example/openresty/README.md
+++ b/example/openresty/README.md
@@ -28,19 +28,13 @@ export DD_API_KEY=your_api_key_here
 bin/run
 ```
 
-You can also choose which OpenResty version to run with the RESTY_VERSION environment variable:
-
-```shell
-RESTY_VERSION=1.27.1.2 bin/run
-```
-
 Then, in another shell, make HTTP or gRPC calls to the `openresty` service using
 the included command line tools:
 
 ```shell
 bin/curl http://openresty/openresty
 
-openresty lua
+openresty lua generated content
 ```
 
 See [services/openresty/nginx.conf](services/openresty/nginx.conf) for the available routes.

--- a/example/openresty/bin/run
+++ b/example/openresty/bin/run
@@ -3,28 +3,57 @@ set -e
 
 cd "$(dirname "$0")"/..
 
-if [ -z "$RESTY_VERSION" ]; then
-    export RESTY_VERSION=1.29.2.1
-fi
+DEFAULT_OPENRESTY_VERSION=1.29.2.1
 
-if [ -z "$BASE_IMAGE" ]; then
-    BASE_IMAGE="openresty/openresty:${RESTY_VERSION}-alpine"
-    export BASE_IMAGE
-fi
+usage() {
+    echo "Usage: $0 [--openresty OpenResty_version] [--nginx-datadog Nginx_Datadog_version] [--no-cache]"
+    echo "  -h, --help"
+    echo "      show this help message"
+    echo "  --openresty OpenResty_version"
+    echo "      OpenResty version (default: $DEFAULT_OPENRESTY_VERSION)"
+    echo "  --nginx-datadog Nginx_Datadog_version"
+    echo "      Nginx Datadog release tag (example: 1.0.0, default: latest one)"
+    echo "  --no-cache"
+    echo "      disable cache when building Docker images"
+}
 
-# Fail fast in case the base image is not supported.
-# For now, we only support nginx, nginx-alpine, and amazonlinux images.
-case "$BASE_IMAGE" in
-    openresty/openresty:*) ;;
-    *)
-      >&2 echo 'BASE_IMAGE value "%s" is invalid.' "$BASE_IMAGE"
-      exit 1
-      ;;
-esac
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        --openresty)
+            [ $# -ge 2 ] || { usage >&2; exit 1; }
+            OPENRESTY_VERSION="$2"
+            shift 2
+            ;;
+        --nginx-datadog)
+            [ $# -ge 2 ] || { usage >&2; exit 1; }
+            NGINX_DATADOG_VERSION="$2"
+            shift 2
+            ;;
+        --no-cache)
+            NO_CACHE=true
+            shift
+            ;;
+        *)
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+OPENRESTY_VERSION=${OPENRESTY_VERSION:-${DEFAULT_OPENRESTY_VERSION}}
+export OPENRESTY_VERSION
+export NGINX_DATADOG_VERSION
 
 if [ "$DD_API_KEY" = '' ]; then
     >&2 echo 'The environment variable DD_API_KEY must be set to a Datadog API key.'
     exit 1
 fi
 
+if [ -n "$NO_CACHE" ]; then
+    docker compose build --no-cache
+fi
 docker compose up --build --abort-on-container-exit --remove-orphans

--- a/example/openresty/docker-compose.yml
+++ b/example/openresty/docker-compose.yml
@@ -3,8 +3,8 @@ services:
   # `openresty` is an instance of openresty that has the Datadog tracing module loaded.
   openresty:
     build:
-      context: ./services/openresty
-      dockerfile: ./Dockerfile
+      context: ..
+      dockerfile: openresty/services/openresty/Dockerfile
       args:
         OPENRESTY_VERSION: ${OPENRESTY_VERSION:-}
         NGINX_DATADOG_VERSION: ${NGINX_DATADOG_VERSION:-}

--- a/example/openresty/docker-compose.yml
+++ b/example/openresty/docker-compose.yml
@@ -6,7 +6,8 @@ services:
       context: ./services/openresty
       dockerfile: ./Dockerfile
       args:
-        BASE_IMAGE: ${BASE_IMAGE}
+        OPENRESTY_VERSION: ${OPENRESTY_VERSION:-}
+        NGINX_DATADOG_VERSION: ${NGINX_DATADOG_VERSION:-}
     environment:
       - DD_AGENT_HOST=agent
     depends_on:

--- a/example/openresty/services/openresty/Dockerfile
+++ b/example/openresty/services/openresty/Dockerfile
@@ -10,10 +10,11 @@ ARG OPENRESTY_VERSION
 ENV OPENRESTY_VERSION=${OPENRESTY_VERSION}
 ARG NGINX_DATADOG_VERSION
 ENV NGINX_DATADOG_VERSION=${NGINX_DATADOG_VERSION}
-COPY ./install_datadog.sh /tmp/
+COPY ./install_datadog_utils.sh /tmp/
+COPY ./openresty/services/openresty/install_datadog.sh /tmp/
 RUN /tmp/install_datadog.sh
 
-COPY ./nginx.conf /usr/local/openresty/nginx/conf/nginx.conf
+COPY ./openresty/services/openresty/nginx.conf /usr/local/openresty/nginx/conf/nginx.conf
 
 ENTRYPOINT ["nginx"]
 CMD ["-g", "daemon off;"]

--- a/example/openresty/services/openresty/Dockerfile
+++ b/example/openresty/services/openresty/Dockerfile
@@ -1,8 +1,18 @@
-# Build an nginx container that includes the module for Datadog tracing.
-ARG BASE_IMAGE
+# Build an Nginx container that includes the module for Datadog tracing.
+# The default value for BASE_IMAGE is to silent the InvalidDefaultArgInFrom
+#   warning. Actually BASE_IMAGE is set in docker-compose.yml.
+ARG OPENRESTY_VERSION=1.29.2.1
+ARG BASE_IMAGE=openresty/openresty:${OPENRESTY_VERSION}-alpine
 FROM ${BASE_IMAGE}
 
-COPY ngx_http_datadog_module.so* /usr/local/openresty/nginx/modules
+# Install the Datadog tracing module.
+ARG OPENRESTY_VERSION
+ENV OPENRESTY_VERSION=${OPENRESTY_VERSION}
+ARG NGINX_DATADOG_VERSION
+ENV NGINX_DATADOG_VERSION=${NGINX_DATADOG_VERSION}
+COPY ./install_datadog.sh /tmp/
+RUN /tmp/install_datadog.sh
+
 COPY ./nginx.conf /usr/local/openresty/nginx/conf/nginx.conf
 
 ENTRYPOINT ["nginx"]

--- a/example/openresty/services/openresty/install_datadog.sh
+++ b/example/openresty/services/openresty/install_datadog.sh
@@ -4,18 +4,7 @@
 set -x
 set -e
 
-is_installed() {
-  command -v "$1" > /dev/null 2>&1
-}
-
-get_latest_release() {
-  tag=$(curl --silent --fail "https://api.github.com/repos/$1/releases/latest" | jq --raw-output .tag_name)
-  if [ -z "$tag" ] || [ "$tag" = "null" ]; then
-    >&2 echo "Failed to fetch latest release tag for $1. Check network and GitHub API rate limits."
-    exit 1
-  fi
-  echo "$tag"
-}
+. /tmp/install_datadog_utils.sh
 
 arch="$(uname -m)"
 case "$arch" in

--- a/example/openresty/services/openresty/install_datadog.sh
+++ b/example/openresty/services/openresty/install_datadog.sh
@@ -6,7 +6,7 @@ set -e
 
 . /tmp/install_datadog_utils.sh
 
-detect_arch
+arch=$(detect_arch)
 
 install_packages curl jq tar wget
 

--- a/example/openresty/services/openresty/install_datadog.sh
+++ b/example/openresty/services/openresty/install_datadog.sh
@@ -43,6 +43,11 @@ else
     exit 3
 fi
 
+if [ -z "$OPENRESTY_VERSION" ]; then
+  >&2 echo 'OPENRESTY_VERSION must be set (e.g. "1.29.2.1").'
+  exit 1
+fi
+
 tarball="openresty-ngx_http_datadog_module-appsec-${arch}-${OPENRESTY_VERSION}.so.tgz"
 
 repository="DataDog/nginx-datadog"

--- a/example/openresty/services/openresty/install_datadog.sh
+++ b/example/openresty/services/openresty/install_datadog.sh
@@ -6,36 +6,9 @@ set -e
 
 . /tmp/install_datadog_utils.sh
 
-arch="$(uname -m)"
-case "$arch" in
-    aarch64)
-      arch="arm64"
-      ;;
-    x86_64)
-      arch="amd64"
-      ;;
-    *)
-      >&2 echo "Platform ${arch} is not supported."
-      exit 1
-      ;;
-esac
+detect_arch
 
-# Install the command line tools needed to fetch and extract the module.
-# `apt-get` (Debian, Ubuntu), `apk` (Alpine), and `yum` (Amazon Linux) are
-# supported.
-if is_installed apt-get; then
-    apt-get update
-    DEBIAN_FRONTEND=noninteractive apt-get install -y tar wget curl jq
-elif is_installed apk; then
-    apk update
-    apk add tar wget curl jq
-elif is_installed yum; then
-    yum update -y
-    yum install -y tar wget curl jq
-else
-    >&2 printf 'Did not find a supported package manager.\n'
-    exit 3
-fi
+install_packages curl jq tar wget
 
 if [ -z "$OPENRESTY_VERSION" ]; then
   >&2 echo 'OPENRESTY_VERSION must be set (e.g. "1.29.2.1").'

--- a/example/openresty/services/openresty/install_datadog.sh
+++ b/example/openresty/services/openresty/install_datadog.sh
@@ -54,5 +54,5 @@ else
 fi
 
 wget "https://github.com/$repository/releases/download/$nginx_datadog_release_tag/$tarball"
-tar -xzf $tarball -C /usr/local/openresty/nginx/modules
-rm $tarball
+tar -xzf "$tarball" -C /usr/local/openresty/nginx/modules
+rm "$tarball"

--- a/example/openresty/services/openresty/install_datadog.sh
+++ b/example/openresty/services/openresty/install_datadog.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+# Install the Nginx Datadog module.
+
+set -x
+set -e
+
+is_installed() {
+  command -v "$1" > /dev/null 2>&1
+}
+
+get_latest_release() {
+  curl --silent "https://api.github.com/repos/$1/releases/latest" | jq --raw-output .tag_name
+}
+
+arch="$(uname -m)"
+case "$arch" in
+    aarch64)
+      arch="arm64"
+      ;;
+    x86_64)
+      arch="amd64"
+      ;;
+    *)
+      >&2 echo "Platform ${arch} is not supported."
+      exit 1
+      ;;
+esac
+
+# Install the command line tools needed to fetch and extract the module.
+# `apt-get` (Debian, Ubuntu), `apk` (Alpine), and `yum` (Amazon Linux) are
+# supported.
+if is_installed apt-get; then
+    apt-get update
+    DEBIAN_FRONTEND=noninteractive apt-get install -y tar wget curl jq
+elif is_installed apk; then
+    apk update
+    apk add tar wget curl jq
+elif is_installed yum; then
+    yum update -y
+    yum install -y tar wget curl jq
+else
+    >&2 printf 'Did not find a supported package manager.\n'
+    exit 3
+fi
+
+tarball="openresty-ngx_http_datadog_module-appsec-${arch}-${OPENRESTY_VERSION}.so.tgz"
+
+repository="DataDog/nginx-datadog"
+
+if [ -n "$NGINX_DATADOG_VERSION" ]; then
+  nginx_datadog_release_tag="v${NGINX_DATADOG_VERSION}"
+else
+  nginx_datadog_release_tag=$(get_latest_release $repository)
+fi
+
+wget "https://github.com/$repository/releases/download/$nginx_datadog_release_tag/$tarball"
+tar -xzf $tarball -C /usr/local/openresty/nginx/modules
+rm $tarball

--- a/example/openresty/services/openresty/install_datadog.sh
+++ b/example/openresty/services/openresty/install_datadog.sh
@@ -50,7 +50,7 @@ repository="DataDog/nginx-datadog"
 if [ -n "$NGINX_DATADOG_VERSION" ]; then
   nginx_datadog_release_tag="v${NGINX_DATADOG_VERSION}"
 else
-  nginx_datadog_release_tag=$(get_latest_release $repository)
+  nginx_datadog_release_tag=$(get_latest_release "$repository")
 fi
 
 wget "https://github.com/$repository/releases/download/$nginx_datadog_release_tag/$tarball"

--- a/example/openresty/services/openresty/install_datadog.sh
+++ b/example/openresty/services/openresty/install_datadog.sh
@@ -9,7 +9,12 @@ is_installed() {
 }
 
 get_latest_release() {
-  curl --silent "https://api.github.com/repos/$1/releases/latest" | jq --raw-output .tag_name
+  tag=$(curl --silent --fail "https://api.github.com/repos/$1/releases/latest" | jq --raw-output .tag_name)
+  if [ -z "$tag" ] || [ "$tag" = "null" ]; then
+    >&2 echo "Failed to fetch latest release tag for $1. Check network and GitHub API rate limits."
+    exit 1
+  fi
+  echo "$tag"
 }
 
 arch="$(uname -m)"

--- a/example/tracing/bin/run
+++ b/example/tracing/bin/run
@@ -3,8 +3,52 @@ set -e
 
 cd "$(dirname "$0")"/..
 
-BASE_IMAGE="${BASE_IMAGE:-nginx:1.29.7-alpine}"
+DEFAULT_NGINX_VERSION=1.29.7
+
+usage() {
+    echo "Usage: $0 [--nginx Nginx_version] [--nginx-datadog Nginx_Datadog_version] [--no-cache]"
+    echo "  -h, --help"
+    echo "      show this help message"
+    echo "  --nginx Nginx_version"
+    echo "      Nginx version (default: $DEFAULT_NGINX_VERSION)"
+    echo "  --nginx-datadog Nginx_Datadog_version"
+    echo "      Nginx Datadog release tag (example: 1.0.0, default: latest one)"
+    echo "  --no-cache"
+    echo "      disable cache when building Docker images"
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        --nginx)
+            [ $# -ge 2 ] || { usage >&2; exit 1; }
+            NGINX_VERSION="$2"
+            shift 2
+            ;;
+        --nginx-datadog)
+            [ $# -ge 2 ] || { usage >&2; exit 1; }
+            NGINX_DATADOG_VERSION="$2"
+            shift 2
+            ;;
+        --no-cache)
+            NO_CACHE=true
+            shift
+            ;;
+        *)
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+NGINX_VERSION=${NGINX_VERSION:-${DEFAULT_NGINX_VERSION}}
+export NGINX_VERSION
+BASE_IMAGE=${BASE_IMAGE:-nginx:${NGINX_VERSION}-alpine}
 export BASE_IMAGE
+export NGINX_DATADOG_VERSION
 
 # Fail fast in case the base image is not supported.
 # For now, we only support nginx, nginx-alpine, and amazonlinux images.
@@ -22,4 +66,7 @@ if [ "$DD_API_KEY" = '' ]; then
     exit 1
 fi
 
+if [ -n "$NO_CACHE" ]; then
+    docker compose build --no-cache
+fi
 docker compose up --build --abort-on-container-exit --remove-orphans

--- a/example/tracing/docker-compose.yml
+++ b/example/tracing/docker-compose.yml
@@ -6,8 +6,8 @@ services:
       context: ./services/nginx
       dockerfile: ./Dockerfile
       args:
-        BASE_IMAGE: ${BASE_IMAGE}
-        NGINX_DATADOG_VERSION: ${NGINX_DATADOG_VERSION}
+        BASE_IMAGE: ${BASE_IMAGE:-}
+        NGINX_DATADOG_VERSION: ${NGINX_DATADOG_VERSION:-}
     environment:
       - DD_AGENT_HOST=agent
     depends_on:

--- a/example/tracing/docker-compose.yml
+++ b/example/tracing/docker-compose.yml
@@ -3,8 +3,8 @@ services:
   # `nginx` is an instance of nginx that has the Datadog tracing module loaded.
   nginx:
     build:
-      context: ./services/nginx
-      dockerfile: ./Dockerfile
+      context: ..
+      dockerfile: tracing/services/nginx/Dockerfile
       args:
         BASE_IMAGE: ${BASE_IMAGE:-}
         NGINX_DATADOG_VERSION: ${NGINX_DATADOG_VERSION:-}

--- a/example/tracing/docker-compose.yml
+++ b/example/tracing/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       dockerfile: ./Dockerfile
       args:
         BASE_IMAGE: ${BASE_IMAGE}
+        NGINX_DATADOG_VERSION: ${NGINX_DATADOG_VERSION}
     environment:
       - DD_AGENT_HOST=agent
     depends_on:

--- a/example/tracing/services/nginx/Dockerfile
+++ b/example/tracing/services/nginx/Dockerfile
@@ -1,4 +1,4 @@
-# Build an nginx container that includes the module for Datadog tracing.
+# Build an Nginx container that includes the module for Datadog tracing.
 # The default value for BASE_IMAGE is to silent the InvalidDefaultArgInFrom
 #   warning. Actually BASE_IMAGE is set in docker-compose.yml.
 ARG BASE_IMAGE=nginx:1.29.7-alpine

--- a/example/tracing/services/nginx/Dockerfile
+++ b/example/tracing/services/nginx/Dockerfile
@@ -5,14 +5,15 @@ ARG BASE_IMAGE=nginx:1.29.7-alpine
 FROM ${BASE_IMAGE}
 
 # Install the Datadog tracing module.
-COPY ./install_datadog.sh /tmp/
+COPY ./install_datadog_utils.sh /tmp/
+COPY ./tracing/services/nginx/install_datadog.sh /tmp/
 ARG BASE_IMAGE
 ENV BASE_IMAGE=${BASE_IMAGE}
 ARG NGINX_DATADOG_VERSION
 ENV NGINX_DATADOG_VERSION=${NGINX_DATADOG_VERSION}
 RUN /tmp/install_datadog.sh
 
-COPY ./nginx.conf /etc/nginx/nginx.conf
+COPY ./tracing/services/nginx/nginx.conf /etc/nginx/nginx.conf
 
 ENTRYPOINT ["nginx"]
 CMD ["-g", "daemon off;"]

--- a/example/tracing/services/nginx/Dockerfile
+++ b/example/tracing/services/nginx/Dockerfile
@@ -8,6 +8,8 @@ FROM ${BASE_IMAGE}
 COPY ./install_datadog.sh /tmp/
 ARG BASE_IMAGE
 ENV BASE_IMAGE=${BASE_IMAGE}
+ARG NGINX_DATADOG_VERSION
+ENV NGINX_DATADOG_VERSION=${NGINX_DATADOG_VERSION}
 RUN /tmp/install_datadog.sh
 
 COPY ./nginx.conf /etc/nginx/nginx.conf

--- a/example/tracing/services/nginx/install_datadog.sh
+++ b/example/tracing/services/nginx/install_datadog.sh
@@ -4,13 +4,7 @@
 set -x
 set -e
 
-is_installed() {
-  command -v "$1" > /dev/null 2>&1
-}
-
-get_latest_release() {
-  curl --silent "https://api.github.com/repos/$1/releases/latest" | jq --raw-output .tag_name
-}
+. /tmp/install_datadog_utils.sh
 
 get_nginx_version() {
   if ! is_installed nginx; then

--- a/example/tracing/services/nginx/install_datadog.sh
+++ b/example/tracing/services/nginx/install_datadog.sh
@@ -106,5 +106,5 @@ else
 fi
 
 wget "https://github.com/$repository/releases/download/$nginx_datadog_release_tag/$tarball"
-tar -xzf $tarball -C $nginx_modules_path
-rm $tarball
+tar -xzf "$tarball" -C $nginx_modules_path
+rm "$tarball"

--- a/example/tracing/services/nginx/install_datadog.sh
+++ b/example/tracing/services/nginx/install_datadog.sh
@@ -106,5 +106,5 @@ else
 fi
 
 wget "https://github.com/$repository/releases/download/$nginx_datadog_release_tag/$tarball"
-tar -xzf "$tarball" -C $nginx_modules_path
+tar -xzf "$tarball" -C "$nginx_modules_path"
 rm "$tarball"

--- a/example/tracing/services/nginx/install_datadog.sh
+++ b/example/tracing/services/nginx/install_datadog.sh
@@ -34,7 +34,7 @@ case "$BASE_IMAGE" in
       ;;
 esac
 
-detect_arch
+arch=$(detect_arch)
 
 install_packages curl jq tar wget
 

--- a/example/tracing/services/nginx/install_datadog.sh
+++ b/example/tracing/services/nginx/install_datadog.sh
@@ -102,7 +102,7 @@ repository="DataDog/nginx-datadog"
 if [ -n "$NGINX_DATADOG_VERSION" ]; then
   nginx_datadog_release_tag="v${NGINX_DATADOG_VERSION}"
 else
-  nginx_datadog_release_tag=$(get_latest_release $repository)
+  nginx_datadog_release_tag=$(get_latest_release "$repository")
 fi
 
 wget "https://github.com/$repository/releases/download/$nginx_datadog_release_tag/$tarball"

--- a/example/tracing/services/nginx/install_datadog.sh
+++ b/example/tracing/services/nginx/install_datadog.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Set up the nginx container image. Install nginx, if necessary, and install the nginx-datadog module.
+# Set up the Nginx container image. Install Nginx, if necessary, and install the Nginx Datadog module.
 
 set -x
 set -e
@@ -40,16 +40,16 @@ case "$BASE_IMAGE" in
       ;;
 esac
 
-ARCH="$(uname -m)"
-case "$ARCH" in
+arch="$(uname -m)"
+case "$arch" in
     aarch64)
-      ARCH="arm64"
+      arch="arm64"
       ;;
     x86_64)
-      ARCH="amd64"
+      arch="amd64"
       ;;
     *)
-      >&2 echo "Platform ${BASE_IMAGE}-${ARCH} is not supported."
+      >&2 echo "Platform ${BASE_IMAGE}-${arch} is not supported."
       exit 1
       ;;
 esac
@@ -94,18 +94,17 @@ if ! is_installed nginx; then
   fi
 fi
 
+nginx_version=$(get_nginx_version)
+tarball="ngx_http_datadog_module-appsec-${arch}-${nginx_version}.so.tgz"
 
-NGINX_VERSION=$(get_nginx_version)
-tarball="ngx_http_datadog_module-appsec-${ARCH}-${NGINX_VERSION}.so.tgz"
-
-REPOSITORY="DataDog/nginx-datadog"
+repository="DataDog/nginx-datadog"
 
 if [ -n "$NGINX_DATADOG_VERSION" ]; then
-  NGINX_DATADOG_RELEASE_TAG="v${NGINX_DATADOG_VERSION}"
+  nginx_datadog_release_tag="v${NGINX_DATADOG_VERSION}"
 else
-  NGINX_DATADOG_RELEASE_TAG=$(get_latest_release $REPOSITORY)
+  nginx_datadog_release_tag=$(get_latest_release $repository)
 fi
 
-wget "https://github.com/$REPOSITORY/releases/download/$NGINX_DATADOG_RELEASE_TAG/$tarball"
+wget "https://github.com/$repository/releases/download/$nginx_datadog_release_tag/$tarball"
 tar -xzf $tarball -C $nginx_modules_path
 rm $tarball

--- a/example/tracing/services/nginx/install_datadog.sh
+++ b/example/tracing/services/nginx/install_datadog.sh
@@ -34,58 +34,19 @@ case "$BASE_IMAGE" in
       ;;
 esac
 
-arch="$(uname -m)"
-case "$arch" in
-    aarch64)
-      arch="arm64"
-      ;;
-    x86_64)
-      arch="amd64"
-      ;;
-    *)
-      >&2 echo "Platform ${BASE_IMAGE}-${arch} is not supported."
-      exit 1
-      ;;
-esac
+detect_arch
 
-# Install the command line tools needed to fetch and extract the module.
-# `apt-get` (Debian, Ubuntu), `apk` (Alpine), and `yum` (Amazon Linux) are
-# supported.
-if is_installed apt-get; then
-    apt-get update
-    DEBIAN_FRONTEND=noninteractive apt-get install -y tar wget curl jq
-elif is_installed apk; then
-    apk update
-    apk add tar wget curl jq
-elif is_installed yum; then
-    yum update -y
-    yum install -y tar wget curl jq
-else
-    >&2 printf 'Did not find a supported package manager.\n'
-    exit 3
-fi
+install_packages curl jq tar wget
 
 # If nginx itself is not installed already, then install it.
 if ! is_installed nginx; then
-  if is_installed apt-get; then
-      apt-get update
-      DEBIAN_FRONTEND=noninteractive apt-get install -y nginx
-  elif is_installed apk; then
-      apk update
-      apk add nginx
-  elif is_installed yum; then
-      yum update -y
-      # Older versions of Amazon Linux needed "amazon-linux-extras" in order to
-      # install nginx. Newer versions of Amazon Linux don't have
-      # "amazon-linux-extras".
-      if >/dev/null command -v amazon-linux-extras; then
-          amazon-linux-extras enable -y nginx1
-      fi
-      yum install -y nginx
-  else
-      >&2 printf 'Did not find a supported package manager.\n'
-      exit 2
+  # Older versions of Amazon Linux needed "amazon-linux-extras" in order to
+  # install nginx. Newer versions of Amazon Linux don't have
+  # "amazon-linux-extras".
+  if is_installed yum && >/dev/null command -v amazon-linux-extras; then
+      amazon-linux-extras enable -y nginx1
   fi
+  install_packages nginx
 fi
 
 nginx_version=$(get_nginx_version)

--- a/example/tracing/services/nginx/install_datadog.sh
+++ b/example/tracing/services/nginx/install_datadog.sh
@@ -17,7 +17,6 @@ get_nginx_version() {
     >&2 echo 'Could not execute nginx binary'
     exit 1
   fi
-
   nginx -version 2>&1 | sed 's@.*/@@'
 }
 
@@ -95,10 +94,18 @@ if ! is_installed nginx; then
   fi
 fi
 
-RELEASE_TAG=$(get_latest_release DataDog/nginx-datadog)
+
 NGINX_VERSION=$(get_nginx_version)
 tarball="ngx_http_datadog_module-appsec-${ARCH}-${NGINX_VERSION}.so.tgz"
 
-wget "https://github.com/DataDog/nginx-datadog/releases/download/$RELEASE_TAG/$tarball"
-tar -xzf "$tarball" -C "$nginx_modules_path"
-rm "$tarball"
+REPOSITORY="DataDog/nginx-datadog"
+
+if [ -n "$NGINX_DATADOG_VERSION" ]; then
+  NGINX_DATADOG_RELEASE_TAG="v${NGINX_DATADOG_VERSION}"
+else
+  NGINX_DATADOG_RELEASE_TAG=$(get_latest_release $REPOSITORY)
+fi
+
+wget "https://github.com/$REPOSITORY/releases/download/$NGINX_DATADOG_RELEASE_TAG/$tarball"
+tar -xzf $tarball -C $nginx_modules_path
+rm $tarball


### PR DESCRIPTION
To simplify the procedure to run smoke tests (see [internal documentation](https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/6059131694/Delivery+Nginx+Module#Run-Smoke-Tests)):

- Tracing (vanilla Nginx): In the `run` script, add options to dynamically set the Nginx and the Nginx Datadog versions.
- OpenResty:
  - Add a script to download the Datadog module (as done in Tracing).
  -  In the `run` script, add options to dynamically set the OpenResty and the Nginx Datadog versions.
- Ingress Nginx: only amend the smoke tests procedure (linked above).