### PR TITLE
ci: upload all 62 RUM variants on tag releases

### DIFF
--- a/.gitlab/build-and-test-all.yml
+++ b/.gitlab/build-and-test-all.yml
@@ -510,3 +510,26 @@ test-openresty-all:
           - "1.29.2.1"
           - "1.29.2.3"
         WAF: ["ON", "OFF"]
+
+# Tag-pipeline RUM snapshot uploads. Reuses .upload-rum-snapshot-template
+# defined in build-and-test-fast.yml (both files are aggregated into the
+# main pipeline, so hidden jobs are visible across).
+#
+# Don't put 'needs: [build-nginx-rum-all]' — the 62-entry matrix exceeds
+# GitLab's 50-need limit. Stage ordering (build-all → test-all → assemble
+# → aws) guarantees the build-nginx-rum-all artifacts (including upload/)
+# are available.
+.upload-rum-snapshot-all:
+  extends:
+    - .build-and-test-all
+    - .upload-rum-snapshot-template
+
+upload-rum-snapshots-all:
+  extends: .upload-rum-snapshot-all
+  variables:
+    S3_PATH: s3://rum-auto-instrumentation/nginx/snapshots/pipeline-${CI_PIPELINE_ID}
+
+upload-rum-snapshots-latest-all:
+  extends: .upload-rum-snapshot-all
+  variables:
+    S3_PATH: s3://rum-auto-instrumentation/nginx/snapshots/latest

--- a/.gitlab/build-and-test-fast.yml
+++ b/.gitlab/build-and-test-fast.yml
@@ -224,10 +224,6 @@ coverage:
 
 .upload-rum-snapshot-template:
   stage: aws
-  needs:
-    - job: build-nginx-rum-fast
-      artifacts: true
-    - job: test-nginx-rum-fast
   tags: ["arch:amd64"]
   image: registry.ddbuild.io/images/aws-cli:2.33.12
   script:
@@ -247,8 +243,15 @@ coverage:
       done
       [ "$failed" -eq 0 ]
 
-upload-rum-branch-snapshots:
+.upload-rum-snapshot-fast:
   extends: .upload-rum-snapshot-template
+  needs:
+    - job: build-nginx-rum-fast
+      artifacts: true
+    - job: test-nginx-rum-fast
+
+upload-rum-branch-snapshots:
+  extends: .upload-rum-snapshot-fast
   variables:
     S3_PATH: s3://rum-auto-instrumentation/nginx/branch-snapshots/pipeline-${CI_PIPELINE_ID}
   rules:
@@ -257,14 +260,14 @@ upload-rum-branch-snapshots:
     - if: $CI_COMMIT_BRANCH != $CI_DEFAULT_BRANCH
 
 upload-rum-snapshots:
-  extends: .upload-rum-snapshot-template
+  extends: .upload-rum-snapshot-fast
   variables:
     S3_PATH: s3://rum-auto-instrumentation/nginx/snapshots/pipeline-${CI_PIPELINE_ID}
   rules:
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
 
 upload-rum-snapshots-latest:
-  extends: .upload-rum-snapshot-template
+  extends: .upload-rum-snapshot-fast
   variables:
     S3_PATH: s3://rum-auto-instrumentation/nginx/snapshots/latest
   rules:


### PR DESCRIPTION
Stacked on #363.

## Summary
- Wires the existing 62-entry `build-nginx-rum-all` matrix into the snapshot upload pipeline so tag releases publish RUM modules for every supported nginx version × arch.
- Splits the upload template into `.upload-rum-snapshot-template` (transport only) and `.upload-rum-snapshot-fast` (adds fast-specific `needs:`); the new all-pipeline jobs rely on stage ordering instead, matching the existing `ssi-build-all` workaround for GitLab's 50-need limit.

## What runs where
| Trigger | Job | S3 path | Module count |
|---|---|---|---|
| non-default branch | `upload-rum-branch-snapshots` (fast) | `nginx/branch-snapshots/pipeline-<id>/` | 7 × 2 archs |
| default branch | `upload-rum-snapshots`, `upload-rum-snapshots-latest` (fast) | `nginx/snapshots/pipeline-<id>/`, `nginx/snapshots/latest/` | 7 × 2 archs |
| \`vX.Y.Z\` tag | `upload-rum-snapshots-all`, `upload-rum-snapshots-latest-all` | `nginx/snapshots/pipeline-<id>/`, `nginx/snapshots/latest/` | 31 × 2 archs |

## Test plan
- [ ] CI: pipeline succeeds on this branch
- [ ] After PR #363 merges, push a test tag and verify all 62 modules land in `nginx/snapshots/pipeline-<id>/` and `nginx/snapshots/latest/`