### PR TITLE
Add support for Nginx 1.30.1 and 1.31.0

### DIFF
--- a/.gitlab/build-and-test-all.yml
+++ b/.gitlab/build-and-test-all.yml
@@ -57,6 +57,8 @@ build-nginx-all:
           - "1.29.7"
           - "1.29.8"
           - "1.30.0"
+          - "1.30.1"
+          - "1.31.0"
         WAF: ["ON", "OFF"]
 
 build-nginx-rum-all:
@@ -97,6 +99,8 @@ build-nginx-rum-all:
           - "1.29.7"
           - "1.29.8"
           - "1.30.0"
+          - "1.30.1"
+          - "1.31.0"
         WAF: ["OFF"]
 
 build-ingress-nginx-all:
@@ -302,6 +306,14 @@ test-nginx-all-bis:
         NGINX_VERSION: ["1.30.0"]
         WAF: ["ON", "OFF"]
       - ARCH: ["amd64", "arm64"]
+        BASE_IMAGE: ["nginx:1.30.1", "nginx:1.30.1-alpine"]
+        NGINX_VERSION: ["1.30.1"]
+        WAF: ["ON", "OFF"]
+      - ARCH: ["amd64", "arm64"]
+        BASE_IMAGE: ["nginx:1.31.0", "nginx:1.31.0-alpine"]
+        NGINX_VERSION: ["1.31.0"]
+        WAF: ["ON", "OFF"]
+      - ARCH: ["amd64", "arm64"]
         BASE_IMAGE: ["amazonlinux:2023.11.20260427.1"]
         NGINX_VERSION: ["1.28.3"]
         WAF: ["ON", "OFF"]
@@ -431,6 +443,14 @@ test-nginx-rum-all:
       - ARCH: ["amd64", "arm64"]
         BASE_IMAGE: ["nginx:1.30.0"]
         NGINX_VERSION: ["1.30.0"]
+        WAF: ["OFF"]
+      - ARCH: ["amd64", "arm64"]
+        BASE_IMAGE: ["nginx:1.30.1"]
+        NGINX_VERSION: ["1.30.1"]
+        WAF: ["OFF"]
+      - ARCH: ["amd64", "arm64"]
+        BASE_IMAGE: ["nginx:1.31.0"]
+        NGINX_VERSION: ["1.31.0"]
         WAF: ["OFF"]
 
 test-ingress-nginx-all:

--- a/.gitlab/build-and-test-fast.yml
+++ b/.gitlab/build-and-test-fast.yml
@@ -62,7 +62,8 @@ build-nginx-fast:
           - "1.27.5"
           - "1.28.3"
           - "1.29.8"
-          - "1.30.0"
+          - "1.30.1"
+          - "1.31.0"
         WAF: ["ON", "OFF"]
 
 build-ingress-nginx-fast:
@@ -102,7 +103,8 @@ build-nginx-rum-fast:
           - "1.27.5"
           - "1.28.3"
           - "1.29.8"
-          - "1.30.0"
+          - "1.30.1"
+          - "1.31.0"
         WAF: ["OFF"]
 
 test-nginx-fast:
@@ -133,8 +135,12 @@ test-nginx-fast:
         NGINX_VERSION: ["1.29.8"]
         WAF: ["ON", "OFF"]
       - ARCH: ["amd64", "arm64"]
-        BASE_IMAGE: ["nginx:1.30.0", "nginx:1.30.0-alpine"]
-        NGINX_VERSION: ["1.30.0"]
+        BASE_IMAGE: ["nginx:1.30.1", "nginx:1.30.1-alpine"]
+        NGINX_VERSION: ["1.30.1"]
+        WAF: ["ON", "OFF"]
+      - ARCH: ["amd64", "arm64"]
+        BASE_IMAGE: ["nginx:1.31.0", "nginx:1.31.0-alpine"]
+        NGINX_VERSION: ["1.31.0"]
         WAF: ["ON", "OFF"]
       - ARCH: ["amd64", "arm64"]
         BASE_IMAGE: ["amazonlinux:2023.11.20260427.1"]
@@ -195,8 +201,12 @@ test-nginx-rum-fast:
         NGINX_VERSION: ["1.29.8"]
         WAF: ["OFF"]
       - ARCH: ["amd64", "arm64"]
-        BASE_IMAGE: ["nginx:1.30.0"]
-        NGINX_VERSION: ["1.30.0"]
+        BASE_IMAGE: ["nginx:1.30.1"]
+        NGINX_VERSION: ["1.30.1"]
+        WAF: ["OFF"]
+      - ARCH: ["amd64", "arm64"]
+        BASE_IMAGE: ["nginx:1.31.0"]
+        NGINX_VERSION: ["1.31.0"]
         WAF: ["OFF"]
 
 coverage:


### PR DESCRIPTION
## Summary
- Add Nginx 1.30.1 and 1.31.0 to the build/test matrices in `.gitlab/build-and-test-all.yml` (build-nginx-all, build-nginx-rum-all, test-nginx-all-bis, test-nginx-rum-all).
- In `.gitlab/build-and-test-fast.yml`, replace 1.30.0 with 1.30.1 (latest of the 1.30 minor) and add 1.31.0, following the existing fast-matrix convention of keeping only the latest patch per minor branch.

## Test plan
- [ ] GitLab CI `build-and-test-fast` pipeline passes for new 1.30.1 and 1.31.0 entries on amd64 and arm64.
- [ ] GitLab CI `build-and-test-all` pipeline passes for 1.30.1 and 1.31.0 on amd64 and arm64 with WAF ON/OFF.
- [ ] RUM matrices build/test successfully for the new versions.