### PR TITLE
Add support for Nginx 1.30.0

### DIFF
--- a/.gitlab/build-and-test-all.yml
+++ b/.gitlab/build-and-test-all.yml
@@ -57,6 +57,7 @@ build-nginx-all:
           - "1.29.6"
           - "1.29.7"
           - "1.29.8"
+          - "1.30.0"
         WAF: ["ON", "OFF"]
 
 build-nginx-rum-all:
@@ -97,6 +98,7 @@ build-nginx-rum-all:
           - "1.29.6"
           - "1.29.7"
           - "1.29.8"
+          - "1.30.0"
         WAF: ["OFF"]
 
 build-ingress-nginx-all:
@@ -302,6 +304,10 @@ test-nginx-all-bis:
         NGINX_VERSION: ["1.29.8"]
         WAF: ["ON", "OFF"]
       - ARCH: ["amd64", "arm64"]
+        BASE_IMAGE: ["nginx:1.30.0", "nginx:1.30.0-alpine"]
+        NGINX_VERSION: ["1.30.0"]
+        WAF: ["ON", "OFF"]
+      - ARCH: ["amd64", "arm64"]
         BASE_IMAGE: ["amazonlinux:2023.3.20240219.0"]
         NGINX_VERSION: ["1.24.0"]
         WAF: ["ON", "OFF"]
@@ -431,6 +437,10 @@ test-nginx-rum-all:
       - ARCH: ["amd64", "arm64"]
         BASE_IMAGE: ["nginx:1.29.8"]
         NGINX_VERSION: ["1.29.8"]
+        WAF: ["OFF"]
+      - ARCH: ["amd64", "arm64"]
+        BASE_IMAGE: ["nginx:1.30.0"]
+        NGINX_VERSION: ["1.30.0"]
         WAF: ["OFF"]
 
 test-ingress-nginx-all:

--- a/.gitlab/build-and-test-fast.yml
+++ b/.gitlab/build-and-test-fast.yml
@@ -63,6 +63,7 @@ build-nginx-fast:
           - "1.27.5"
           - "1.28.3"
           - "1.29.8"
+          - "1.30.0"
         WAF: ["ON", "OFF"]
 
 build-ingress-nginx-fast:
@@ -103,6 +104,7 @@ build-nginx-rum-fast:
           - "1.27.5"
           - "1.28.3"
           - "1.29.8"
+          - "1.30.0"
         WAF: ["OFF"]
 
 test-nginx-fast:
@@ -135,6 +137,10 @@ test-nginx-fast:
       - ARCH: ["amd64", "arm64"]
         BASE_IMAGE: ["nginx:1.29.8", "nginx:1.29.8-alpine"]
         NGINX_VERSION: ["1.29.8"]
+        WAF: ["ON", "OFF"]
+      - ARCH: ["amd64", "arm64"]
+        BASE_IMAGE: ["nginx:1.30.0", "nginx:1.30.0-alpine"]
+        NGINX_VERSION: ["1.30.0"]
         WAF: ["ON", "OFF"]
       - ARCH: ["amd64", "arm64"]
         BASE_IMAGE: ["amazonlinux:2023.3.20240219.0"]
@@ -197,6 +203,10 @@ test-nginx-rum-fast:
       - ARCH: ["amd64", "arm64"]
         BASE_IMAGE: ["nginx:1.29.8"]
         NGINX_VERSION: ["1.29.8"]
+        WAF: ["OFF"]
+      - ARCH: ["amd64", "arm64"]
+        BASE_IMAGE: ["nginx:1.30.0"]
+        NGINX_VERSION: ["1.30.0"]
         WAF: ["OFF"]
 
 coverage:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 cmake_policy(SET CMP0068 NEW)
 cmake_policy(SET CMP0135 NEW)
 
-set(NGINX_DATADOG_VERSION 1.15.0)
+set(NGINX_DATADOG_VERSION 1.16.0)
 project(ngx_http_datadog_module VERSION ${NGINX_DATADOG_VERSION})
 
 option(NGINX_DATADOG_ASM_ENABLED "Build with libddwaf" ON)


### PR DESCRIPTION
- Add support for [Nginx 1.30.0](https://github.com/nginx/nginx/releases/tag/release-1.30.0).
- Bump version to `1.16.0`.