### PR TITLE
Fix SLO following baseline drift

### DIFF
--- a/.gitlab/bp-runner.fail-on-breach.yml
+++ b/.gitlab/bp-runner.fail-on-breach.yml
@@ -13,5 +13,5 @@ experiments:
               - throughput > 3700 op/s
           - name: normal_operation/only-tracing
             thresholds:
-              - threshold: agg_http_req_duration_p50 < 0.116 ms
+              - threshold: agg_http_req_duration_p50 < 0.119 ms
                 warning_range: 2


### PR DESCRIPTION
We need to update the SLO following a platform drift, which can be seen [on the Benchmarking Platform dashboard](https://ddstaging.datadoghq.com/dashboard/uc8-pup-pkt?fromUser=true&refresh_mode=paused&from_ts=1773814631666&to_ts=1779354235000&live=false):
<img width="482" height="275" alt="image" src="https://github.com/user-attachments/assets/75f7a1f8-5e17-49ad-9e8e-21a1f3ac503a" />

The first drift happened on March 30th, and was taken into account by https://github.com/DataDog/nginx-datadog/pull/354.

The second drift happened between April 16th and May 4th (between April 16th and May 19th, the SLO reporting was broken; see https://github.com/DataDog/nginx-datadog/pull/383).

I think this is a platform drift because the bump can be observed on the baseline, and [nothing changed on the benchmark tests setup side](https://github.com/DataDog/nginx-datadog/commits/master/.gitlab/benchmarks.yml).