### PR TITLE
Update the `OCI_PACKAGE_NAME` value to `datadog-apm-library-nginx`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,7 +17,7 @@ include:
   - local: ".gitlab/one-pipeline.locked.yml"
 
 variables:
-  OCI_PACKAGE_NAME: datadog-nginx-ssi
+  OCI_PACKAGE_NAME: datadog-apm-library-nginx
   OCI_AGENT_REGISTRY_PACKAGE_NAME: apm-library-nginx-package
   AGENT_REPO_PRODUCT_NAME: auto_inject-nginx
   LIB_INJECTION_NAME: dd-lib-nginx-init


### PR DESCRIPTION
Currently this value is set to `datadog-nginx-ssi`, which does not conform to the standard of `datadog-apm-library-<lang>`. Fixing this so the release process looks for and updates the correct repository in the public registries.

### Testing
Validated on this branch (https://github.com/DataDog/nginx-datadog/pull/375), which has the One Pipeline version with the variable validation job pinned.