### PR TITLE
Release v1.16.1

### DIFF
--- a/.gitlab/build-and-test-all.yml
+++ b/.gitlab/build-and-test-all.yml
@@ -302,8 +302,8 @@ test-nginx-all-bis:
         NGINX_VERSION: ["1.30.0"]
         WAF: ["ON", "OFF"]
       - ARCH: ["amd64", "arm64"]
-        BASE_IMAGE: ["amazonlinux:2023.3.20240219.0"]
-        NGINX_VERSION: ["1.30.0"]
+        BASE_IMAGE: ["amazonlinux:2023.11.20260427.1"]
+        NGINX_VERSION: ["1.28.3"]
         WAF: ["ON", "OFF"]
 
 test-nginx-rum-all:

--- a/.gitlab/build-and-test-all.yml
+++ b/.gitlab/build-and-test-all.yml
@@ -27,7 +27,6 @@ build-nginx-all:
     matrix:
       - ARCH: ["amd64", "arm64"]
         NGINX_VERSION:
-          - "1.24.0"
           - "1.25.0"
           - "1.25.1"
           - "1.25.2"
@@ -68,7 +67,6 @@ build-nginx-rum-all:
     matrix:
       - ARCH: ["amd64", "arm64"]
         NGINX_VERSION:
-          - "1.24.0"
           - "1.25.0"
           - "1.25.1"
           - "1.25.2"
@@ -175,10 +173,6 @@ test-nginx-all:
     - .test-nginx
   parallel:
     matrix:
-      - ARCH: ["amd64", "arm64"]
-        BASE_IMAGE: ["nginx:1.24.0", "nginx:1.24.0-alpine"]
-        NGINX_VERSION: ["1.24.0"]
-        WAF: ["ON", "OFF"]
       - ARCH: ["amd64", "arm64"]
         BASE_IMAGE: ["nginx:1.25.0", "nginx:1.25.0-alpine"]
         NGINX_VERSION: ["1.25.0"]
@@ -309,7 +303,7 @@ test-nginx-all-bis:
         WAF: ["ON", "OFF"]
       - ARCH: ["amd64", "arm64"]
         BASE_IMAGE: ["amazonlinux:2023.3.20240219.0"]
-        NGINX_VERSION: ["1.24.0"]
+        NGINX_VERSION: ["1.30.0"]
         WAF: ["ON", "OFF"]
 
 test-nginx-rum-all:
@@ -318,10 +312,6 @@ test-nginx-rum-all:
     - .test-nginx-rum
   parallel:
     matrix:
-      - ARCH: ["amd64", "arm64"]
-        BASE_IMAGE: ["nginx:1.24.0"]
-        NGINX_VERSION: ["1.24.0"]
-        WAF: ["OFF"]
       - ARCH: ["amd64", "arm64"]
         BASE_IMAGE: ["nginx:1.25.0"]
         NGINX_VERSION: ["1.25.0"]

--- a/.gitlab/build-and-test-fast.yml
+++ b/.gitlab/build-and-test-fast.yml
@@ -57,7 +57,6 @@ build-nginx-fast:
         # must be one of the ones below (and must match the one set in .github/workflows/system-tests.yml).
         # (This is why a latest but one version can be in build-nginx-fast but not in test-nginx-fast.)
         NGINX_VERSION:
-          - "1.24.0"
           - "1.25.5"
           - "1.26.3"
           - "1.27.5"
@@ -98,7 +97,6 @@ build-nginx-rum-fast:
     matrix:
       - ARCH: ["amd64", "arm64"]
         NGINX_VERSION:
-          - "1.24.0"
           - "1.25.5"
           - "1.26.3"
           - "1.27.5"
@@ -114,10 +112,6 @@ test-nginx-fast:
   needs: [build-nginx-fast]
   parallel:
     matrix:
-      - ARCH: ["amd64", "arm64"]
-        BASE_IMAGE: ["nginx:1.24.0", "nginx:1.24.0-alpine"]
-        NGINX_VERSION: ["1.24.0"]
-        WAF: ["ON", "OFF"]
       - ARCH: ["amd64", "arm64"]
         BASE_IMAGE: ["nginx:1.25.5", "nginx:1.25.5-alpine"]
         NGINX_VERSION: ["1.25.5"]
@@ -144,7 +138,7 @@ test-nginx-fast:
         WAF: ["ON", "OFF"]
       - ARCH: ["amd64", "arm64"]
         BASE_IMAGE: ["amazonlinux:2023.3.20240219.0"]
-        NGINX_VERSION: ["1.24.0"]
+        NGINX_VERSION: ["1.30.0"]
         WAF: ["ON", "OFF"]
 
 test-ingress-nginx-fast:
@@ -180,10 +174,6 @@ test-nginx-rum-fast:
   needs: [build-nginx-rum-fast]
   parallel:
     matrix:
-      - ARCH: ["amd64", "arm64"]
-        BASE_IMAGE: ["nginx:1.24.0"]
-        NGINX_VERSION: ["1.24.0"]
-        WAF: ["OFF"]
       - ARCH: ["amd64", "arm64"]
         BASE_IMAGE: ["nginx:1.25.5"]
         NGINX_VERSION: ["1.25.5"]

--- a/.gitlab/build-and-test-fast.yml
+++ b/.gitlab/build-and-test-fast.yml
@@ -137,8 +137,8 @@ test-nginx-fast:
         NGINX_VERSION: ["1.30.0"]
         WAF: ["ON", "OFF"]
       - ARCH: ["amd64", "arm64"]
-        BASE_IMAGE: ["amazonlinux:2023.3.20240219.0"]
-        NGINX_VERSION: ["1.30.0"]
+        BASE_IMAGE: ["amazonlinux:2023.11.20260427.1"]
+        NGINX_VERSION: ["1.28.3"]
         WAF: ["ON", "OFF"]
 
 test-ingress-nginx-fast:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "dd-trace-cpp"]
 	path = dd-trace-cpp
-	url = ../dd-trace-cpp.git
+	url = https://github.com/DataDog/dd-trace-cpp.git
 [submodule "libddwaf"]
 	path = libddwaf
-	url = ../libddwaf.git
+	url = https://github.com/DataDog/libddwaf.git
 [submodule "deps/inject-browser-sdk"]
 	path = deps/inject-browser-sdk
 	url = https://gitlab.ddbuild.io/DataDog/inject-browser-sdk

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 cmake_policy(SET CMP0068 NEW)
 cmake_policy(SET CMP0135 NEW)
 
-set(NGINX_DATADOG_VERSION 1.16.0)
+set(NGINX_DATADOG_VERSION 1.16.1)
 project(ngx_http_datadog_module VERSION ${NGINX_DATADOG_VERSION})
 
 option(NGINX_DATADOG_ASM_ENABLED "Build with libddwaf" ON)

--- a/test/services/nginx/install_tools.sh
+++ b/test/services/nginx/install_tools.sh
@@ -46,7 +46,7 @@ elif command -v apk >/dev/null 2>&1; then
     fi
 elif command -v yum >/dev/null 2>&1; then
     yum update -y
-    yum install -y procps gdb
+    yum install -y findutils gdb procps util-linux-core
     if ! command -v nginx >/dev/null 2>&1; then
         install_nginx_on_amazon_linux
     fi


### PR DESCRIPTION
Prepare release `v1.16.1`, with the following changes:

- Update `dd-trace-cpp` to [v2.1.0](https://github.com/DataDog/dd-trace-cpp/releases/tag/v2.1.0).
- Remove support of Nginx 1.24.0 (which reached end of life more than one year ago, on May 1st 2025).
- Upgrade Amazon Linux to latest available version (we used a 2 years old that embedded Nginx `1.24.0`).