### PR TITLE
Version 1.18.0 with support for latest Nginx and OpenResty versions

### DIFF
--- a/.gitlab/build-and-test-all.yml
+++ b/.gitlab/build-and-test-all.yml
@@ -58,7 +58,9 @@ build-nginx-all:
           - "1.29.8"
           - "1.30.0"
           - "1.30.1"
+          - "1.30.2"
           - "1.31.0"
+          - "1.31.1"
         WAF: ["ON", "OFF"]
 
 build-nginx-rum-all:
@@ -100,7 +102,9 @@ build-nginx-rum-all:
           - "1.29.8"
           - "1.30.0"
           - "1.30.1"
+          - "1.30.2"
           - "1.31.0"
+          - "1.31.1"
         WAF: ["OFF"]
 
 build-ingress-nginx-all:
@@ -169,6 +173,7 @@ build-openresty-all:
           - "1.27.1.2"
           - "1.29.2.1"
           - "1.29.2.3"
+          - "1.29.2.4"
         WAF: ["ON", "OFF"]
 
 test-nginx-all:
@@ -310,8 +315,16 @@ test-nginx-all-bis:
         NGINX_VERSION: ["1.30.1"]
         WAF: ["ON", "OFF"]
       - ARCH: ["amd64", "arm64"]
+        BASE_IMAGE: ["nginx:1.30.2", "nginx:1.30.2-alpine"]
+        NGINX_VERSION: ["1.30.2"]
+        WAF: ["ON", "OFF"]
+      - ARCH: ["amd64", "arm64"]
         BASE_IMAGE: ["nginx:1.31.0", "nginx:1.31.0-alpine"]
         NGINX_VERSION: ["1.31.0"]
+        WAF: ["ON", "OFF"]
+      - ARCH: ["amd64", "arm64"]
+        BASE_IMAGE: ["nginx:1.31.1", "nginx:1.31.1-alpine"]
+        NGINX_VERSION: ["1.31.1"]
         WAF: ["ON", "OFF"]
       - ARCH: ["amd64", "arm64"]
         BASE_IMAGE: ["amazonlinux:2023.11.20260427.1"]
@@ -449,8 +462,16 @@ test-nginx-rum-all:
         NGINX_VERSION: ["1.30.1"]
         WAF: ["OFF"]
       - ARCH: ["amd64", "arm64"]
+        BASE_IMAGE: ["nginx:1.30.2"]
+        NGINX_VERSION: ["1.30.2"]
+        WAF: ["OFF"]
+      - ARCH: ["amd64", "arm64"]
         BASE_IMAGE: ["nginx:1.31.0"]
         NGINX_VERSION: ["1.31.0"]
+        WAF: ["OFF"]
+      - ARCH: ["amd64", "arm64"]
+        BASE_IMAGE: ["nginx:1.31.1"]
+        NGINX_VERSION: ["1.31.1"]
         WAF: ["OFF"]
 
 test-ingress-nginx-all:
@@ -519,4 +540,5 @@ test-openresty-all:
           - "1.27.1.2"
           - "1.29.2.1"
           - "1.29.2.3"
+          - "1.29.2.4"
         WAF: ["ON", "OFF"]

--- a/.gitlab/build-and-test-fast.yml
+++ b/.gitlab/build-and-test-fast.yml
@@ -62,8 +62,8 @@ build-nginx-fast:
           - "1.27.5"
           - "1.28.3"
           - "1.29.8"
-          - "1.30.1"
-          - "1.31.0"
+          - "1.30.2"
+          - "1.31.1"
         WAF: ["ON", "OFF"]
 
 build-ingress-nginx-fast:
@@ -87,7 +87,7 @@ build-openresty-fast:
       - ARCH: ["amd64", "arm64"]
         RESTY_VERSION:
           - "1.27.1.2"
-          - "1.29.2.3"
+          - "1.29.2.4"
         WAF: ["ON", "OFF"]
 
 build-nginx-rum-fast:
@@ -103,8 +103,8 @@ build-nginx-rum-fast:
           - "1.27.5"
           - "1.28.3"
           - "1.29.8"
-          - "1.30.1"
-          - "1.31.0"
+          - "1.30.2"
+          - "1.31.1"
         WAF: ["OFF"]
 
 test-nginx-fast:
@@ -135,12 +135,12 @@ test-nginx-fast:
         NGINX_VERSION: ["1.29.8"]
         WAF: ["ON", "OFF"]
       - ARCH: ["amd64", "arm64"]
-        BASE_IMAGE: ["nginx:1.30.1", "nginx:1.30.1-alpine"]
-        NGINX_VERSION: ["1.30.1"]
+        BASE_IMAGE: ["nginx:1.30.2", "nginx:1.30.2-alpine"]
+        NGINX_VERSION: ["1.30.2"]
         WAF: ["ON", "OFF"]
       - ARCH: ["amd64", "arm64"]
-        BASE_IMAGE: ["nginx:1.31.0", "nginx:1.31.0-alpine"]
-        NGINX_VERSION: ["1.31.0"]
+        BASE_IMAGE: ["nginx:1.31.1", "nginx:1.31.1-alpine"]
+        NGINX_VERSION: ["1.31.1"]
         WAF: ["ON", "OFF"]
       - ARCH: ["amd64", "arm64"]
         BASE_IMAGE: ["amazonlinux:2023.11.20260427.1"]
@@ -170,7 +170,7 @@ test-openresty-fast:
       - ARCH: ["amd64", "arm64"]
         RESTY_VERSION:
           - "1.27.1.2"
-          - "1.29.2.3"
+          - "1.29.2.4"
         WAF: ["ON", "OFF"]
 
 test-nginx-rum-fast:
@@ -201,12 +201,12 @@ test-nginx-rum-fast:
         NGINX_VERSION: ["1.29.8"]
         WAF: ["OFF"]
       - ARCH: ["amd64", "arm64"]
-        BASE_IMAGE: ["nginx:1.30.1"]
-        NGINX_VERSION: ["1.30.1"]
+        BASE_IMAGE: ["nginx:1.30.2"]
+        NGINX_VERSION: ["1.30.2"]
         WAF: ["OFF"]
       - ARCH: ["amd64", "arm64"]
-        BASE_IMAGE: ["nginx:1.31.0"]
-        NGINX_VERSION: ["1.31.0"]
+        BASE_IMAGE: ["nginx:1.31.1"]
+        NGINX_VERSION: ["1.31.1"]
         WAF: ["OFF"]
 
 coverage:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 cmake_policy(SET CMP0068 NEW)
 cmake_policy(SET CMP0135 NEW)
 
-set(NGINX_DATADOG_VERSION 1.17.1)
+set(NGINX_DATADOG_VERSION 1.18.0)
 project(ngx_http_datadog_module VERSION ${NGINX_DATADOG_VERSION})
 
 option(NGINX_DATADOG_ASM_ENABLED "Build with libddwaf" ON)


### PR DESCRIPTION
- Add support for Nginx [1.30.2](https://github.com/nginx/nginx/releases/tag/release-1.30.2) and [1.31.1](https://github.com/nginx/nginx/releases/tag/release-1.31.1) and [OpenResty 1.29.2.4](https://openresty.org/en/ann-1029002004.html).
- Bump the version to `1.18.0`.

_At the time of writing, some CI jobs will fail because the Alpine Docker images for Nginx 1.30.2 and 1.31.1 are not yet available._