### PR TITLE
Amend benchmark threshold

### DIFF
--- a/.gitlab/bp-runner.fail-on-breach.yml
+++ b/.gitlab/bp-runner.fail-on-breach.yml
@@ -1,17 +1,16 @@
-# Measurements from https://benchmarking.us1.prod.dog/benchmarks?projectId=8&page=1&ciJobDateStart=1746954906962&ciJobDateEnd=1749546906962&benchmarkGroupPipelineId=67348573&benchmarkGroupSha=9eb1ba2051efb90b557655c4deca14ab1312f22b
-
-# Thresholds set based on guidance in https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/5070193198/How+to+set+up+pre-release+performance+quality+gates#How-to-choose-thresholds-for-pre-release-gates%3F
+# Measurements from: https://benchmarking.us1.prod.dog/benchmarks?projectId=8
+# Thresholds guidance: https://datadoghq.atlassian.net/wiki/x/LgI1LgE
 
 experiments:
   - name: Run SLO breach check
     steps:
       - name: SLO breach check
         run: fail_on_breach
-        warning_range: 7
+        warning_range: 2
         scenarios:
           - name: high_load/only-tracing
             thresholds:
               - throughput > 3700 op/s
           - name: normal_operation/only-tracing
             thresholds:
-              - agg_http_req_duration_p50 < 0.11617 ms
+              - agg_http_req_duration_p50 < 0.116 ms

--- a/.gitlab/bp-runner.fail-on-breach.yml
+++ b/.gitlab/bp-runner.fail-on-breach.yml
@@ -6,7 +6,7 @@ experiments:
     steps:
       - name: SLO breach check
         run: fail_on_breach
-        warning_range: 2
+        warning_range: 7
         scenarios:
           - name: high_load/only-tracing
             thresholds:
@@ -14,3 +14,4 @@ experiments:
           - name: normal_operation/only-tracing
             thresholds:
               - agg_http_req_duration_p50 < 0.116 ms
+                warning_range: 2


### PR DESCRIPTION
From the [Benchmarking Platform | C++ dashboard](https://ddstaging.datadoghq.com/dashboard/uc8-pup-pkt), one can see that the average p50 latency for the `normal_operation/only-tracing` benchmark tests [used to be 103.8 μs](https://ddstaging.datadoghq.com/dashboard/uc8-pup-pkt?fromUser=true&refresh_mode=paused&from_ts=1767225600000&to_ts=1774715189212&live=false), and [is now 111.7 μs](https://ddstaging.datadoghq.com/dashboard/uc8-pup-pkt?fromUser=true&refresh_mode=paused&from_ts=1774928754279&to_ts=1775746634000&live=false) (since March 31st).

There was definitively no code change at that time, so this drift comes from the platform.

Moreover, this 10% bump is also present in the baseline (without instrumentation):
<img width="481" height="276" alt="image" src="https://github.com/user-attachments/assets/fe2acbae-6010-46b5-b5a0-6c518abceb21" />

So we computed new thresholds, following the n [How to set up pre-release performance quality gates? - How to choose thresholds and warning ranges?](https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/5070193198/How+to+set+up+pre-release+performance+quality+gates#How-to-choose-thresholds-and-warning-ranges?) documentation.