### PR TITLE
fix: check buf->last_buf instead of buf->last in chain::has_last()

### DIFF
--- a/src/security/util.h
+++ b/src/security/util.h
@@ -211,7 +211,7 @@ inline std::size_t has_special(ngx_chain_t const *ch) {
 }
 inline std::size_t has_last(ngx_chain_t const *ch) {
   for (ngx_chain_t const *cl = ch; cl; cl = cl->next) {
-    if (cl->buf->last) {
+    if (cl->buf->last_buf) {
       return true;
     }
   }

--- a/test/cases/sec_addresses/conf/http.conf
+++ b/test/cases/sec_addresses/conf/http.conf
@@ -16,6 +16,7 @@ http {
     datadog_appsec_ruleset_file /tmp/waf.json;
     datadog_appsec_waf_timeout 2s;
     datadog_waf_thread_pool_name waf_thread_pool;
+    send_timeout 5s;
 
     server {
         listen       80;

--- a/test/cases/sec_addresses/conf/waf_response_body_address.json
+++ b/test/cases/sec_addresses/conf/waf_response_body_address.json
@@ -1,0 +1,56 @@
+{
+  "version": "2.1",
+  "metadata": {
+    "rules_version": "1.2.6"
+  },
+  "rules": [
+    {
+      "id": "any_response_body",
+      "name": "Match any response body (including empty string)",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.response.body"
+              }
+            ],
+            "regex": ".*"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": [
+        "values_only"
+      ]
+    },
+    {
+      "id": "202",
+      "name": "Match 202 response",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.response.status"
+              }
+            ],
+            "regex": "^202$"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": [
+        "values_only"
+      ]
+    }
+  ]
+}

--- a/test/cases/sec_addresses/test_sec_response_body_address.py
+++ b/test/cases/sec_addresses/test_sec_response_body_address.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+from .. import case
+
+
+class TestSecResponseBodyAddress(case.TestCase):
+    """Verify which WAF addresses are populated for responses with empty bodies."""
+
+    config_setup_done = False
+    requires_waf = True
+
+    def setUp(self):
+        super().setUp()
+        if not TestSecResponseBodyAddress.config_setup_done:
+            waf_path = (Path(__file__).parent /
+                        './conf/waf_response_body_address.json')
+            self.orch.nginx_replace_file('/tmp/waf.json', waf_path.read_text())
+
+            conf_path = Path(__file__).parent / './conf/http.conf'
+            status, log_lines = self.orch.nginx_replace_config(
+                conf_path.read_text(), conf_path.name)
+            self.assertEqual(0, status, log_lines)
+
+            TestSecResponseBodyAddress.config_setup_done = True
+
+        self.orch.sync_service('agent')
+
+    def test_empty_body_response_body_address_absent(self):
+        """server.response.body is not sent to the WAF for empty-body responses."""
+        status, _, _ = self.orch.send_nginx_http_request(
+            '/http/empty_body_json', 80)
+        self.assertEqual(202, status)
+
+        report = self.orch.find_first_appsec_report()
+        self.assertIsNotNone(report, 'WAF did not produce an appsec report')
+
+        rule_ids = {t['rule']['id'] for t in report['triggers']}
+        self.assertIn(
+            '202', rule_ids, 'WAF did not fire on server.response.status; '
+            'WAF may not have run at all')
+        self.assertNotIn(
+            'any_response_body', rule_ids,
+            'server.response.body was unexpectedly sent to '
+            'the WAF for an empty-body response')

--- a/test/services/http/http.js
+++ b/test/services/http/http.js
@@ -63,6 +63,15 @@ const requestListener = function (request, response) {
     return;
   }
 
+  if (request.url.match(/.*\/empty_body_json\/?(?:\?.*)?$/)) {
+    response.writeHead(202, {
+      "content-type": "application/json",
+      "content-length": "0"
+    });
+    response.end();
+    return;
+  }
+
   // parameterized response body test endpoint
   if (request.url.match(/.*\/response_body_test\/?.*/)) {
     ignoreRequestBody(request);


### PR DESCRIPTION
Replaces https://github.com/DataDog/nginx-datadog/pull/386 to add a commit, satisfy the signing requirements and run the CI jobs.

Key elements from the original PR:

## Impact
Any upstream response with `Content-Length: 0` and a parseable `Content-Type` (`application/json`, `text/plain`) hangs for 60 seconds and returns `408` when AppSec is enabled.

## Reproduction

1. Configure Nginx with AppSec enabled (`datadog_appsec_enabled on`).
2. Set up a `proxy_pass` upstream that returns `202 Accepted` with `Content-Length: 0` and `Content-Type: application/json`.
3. Send a POST request through Nginx.
4. Observe: Nginx hangs for 60s (`send_timeout` default), then returns 408 with `bytes_sent: 0`.