### PR TITLE
Strip v prefix from OCI package version

### DIFF
--- a/.gitlab/ssi-package.yml
+++ b/.gitlab/ssi-package.yml
@@ -20,6 +20,7 @@
   script:
     - set -euo pipefail
     - VERSION="${CI_COMMIT_TAG:-0.0.1-${CI_COMMIT_SHORT_SHA}}"
+    - VERSION="${VERSION#v}"
     - OUTPUT="artifacts/ssi-sources/${ARCH}"
     - mkdir -p "${OUTPUT}"
     - |


### PR DESCRIPTION
## Summary
- Strip the `v` prefix from `CI_COMMIT_TAG` before writing it to the OCI version file
- Fixes `promote-oci-to-prod` failures where `agent-release-management` rejects versions like `v1.16.0-1` because its `version_check.py` requires versions to start with a digit (e.g. `1.16.0-1`)

## Failing pipelines
- [promote-oci-to-prod job 1596723874](https://gitlab.ddbuild.io/DataDog/apm-reliability/nginx-datadog/-/jobs/1596723874) — API rejects `RELEASE_VERSION "v1.16.0-1"`


## Change
```diff
- VERSION="${CI_COMMIT_TAG:-0.0.1-${CI_COMMIT_SHORT_SHA}}"
+ VERSION="${CI_COMMIT_TAG:-0.0.1-${CI_COMMIT_SHORT_SHA}}"
+ VERSION="${VERSION#v}"
```

Keeps the original default fallback for non-tag pipelines, then strips any leading `v`.

## Test plan
- [ ] Verify non-tag pipelines still get `0.0.1-<sha>` as version
- [ ] Verify tag pipelines (e.g. `v1.16.0`) produce `1.16.0` in the version file
- [ ] Re-run promote-oci-to-prod after merge to confirm it passes