### PR TITLE
Disable Docker buildx attestations to fix multi-arch push of images for CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,9 +86,9 @@ build-push-uwsgi-test-image:
 
 # $(1): image name, $(2): build context
 define build-push-multiarch
-	docker build --progress=plain --platform linux/amd64 --build-arg ARCH=x86_64 -t $(1):latest-amd64 $(2)
+	docker build --provenance=false --sbom=false --progress=plain --platform linux/amd64 --build-arg ARCH=x86_64 -t $(1):latest-amd64 $(2)
 	docker push $(1):latest-amd64
-	docker build --progress=plain --platform linux/arm64 --build-arg ARCH=aarch64 -t $(1):latest-arm64 $(2)
+	docker build --provenance=false --sbom=false --progress=plain --platform linux/arm64 --build-arg ARCH=aarch64 -t $(1):latest-arm64 $(2)
 	docker push $(1):latest-arm64
 	docker buildx imagetools create -t $(1):latest $(1):latest-amd64 $(1):latest-arm64
 endef


### PR DESCRIPTION
`make build-push-images-for-CI` was failing on the final `docker buildx imagetools create` step:
```
docker buildx imagetools create -t registry.ddbuild.io/ci/nginx-datadog/nginx_musl_toolchain:latest registry.ddbuild.io/ci/nginx-datadog/nginx_musl_toolchain:latest-amd64
  registry.ddbuild.io/ci/nginx-datadog/nginx_musl_toolchain:latest-arm64
ERROR: publish sha256:30ee4b752f9f7be827d7955de7479222bdee5086149de4dd9e48139373f8fa0c to registry.ddbuild.io/ci/nginx-datadog/nginx_musl_toolchain:latest: unexpected status from HEAD request to
  https://registry.ddbuild.io/v2/ci/nginx-datadog/nginx_musl_toolchain/manifests/latest: 400 Bad Request
```

Reason:
Recent BuildKit versions default to attaching SLSA provenance and SBOM attestations to `docker build` output, turning per-arch images into OCI image indexes containing extra `unknown/unknown` attestation manifests. `registry.ddbuild.io` rejects the resulting multi-arch manifest list because it can't accept the embedded attestation children.

Fix:
Add `--provenance=false --sbom=false` to `docker build` commands.
Doing so, each `:latest-<arch>` tag is a plain Docker v2 manifest and `imagetools create` produces a `application/vnd.docker.distribution.manifest.list.v2+json`.