### PR TITLE
appsec: verify jwt-related tags

### DIFF
--- a/test/cases/sec_jwt/conf/http.conf
+++ b/test/cases/sec_jwt/conf/http.conf
@@ -1,0 +1,27 @@
+thread_pool waf_thread_pool threads=2 max_queue=5;
+
+load_module /datadog-tests/ngx_http_datadog_module.so;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    datadog_agent_url http://agent:8126;
+    datadog_appsec_enabled on;
+    datadog_appsec_ruleset_file /tmp/waf.json;
+    datadog_appsec_waf_timeout 2s;
+    datadog_waf_thread_pool_name waf_thread_pool;
+
+    server {
+        listen       80;
+
+        location /http {
+            proxy_pass http://http:8080;
+        }
+
+        location /sync {
+            return 200;
+        }
+    }
+}

--- a/test/cases/sec_jwt/conf/waf.json
+++ b/test/cases/sec_jwt/conf/waf.json
@@ -1,0 +1,172 @@
+{
+    "version": "2.1",
+    "metadata": {
+        "rules_version": "1.2.6"
+    },
+    "processors": [
+        {
+            "id": "decode-auth-jwt",
+            "generator": "jwt_decode",
+            "min_version": "1.25.0",
+            "parameters": {
+                "mappings": [
+                    {
+                        "inputs": [
+                            {
+                                "address": "server.request.headers.no_cookies",
+                                "key_path": ["authorization"]
+                            }
+                        ],
+                        "output": "server.request.jwt"
+                    }
+                ]
+            },
+            "evaluate": true,
+            "output": false
+        }
+    ],
+    "rules": [],
+    "rules_compat": [
+        {
+            "id": "api-001-100",
+            "name": "JWT: No expiry is present",
+            "tags": {
+                "type": "jwt",
+                "category": "api_security",
+                "confidence": "0",
+                "module": "business-logic"
+            },
+            "min_version": "1.25.0",
+            "conditions": [
+                {
+                    "parameters": {
+                        "inputs": [
+                            {
+                                "address": "server.request.jwt",
+                                "key_path": ["payload", "exp"]
+                            }
+                        ]
+                    },
+                    "operator": "!exists"
+                }
+            ],
+            "transformers": [],
+            "output": {
+                "event": false,
+                "keep": false,
+                "attributes": {
+                    "_dd.appsec.api.jwt.no_expiry": {
+                        "value": 1
+                    }
+                }
+            }
+        },
+        {
+            "id": "api-001-110",
+            "name": "JWT: Collect algorithm used",
+            "tags": {
+                "type": "jwt",
+                "category": "api_security",
+                "confidence": "0",
+                "module": "business-logic"
+            },
+            "min_version": "1.25.0",
+            "conditions": [
+                {
+                    "parameters": {
+                        "inputs": [
+                            {
+                                "address": "server.request.jwt",
+                                "key_path": ["header", "alg"]
+                            }
+                        ]
+                    },
+                    "operator": "exists"
+                }
+            ],
+            "transformers": [],
+            "output": {
+                "event": false,
+                "keep": false,
+                "attributes": {
+                    "api.security.jwt.alg": {
+                        "address": "server.request.jwt",
+                        "key_path": ["header", "alg"]
+                    }
+                }
+            }
+        },
+        {
+            "id": "api-001-120",
+            "name": "JWT: No audience is specified",
+            "tags": {
+                "type": "jwt",
+                "category": "api_security",
+                "confidence": "0",
+                "module": "business-logic"
+            },
+            "min_version": "1.25.0",
+            "conditions": [
+                {
+                    "parameters": {
+                        "inputs": [
+                            {
+                                "address": "server.request.jwt",
+                                "key_path": ["payload", "aud"]
+                            }
+                        ]
+                    },
+                    "operator": "!exists"
+                }
+            ],
+            "transformers": [],
+            "output": {
+                "event": false,
+                "keep": false,
+                "attributes": {
+                    "_dd.appsec.api.jwt.no_audience": {
+                        "value": 1
+                    }
+                }
+            }
+        },
+        {
+            "id": "api-001-130",
+            "name": "JWT: None algorithm used",
+            "tags": {
+                "type": "jwt",
+                "category": "api_security",
+                "confidence": "0",
+                "module": "business-logic"
+            },
+            "min_version": "1.25.0",
+            "conditions": [
+                {
+                    "parameters": {
+                        "inputs": [
+                            {
+                                "address": "server.request.jwt",
+                                "key_path": ["header", "alg"]
+                            }
+                        ],
+                        "list": [
+                            "none", "nonE", "noNe", "noNE", "nOne", "nOnE", "nONe", "nONE",
+                            "None", "NonE", "NoNe", "NoNE", "NOne", "NOnE", "NONe", "NONE"
+                        ]
+                    },
+                    "operator": "exact_match"
+                }
+            ],
+            "transformers": [],
+            "output": {
+                "event": false,
+                "keep": true,
+                "attributes": {
+                    "_dd.appsec.api.jwt.none_alg": {
+                        "value": 1
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/test/cases/sec_jwt/test_jwt.py
+++ b/test/cases/sec_jwt/test_jwt.py
@@ -18,24 +18,16 @@ from pathlib import Path
 
 from .. import case, formats
 
-# HS256, no exp, no aud
-_JWT_HS256_NO_EXP_NO_AUD = (
-    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
-    ".eyJzdWIiOiJ0ZXN0IiwiaWF0IjoxNTE2MjM5MDIyfQ"
-    "."
-)
-# HS256, with exp and aud
+_JWT_HS256_NO_EXP_NO_AUD = ("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
+                            ".eyJzdWIiOiJ0ZXN0IiwiaWF0IjoxNTE2MjM5MDIyfQ"
+                            ".")
 _JWT_HS256_WITH_EXP_WITH_AUD = (
     "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
     ".eyJzdWIiOiJ0ZXN0IiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjk5OTk5OTk5OTksImF1ZCI6ImFwaSJ9"
-    "."
-)
-# none alg, no exp, no aud
-_JWT_NONE_ALG = (
-    "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0"
-    ".eyJzdWIiOiJ0ZXN0IiwiaWF0IjoxNTE2MjM5MDIyfQ"
-    "."
-)
+    ".")
+_JWT_NONE_ALG = ("eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0"
+                 ".eyJzdWIiOiJ0ZXN0IiwiaWF0IjoxNTE2MjM5MDIyfQ"
+                 ".")
 
 
 class TestJwt(case.TestCase):
@@ -55,15 +47,16 @@ class TestJwt(case.TestCase):
 
             conf_path = Path(__file__).parent / "conf/http.conf"
             status, log_lines = self.orch.nginx_replace_config(
-                conf_path.read_text(), conf_path.name
-            )
+                conf_path.read_text(), conf_path.name)
             self.assertEqual(0, status, log_lines)
             TestJwt._config_done = True
 
         self.orch.sync_service("agent")
 
     def _spans_for_request(self, headers):
-        status, _, _ = self.orch.send_nginx_http_request("/http", 80, headers=headers)
+        status, _, _ = self.orch.send_nginx_http_request("/http",
+                                                         80,
+                                                         headers=headers)
         self.assertEqual(status, 200)
         self.orch.reload_nginx()
         log_lines = self.orch.sync_service("agent")
@@ -90,83 +83,76 @@ class TestJwt(case.TestCase):
     def test_no_expiry_tag_set_when_exp_missing(self):
         """api-001-100: _dd.appsec.api.jwt.no_expiry is set when JWT has no exp claim."""
         spans = self._spans_for_request(
-            {"Authorization": f"Bearer {_JWT_HS256_NO_EXP_NO_AUD}"}
-        )
+            {"Authorization": f"Bearer {_JWT_HS256_NO_EXP_NO_AUD}"})
         metrics = self._get_metrics(spans)
         self.assertIn(
             "_dd.appsec.api.jwt.no_expiry",
             metrics,
-            f"Expected _dd.appsec.api.jwt.no_expiry in metrics; got metrics={metrics}",
+            f"Expected _dd.appsec.api.jwt.no_expiry in metrics; got metrics={metrics!r}",
         )
 
     def test_no_expiry_tag_absent_when_exp_present(self):
         """api-001-100: _dd.appsec.api.jwt.no_expiry is absent when JWT has an exp claim."""
         spans = self._spans_for_request(
-            {"Authorization": f"Bearer {_JWT_HS256_WITH_EXP_WITH_AUD}"}
-        )
+            {"Authorization": f"Bearer {_JWT_HS256_WITH_EXP_WITH_AUD}"})
         metrics = self._get_metrics(spans)
         self.assertNotIn(
             "_dd.appsec.api.jwt.no_expiry",
             metrics,
-            f"Expected _dd.appsec.api.jwt.no_expiry to be absent; got metrics={metrics}",
+            f"Expected _dd.appsec.api.jwt.no_expiry to be absent; got metrics={metrics!r}",
         )
 
     def test_algorithm_collected(self):
         """api-001-110: api.security.jwt.alg is set to the algorithm from the JWT header."""
         spans = self._spans_for_request(
-            {"Authorization": f"Bearer {_JWT_HS256_NO_EXP_NO_AUD}"}
-        )
+            {"Authorization": f"Bearer {_JWT_HS256_NO_EXP_NO_AUD}"})
         meta = self._get_meta(spans)
         self.assertEqual(
             meta.get("api.security.jwt.alg"),
             "HS256",
-            f"Expected api.security.jwt.alg='HS256'; got meta={meta}",
+            f"Expected api.security.jwt.alg='HS256'; got meta={meta!r}",
         )
 
     def test_no_audience_tag_set_when_aud_missing(self):
         """api-001-120: _dd.appsec.api.jwt.no_audience is set when JWT has no aud claim."""
         spans = self._spans_for_request(
-            {"Authorization": f"Bearer {_JWT_HS256_NO_EXP_NO_AUD}"}
-        )
+            {"Authorization": f"Bearer {_JWT_HS256_NO_EXP_NO_AUD}"})
         metrics = self._get_metrics(spans)
         self.assertIn(
             "_dd.appsec.api.jwt.no_audience",
             metrics,
-            f"Expected _dd.appsec.api.jwt.no_audience in metrics; got metrics={metrics}",
+            f"Expected _dd.appsec.api.jwt.no_audience in metrics; got metrics={metrics!r}",
         )
 
     def test_no_audience_tag_absent_when_aud_present(self):
         """api-001-120: _dd.appsec.api.jwt.no_audience is absent when JWT has an aud claim."""
         spans = self._spans_for_request(
-            {"Authorization": f"Bearer {_JWT_HS256_WITH_EXP_WITH_AUD}"}
-        )
+            {"Authorization": f"Bearer {_JWT_HS256_WITH_EXP_WITH_AUD}"})
         metrics = self._get_metrics(spans)
         self.assertNotIn(
             "_dd.appsec.api.jwt.no_audience",
             metrics,
-            f"Expected _dd.appsec.api.jwt.no_audience to be absent; got metrics={metrics}",
+            f"Expected _dd.appsec.api.jwt.no_audience to be absent; got metrics={metrics!r}",
         )
 
     def test_none_alg_tag_set(self):
         """api-001-130: _dd.appsec.api.jwt.none_alg is set when JWT uses alg=none."""
         spans = self._spans_for_request(
-            {"Authorization": f"Bearer {_JWT_NONE_ALG}"}
-        )
+            {"Authorization": f"Bearer {_JWT_NONE_ALG}"})
         metrics = self._get_metrics(spans)
         self.assertIn(
             "_dd.appsec.api.jwt.none_alg",
             metrics,
-            f"Expected _dd.appsec.api.jwt.none_alg in metrics; got metrics={metrics}",
+            f"Expected _dd.appsec.api.jwt.none_alg in metrics; got metrics={metrics!r}",
         )
 
     def test_none_alg_tag_absent_for_hs256(self):
         """api-001-130: _dd.appsec.api.jwt.none_alg is absent for a normal HS256 JWT."""
         spans = self._spans_for_request(
-            {"Authorization": f"Bearer {_JWT_HS256_NO_EXP_NO_AUD}"}
-        )
+            {"Authorization": f"Bearer {_JWT_HS256_NO_EXP_NO_AUD}"})
         metrics = self._get_metrics(spans)
         self.assertNotIn(
             "_dd.appsec.api.jwt.none_alg",
             metrics,
-            f"Expected _dd.appsec.api.jwt.none_alg to be absent; got metrics={metrics}",
+            f"Expected _dd.appsec.api.jwt.none_alg to be absent; got metrics={metrics!r}",
         )

--- a/test/cases/sec_jwt/test_jwt.py
+++ b/test/cases/sec_jwt/test_jwt.py
@@ -1,0 +1,172 @@
+"""Tests for JWT analysis via the decode-auth-jwt WAF processor (rules api-001-{100..130}).
+
+The processor decodes the JWT from the Authorization header into server.request.jwt.
+The rules_compat rules inspect the decoded JWT and set span attributes. No backend
+endpoint changes are needed — the WAF reads directly from the authorization header.
+
+JWTs used here are unsigned (empty signature); the WAF processor only decodes, it
+does not verify signatures.
+
+Pre-computed tokens (header.payload.):
+  HS256 header  : {"alg":"HS256","typ":"JWT"}
+  none header   : {"alg":"none","typ":"JWT"}
+  payload no exp/aud  : {"sub":"test","iat":1516239022}
+  payload w/ exp+aud  : {"sub":"test","iat":1516239022,"exp":9999999999,"aud":"api"}
+"""
+
+from pathlib import Path
+
+from .. import case, formats
+
+# HS256, no exp, no aud
+_JWT_HS256_NO_EXP_NO_AUD = (
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
+    ".eyJzdWIiOiJ0ZXN0IiwiaWF0IjoxNTE2MjM5MDIyfQ"
+    "."
+)
+# HS256, with exp and aud
+_JWT_HS256_WITH_EXP_WITH_AUD = (
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
+    ".eyJzdWIiOiJ0ZXN0IiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjk5OTk5OTk5OTksImF1ZCI6ImFwaSJ9"
+    "."
+)
+# none alg, no exp, no aud
+_JWT_NONE_ALG = (
+    "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0"
+    ".eyJzdWIiOiJ0ZXN0IiwiaWF0IjoxNTE2MjM5MDIyfQ"
+    "."
+)
+
+
+class TestJwt(case.TestCase):
+    requires_waf = True
+    _config_done = False
+
+    @classmethod
+    def setUpClass(cls):
+        cls._config_done = False
+        super().setUpClass()
+
+    def setUp(self):
+        super().setUp()
+        if not TestJwt._config_done:
+            waf_path = Path(__file__).parent / "conf/waf.json"
+            self.orch.nginx_replace_file("/tmp/waf.json", waf_path.read_text())
+
+            conf_path = Path(__file__).parent / "conf/http.conf"
+            status, log_lines = self.orch.nginx_replace_config(
+                conf_path.read_text(), conf_path.name
+            )
+            self.assertEqual(0, status, log_lines)
+            TestJwt._config_done = True
+
+        self.orch.sync_service("agent")
+
+    def _spans_for_request(self, headers):
+        status, _, _ = self.orch.send_nginx_http_request("/http", 80, headers=headers)
+        self.assertEqual(status, 200)
+        self.orch.reload_nginx()
+        log_lines = self.orch.sync_service("agent")
+        spans = []
+        for line in log_lines:
+            entry = formats.parse_trace(line)
+            if entry is not None:
+                for trace in entry:
+                    spans.extend(trace)
+        return spans
+
+    def _get_meta(self, spans):
+        meta = {}
+        for span in spans:
+            meta.update(span.get("meta", {}))
+        return meta
+
+    def _get_metrics(self, spans):
+        metrics = {}
+        for span in spans:
+            metrics.update(span.get("metrics", {}))
+        return metrics
+
+    def test_no_expiry_tag_set_when_exp_missing(self):
+        """api-001-100: _dd.appsec.api.jwt.no_expiry is set when JWT has no exp claim."""
+        spans = self._spans_for_request(
+            {"Authorization": f"Bearer {_JWT_HS256_NO_EXP_NO_AUD}"}
+        )
+        metrics = self._get_metrics(spans)
+        self.assertIn(
+            "_dd.appsec.api.jwt.no_expiry",
+            metrics,
+            f"Expected _dd.appsec.api.jwt.no_expiry in metrics; got metrics={metrics}",
+        )
+
+    def test_no_expiry_tag_absent_when_exp_present(self):
+        """api-001-100: _dd.appsec.api.jwt.no_expiry is absent when JWT has an exp claim."""
+        spans = self._spans_for_request(
+            {"Authorization": f"Bearer {_JWT_HS256_WITH_EXP_WITH_AUD}"}
+        )
+        metrics = self._get_metrics(spans)
+        self.assertNotIn(
+            "_dd.appsec.api.jwt.no_expiry",
+            metrics,
+            f"Expected _dd.appsec.api.jwt.no_expiry to be absent; got metrics={metrics}",
+        )
+
+    def test_algorithm_collected(self):
+        """api-001-110: api.security.jwt.alg is set to the algorithm from the JWT header."""
+        spans = self._spans_for_request(
+            {"Authorization": f"Bearer {_JWT_HS256_NO_EXP_NO_AUD}"}
+        )
+        meta = self._get_meta(spans)
+        self.assertEqual(
+            meta.get("api.security.jwt.alg"),
+            "HS256",
+            f"Expected api.security.jwt.alg='HS256'; got meta={meta}",
+        )
+
+    def test_no_audience_tag_set_when_aud_missing(self):
+        """api-001-120: _dd.appsec.api.jwt.no_audience is set when JWT has no aud claim."""
+        spans = self._spans_for_request(
+            {"Authorization": f"Bearer {_JWT_HS256_NO_EXP_NO_AUD}"}
+        )
+        metrics = self._get_metrics(spans)
+        self.assertIn(
+            "_dd.appsec.api.jwt.no_audience",
+            metrics,
+            f"Expected _dd.appsec.api.jwt.no_audience in metrics; got metrics={metrics}",
+        )
+
+    def test_no_audience_tag_absent_when_aud_present(self):
+        """api-001-120: _dd.appsec.api.jwt.no_audience is absent when JWT has an aud claim."""
+        spans = self._spans_for_request(
+            {"Authorization": f"Bearer {_JWT_HS256_WITH_EXP_WITH_AUD}"}
+        )
+        metrics = self._get_metrics(spans)
+        self.assertNotIn(
+            "_dd.appsec.api.jwt.no_audience",
+            metrics,
+            f"Expected _dd.appsec.api.jwt.no_audience to be absent; got metrics={metrics}",
+        )
+
+    def test_none_alg_tag_set(self):
+        """api-001-130: _dd.appsec.api.jwt.none_alg is set when JWT uses alg=none."""
+        spans = self._spans_for_request(
+            {"Authorization": f"Bearer {_JWT_NONE_ALG}"}
+        )
+        metrics = self._get_metrics(spans)
+        self.assertIn(
+            "_dd.appsec.api.jwt.none_alg",
+            metrics,
+            f"Expected _dd.appsec.api.jwt.none_alg in metrics; got metrics={metrics}",
+        )
+
+    def test_none_alg_tag_absent_for_hs256(self):
+        """api-001-130: _dd.appsec.api.jwt.none_alg is absent for a normal HS256 JWT."""
+        spans = self._spans_for_request(
+            {"Authorization": f"Bearer {_JWT_HS256_NO_EXP_NO_AUD}"}
+        )
+        metrics = self._get_metrics(spans)
+        self.assertNotIn(
+            "_dd.appsec.api.jwt.none_alg",
+            metrics,
+            f"Expected _dd.appsec.api.jwt.none_alg to be absent; got metrics={metrics}",
+        )


### PR DESCRIPTION
Technically, this only needs that attribute processing work correctly in libddwaf, but it leaves no doubt as to the answer to the question "is JWT processing supported".