### PR TITLE
Fix yaml syntax for threshold with warning_range

### DIFF
--- a/.gitlab/bp-runner.fail-on-breach.yml
+++ b/.gitlab/bp-runner.fail-on-breach.yml
@@ -13,5 +13,5 @@ experiments:
               - throughput > 3700 op/s
           - name: normal_operation/only-tracing
             thresholds:
-              - agg_http_req_duration_p50 < 0.116 ms
+              - threshold: agg_http_req_duration_p50 < 0.116 ms
                 warning_range: 2


### PR DESCRIPTION
As stated in [IDMPL-457 Nginx: master CI: check-slo-breaches broken](https://datadoghq.atlassian.net/browse/IDMPL-457), since April 16, the `check-slo-breaches` CI job used to fail.
This was due to an invalid yaml syntax when using a pre-threshold `warning_range`.

[Example of failure before the fix](https://gitlab.ddbuild.io/DataDog/apm-reliability/nginx-datadog/-/jobs/1693502826):
```
$ bp-runner $SLO_FILE
Running on a Linux distro
bp-runner v2026.5.5
mapping values are not allowed here
  in ".gitlab/bp-runner.fail-on-breach.yml", line 17, column 30
2026-05-19 08:26:43,139 [ERROR] bp-runner.src.execution.runner - 'NoneType' object has no attribute 'setup'
```

[Success in the benchmark pipeline manually triggered in this PR](https://gitlab.ddbuild.io/DataDog/apm-reliability/nginx-datadog/-/jobs/1694204142):
```
$ bp-runner $SLO_FILE
Running on a Linux distro
bp-runner v2026.5.5
2026-05-19 12:16:52,851 [INFO] bp-runner.src.templates.fail_on_breach - Generating Markdown threshold comparison report for CI logs...
Benchmark execution time: 2026-05-19 12:16:54
Comparing candidate commit 50bd3ca156cea2e081e58acc9207df9e06e154cf in branch `xlamorlette/fix-check-slo-breaches` with performance thresholds.
#### high_load--only-tracing
- 🟩 `throughput` seen in benchmark [3979.843op/s; 4084.471op/s]; SLO is > 3700.000op/s
#### normal_operation--only-tracing
- 🟨 `agg_http_req_duration_p50` seen in benchmark [114.488µs; 114.730µs]; SLO is < 116.000µs (warning threshold is 113.680µs)
```