### PR TITLE
ci: upload RUM nginx module snapshots to S3

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,6 +28,7 @@ stages:
   - build-all
   - test-all
   - assemble
+  - aws
   - shared-pipeline
   - benchmarks
 

--- a/.gitlab/build-and-test-fast.yml
+++ b/.gitlab/build-and-test-fast.yml
@@ -283,7 +283,7 @@ upload-rum-snapshots:
 upload-rum-snapshots-latest:
   extends: .upload-rum-snapshot-template
   variables:
-    S3_PATH: s3://rum-auto-instrumentation/nginx/snapshots/latest
+    S3_PATH: s3://rum-auto-instrumentation/nginx/latest
   rules:
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
 

--- a/.gitlab/build-and-test-fast.yml
+++ b/.gitlab/build-and-test-fast.yml
@@ -99,10 +99,34 @@ build-nginx-rum-fast:
       - ARCH: ["amd64", "arm64"]
         NGINX_VERSION:
           - "1.24.0"
+          - "1.25.0"
+          - "1.25.1"
+          - "1.25.2"
+          - "1.25.3"
+          - "1.25.4"
           - "1.25.5"
+          - "1.26.0"
+          - "1.26.1"
+          - "1.26.2"
           - "1.26.3"
+          - "1.27.0"
+          - "1.27.1"
+          - "1.27.2"
+          - "1.27.3"
+          - "1.27.4"
           - "1.27.5"
+          - "1.28.0"
+          - "1.28.1"
+          - "1.28.2"
           - "1.28.3"
+          - "1.29.0"
+          - "1.29.1"
+          - "1.29.2"
+          - "1.29.3"
+          - "1.29.4"
+          - "1.29.5"
+          - "1.29.6"
+          - "1.29.7"
           - "1.29.8"
           - "1.30.0"
         WAF: ["OFF"]
@@ -221,3 +245,77 @@ coverage:
   tags: ["docker-in-docker:$ARCH"]
   script:
     - DD_API_KEY=$(vault kv get -field key kv/k8s/gitlab-runner/nginx-datadog/datadoghq-api-key 2>/dev/null) make coverage
+
+.upload-rum-snapshot-template:
+  stage: aws
+  # Don't put 'needs: [build-nginx-rum-fast]', because it would exceed the maximum number of jobs allowed as a dependency (50).
+  # Stage ordering (build-and-test-fast → assemble → aws) guarantees the build-nginx-rum-fast artifacts (including upload/) are available.
+  tags: ["arch:amd64"]
+  image: registry.ddbuild.io/images/aws-cli:2.33.12
+  script:
+    - aws s3 cp upload/ "${S3_PATH}/" --recursive --acl public-read
+    - echo "Uploaded to ${S3_PATH}/"
+  after_script:
+    - |
+      PUBLIC_URL=$(echo "${S3_PATH}" | sed 's|s3://\([^/]*\)/|https://\1.s3.amazonaws.com/|')
+      echo "Public URLs:"
+      for f in upload/*; do
+        echo "  ${PUBLIC_URL}/$(basename "$f")"
+      done
+      for f in upload/*; do
+        curl -sSfI "${PUBLIC_URL}/$(basename "$f")" && echo "  $(basename "$f") verified" || echo "  $(basename "$f") not accessible"
+      done
+
+upload-rum-branch-snapshots:
+  extends: .upload-rum-snapshot-template
+  variables:
+    S3_PATH: s3://rum-auto-instrumentation/nginx/branch-snapshots/pipeline-${CI_PIPELINE_ID}
+  rules:
+    - if: $CI_COMMIT_BRANCH != $CI_DEFAULT_BRANCH
+
+upload-rum-snapshots:
+  extends: .upload-rum-snapshot-template
+  variables:
+    S3_PATH: s3://rum-auto-instrumentation/nginx/snapshots/pipeline-${CI_PIPELINE_ID}
+  rules:
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+
+upload-rum-snapshots-latest:
+  extends: .upload-rum-snapshot-template
+  variables:
+    S3_PATH: s3://rum-auto-instrumentation/nginx/snapshots/latest
+  rules:
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+
+configure-rum-branch-snapshot-expiry:
+  stage: aws
+  tags: ["arch:amd64"]
+  image: registry.ddbuild.io/images/aws-cli:2.33.12
+  script:
+    - |
+      BUCKET=rum-auto-instrumentation
+      RULE_ID=expire-nginx-branch-snapshots
+
+      # Fetch existing lifecycle config (empty array if none)
+      EXISTING=$(aws s3api get-bucket-lifecycle-configuration --bucket "$BUCKET" 2>/dev/null | jq '.Rules // []' || echo '[]')
+
+      # Build the desired rule
+      RULE=$(jq -n '{
+        ID: $id,
+        Filter: { Prefix: "nginx/branch-snapshots/" },
+        Status: "Enabled",
+        Expiration: { Days: 30 }
+      }' --arg id "$RULE_ID")
+
+      # Replace existing rule with same ID, or append
+      UPDATED=$(echo "$EXISTING" | jq --argjson rule "$RULE" '
+        [.[] | select(.ID != $rule.ID)] + [$rule]
+      ')
+
+      aws s3api put-bucket-lifecycle-configuration \
+        --bucket "$BUCKET" \
+        --lifecycle-configuration "{\"Rules\": $UPDATED}"
+
+      echo "Lifecycle rule '$RULE_ID' configured: expire nginx/branch-snapshots/ after 30 days"
+  rules:
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH

--- a/.gitlab/build-and-test-fast.yml
+++ b/.gitlab/build-and-test-fast.yml
@@ -280,6 +280,13 @@ upload-rum-snapshots:
   rules:
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
 
+upload-rum-snapshots-latest:
+  extends: .upload-rum-snapshot-template
+  variables:
+    S3_PATH: s3://rum-auto-instrumentation/nginx/snapshots/latest
+  rules:
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+
 configure-rum-branch-snapshot-expiry:
   stage: aws
   tags: ["arch:amd64"]

--- a/.gitlab/build-and-test-fast.yml
+++ b/.gitlab/build-and-test-fast.yml
@@ -99,34 +99,10 @@ build-nginx-rum-fast:
       - ARCH: ["amd64", "arm64"]
         NGINX_VERSION:
           - "1.24.0"
-          - "1.25.0"
-          - "1.25.1"
-          - "1.25.2"
-          - "1.25.3"
-          - "1.25.4"
           - "1.25.5"
-          - "1.26.0"
-          - "1.26.1"
-          - "1.26.2"
           - "1.26.3"
-          - "1.27.0"
-          - "1.27.1"
-          - "1.27.2"
-          - "1.27.3"
-          - "1.27.4"
           - "1.27.5"
-          - "1.28.0"
-          - "1.28.1"
-          - "1.28.2"
           - "1.28.3"
-          - "1.29.0"
-          - "1.29.1"
-          - "1.29.2"
-          - "1.29.3"
-          - "1.29.4"
-          - "1.29.5"
-          - "1.29.6"
-          - "1.29.7"
           - "1.29.8"
           - "1.30.0"
         WAF: ["OFF"]
@@ -201,22 +177,7 @@ test-nginx-rum-fast:
   extends:
     - .build-and-test-fast
     - .test-nginx-rum
-  # Need only the matrix subset we test, to stay under GitLab's 50-need limit
-  # (the full build-nginx-rum-fast matrix has 62 entries).
-  needs:
-    - job: build-nginx-rum-fast
-      parallel:
-        matrix:
-          - ARCH: ["amd64", "arm64"]
-            NGINX_VERSION:
-              - "1.24.0"
-              - "1.25.5"
-              - "1.26.3"
-              - "1.27.5"
-              - "1.28.3"
-              - "1.29.8"
-              - "1.30.0"
-            WAF: ["OFF"]
+  needs: [build-nginx-rum-fast]
   parallel:
     matrix:
       - ARCH: ["amd64", "arm64"]
@@ -263,8 +224,10 @@ coverage:
 
 .upload-rum-snapshot-template:
   stage: aws
-  # Don't put 'needs: [build-nginx-rum-fast]', because it would exceed the maximum number of jobs allowed as a dependency (50).
-  # Stage ordering (build-and-test-fast → assemble → aws) guarantees the build-nginx-rum-fast artifacts (including upload/) are available.
+  needs:
+    - job: build-nginx-rum-fast
+      artifacts: true
+    - job: test-nginx-rum-fast
   tags: ["arch:amd64"]
   image: registry.ddbuild.io/images/aws-cli:2.33.12
   script:

--- a/.gitlab/build-and-test-fast.yml
+++ b/.gitlab/build-and-test-fast.yml
@@ -280,13 +280,6 @@ upload-rum-snapshots:
   rules:
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
 
-upload-rum-snapshots-latest:
-  extends: .upload-rum-snapshot-template
-  variables:
-    S3_PATH: s3://rum-auto-instrumentation/nginx/latest
-  rules:
-    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
-
 configure-rum-branch-snapshot-expiry:
   stage: aws
   tags: ["arch:amd64"]

--- a/.gitlab/build-and-test-fast.yml
+++ b/.gitlab/build-and-test-fast.yml
@@ -201,7 +201,22 @@ test-nginx-rum-fast:
   extends:
     - .build-and-test-fast
     - .test-nginx-rum
-  needs: [build-nginx-rum-fast]
+  # Need only the matrix subset we test, to stay under GitLab's 50-need limit
+  # (the full build-nginx-rum-fast matrix has 62 entries).
+  needs:
+    - job: build-nginx-rum-fast
+      parallel:
+        matrix:
+          - ARCH: ["amd64", "arm64"]
+            NGINX_VERSION:
+              - "1.24.0"
+              - "1.25.5"
+              - "1.26.3"
+              - "1.27.5"
+              - "1.28.3"
+              - "1.29.8"
+              - "1.30.0"
+            WAF: ["OFF"]
   parallel:
     matrix:
       - ARCH: ["amd64", "arm64"]
@@ -255,22 +270,27 @@ coverage:
   script:
     - aws s3 cp upload/ "${S3_PATH}/" --recursive --acl public-read
     - echo "Uploaded to ${S3_PATH}/"
-  after_script:
     - |
       PUBLIC_URL=$(echo "${S3_PATH}" | sed 's|s3://\([^/]*\)/|https://\1.s3.amazonaws.com/|')
-      echo "Public URLs:"
+      failed=0
       for f in upload/*; do
-        echo "  ${PUBLIC_URL}/$(basename "$f")"
+        url="${PUBLIC_URL}/$(basename "$f")"
+        if curl -sSfI "$url" > /dev/null; then
+          echo "  ${url} verified"
+        else
+          echo "  ${url} not accessible"
+          failed=1
+        fi
       done
-      for f in upload/*; do
-        curl -sSfI "${PUBLIC_URL}/$(basename "$f")" && echo "  $(basename "$f") verified" || echo "  $(basename "$f") not accessible"
-      done
+      [ "$failed" -eq 0 ]
 
 upload-rum-branch-snapshots:
   extends: .upload-rum-snapshot-template
   variables:
     S3_PATH: s3://rum-auto-instrumentation/nginx/branch-snapshots/pipeline-${CI_PIPELINE_ID}
   rules:
+    - if: $CI_COMMIT_TAG
+      when: never
     - if: $CI_COMMIT_BRANCH != $CI_DEFAULT_BRANCH
 
 upload-rum-snapshots:

--- a/.gitlab/common.yml
+++ b/.gitlab/common.yml
@@ -38,11 +38,13 @@ variables:
     RUM: "ON"
   script:
     - make build-musl-aux
-    - mkdir -p artifacts-rum/$ARCH/$NGINX_VERSION/$WAF
+    - mkdir -p artifacts-rum/$ARCH/$NGINX_VERSION/$WAF upload
     - cp .musl-build/ngx_http_datadog_module.so* artifacts-rum/$ARCH/$NGINX_VERSION/$WAF/
+    - (cd artifacts-rum/$ARCH/$NGINX_VERSION/$WAF && zip "$CI_PROJECT_DIR/upload/ngx_http_datadog_module-${NGINX_VERSION}-${ARCH}.zip" ngx_http_datadog_module.so)
   artifacts:
     paths:
       - artifacts-rum/$ARCH/$NGINX_VERSION/$WAF/
+      - upload/
 
 .build-openresty:
   extends: .build

--- a/.gitlab/common.yml
+++ b/.gitlab/common.yml
@@ -40,7 +40,7 @@ variables:
     - make build-musl-aux
     - mkdir -p artifacts-rum/$ARCH/$NGINX_VERSION/$WAF upload
     - cp .musl-build/ngx_http_datadog_module.so* artifacts-rum/$ARCH/$NGINX_VERSION/$WAF/
-    - (cd artifacts-rum/$ARCH/$NGINX_VERSION/$WAF && zip "$CI_PROJECT_DIR/upload/ngx_http_datadog_module-${NGINX_VERSION}-${ARCH}.zip" ngx_http_datadog_module.so)
+    - cp .musl-build/ngx_http_datadog_module.so "upload/ngx_http_datadog_module-${ARCH}-${NGINX_VERSION}.so"
   artifacts:
     paths:
       - artifacts-rum/$ARCH/$NGINX_VERSION/$WAF/

--- a/.gitlab/ssi-package.yml
+++ b/.gitlab/ssi-package.yml
@@ -48,7 +48,7 @@
 
 ssi-build:
   extends: .ssi-assemble
-  # Don't put 'needs: [build-nginx-rum-fast]', because it would exceed the maximum number of jobs allowed as a dependency (50).
+  needs: [build-nginx-rum-fast]
   rules:
     - if: $CI_COMMIT_TAG
       when: never

--- a/.gitlab/ssi-package.yml
+++ b/.gitlab/ssi-package.yml
@@ -48,7 +48,7 @@
 
 ssi-build:
   extends: .ssi-assemble
-  needs: [build-nginx-rum-fast]
+  # Don't put 'needs: [build-nginx-rum-fast]', because it would exceed the maximum number of jobs allowed as a dependency (50).
   rules:
     - if: $CI_COMMIT_TAG
       when: never


### PR DESCRIPTION
## Summary
- Port snapshot-upload jobs from httpd-datadog (`upload-rum-branch-snapshots` / `-snapshots` / `-snapshots-latest` + 30-day branch-snapshot lifecycle), under a new `aws` stage.
- Expand `build-nginx-rum-fast` to every supported nginx version (1.24.0 → 1.30.0) so snapshots cover all variants on every commit.
- `.build-nginx-rum` now also emits `upload/ngx_http_datadog_module-${VERSION}-${ARCH}.zip`.
- Drop explicit `needs:` on `ssi-build` (mirrors existing `ssi-build-all` workaround) since the 62-entry matrix exceeds GitLab's 50-need limit.

## Test plan
- [ ] CI pipeline succeeds on this branch
- [ ] `upload-rum-branch-snapshots` publishes zips to `s3://rum-auto-instrumentation/nginx/branch-snapshots/pipeline-<id>/`
- [ ] After merge to `master`: `upload-rum-snapshots` and `upload-rum-snapshots-latest` populate `snapshots/pipeline-<id>/` and `snapshots/latest/`