### PR TITLE
fix(ci): authenticate submodule clone in macrobenchmarks build-nginx-module

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -5,6 +5,7 @@ stages:
   - notify
 
 include:
+- local: ".gitlab/common.yml"
 - project: 'DataDog/benchmarking-platform-tools'
   file: 'images/templates/gitlab/notify-slo-breaches.template.yml'
 - project: 'DataDog/benchmarking-platform-tools'
@@ -20,6 +21,7 @@ workflow:
     on_new_commit: interruptible
 
 build-nginx-module:
+  extends: .git-config
   stage: build
   tags: ["arch:amd64"]
   timeout: 20min
@@ -35,7 +37,6 @@ build-nginx-module:
     BUILD_TYPE: Release
     ARCH: x86_64
   script:
-    - git submodule sync && git submodule update --init --recursive
     - export NGINX_SRC_DIR="$PWD/nginx"
     - make build-musl-aux
   artifacts:


### PR DESCRIPTION
## Summary
- The nightly macrobenchmarks pipeline's `build-nginx-module` job has been failing on master since #331 (May 6) added the private `deps/inject-browser-sdk` submodule. Its script ran `git submodule update --init --recursive` with no auth, so the clone of `https://gitlab.ddbuild.io/DataDog/inject-browser-sdk` died with `could not read Username for 'https://gitlab.ddbuild.io'`.
- Sibling jobs (`build-nginx-fast`, `build-nginx-all`) don't fail because they extend `.git-config` in `.gitlab/common.yml`, which sets `GIT_SUBMODULE_STRATEGY=recursive` — the runner then performs the submodule clone itself and injects `http.extraheader` `JOB-TOKEN` auth for same-instance GitLab submodules.
- This change includes `common.yml` from `benchmarks.yml`, extends `.git-config` on `build-nginx-module`, and drops the now-redundant manual `git submodule sync && git submodule update --init --recursive` line.

Example failing job: https://gitlab.ddbuild.io/DataDog/apm-reliability/nginx-datadog/-/jobs/1690207190

[IDMPL-451 Nginx: master CI: build-nginx-module broken](https://datadoghq.atlassian.net/browse/IDMPL-451).

## Test plan
- [ ] Confirm the macrobenchmarks child pipeline on this branch runs `build-nginx-module` to success (submodule clones, including `deps/inject-browser-sdk`, complete with auth).
- [ ] Confirm `build-nginx-fast` and the rest of `build-and-test-fast` still pass (no regressions from the new `include`).