### PR TITLE
ci: skip empty scenarios only on pull_request

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -56,7 +56,7 @@ jobs:
       scenarios_groups: ${{ (github.event_name == 'schedule' || github.event_name == 'push') && 'tracer_release' || 'appsec' }}
       scenarios: DEFAULT
       excluded_scenarios: INTEGRATIONS  # no test activated, and long warm-up
-      skip_empty_scenarios: true
+      skip_empty_scenarios: ${{ github.event_name == 'pull_request' }}
       push_to_test_optimization: true
 
   # Ensure the main job is run to completion

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -67,4 +67,3 @@ jobs:
     - main
     steps:
     - run: exit 0
-

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -67,3 +67,4 @@ jobs:
     - main
     steps:
     - run: exit 0
+


### PR DESCRIPTION
### What does this PR do?

Runs all system-tests scenarios, even the empty ones, when running on master or on schedule.


### Motivation

This gives feedback on easy wins and makes it easier to monitor that no scenario was dropped by accident.