### PR TITLE
Revert "Update the `OCI_PACKAGE_NAME` value to `datadog-apm-library-nginx`"

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,7 +17,7 @@ include:
   - local: ".gitlab/one-pipeline.locked.yml"
 
 variables:
-  OCI_PACKAGE_NAME: datadog-apm-library-nginx
+  OCI_PACKAGE_NAME: datadog-nginx-ssi
   OCI_AGENT_REGISTRY_PACKAGE_NAME: apm-library-nginx-package
   AGENT_REPO_PRODUCT_NAME: auto_inject-nginx
   LIB_INJECTION_NAME: dd-lib-nginx-init


### PR DESCRIPTION
Reverts DataDog/nginx-datadog#374 - since the dockerhub repo is not yet created