### PR TITLE
Supply chain security vulnerability mitigation for code coverage upload

### DIFF
--- a/.gitlab/build-and-test-fast.yml
+++ b/.gitlab/build-and-test-fast.yml
@@ -220,4 +220,4 @@ coverage:
     WAF: "ON"
   tags: ["docker-in-docker:$ARCH"]
   script:
-    - DD_API_KEY=$(vault kv get -field key kv/k8s/gitlab-runner/nginx-datadog/datadoghq-api-key 2>/dev/null) make coverage
+    - make coverage

--- a/Makefile
+++ b/Makefile
@@ -303,4 +303,5 @@ endif
 	uv run --project test test/bin/run.py --image ${BASE_IMAGE} --module-path .musl-build/ngx_http_datadog_module.so -- --verbose --failfast
 	tar -C .musl-build -xzf test/coverage_data.tar.gz
 	cd .musl-build; llvm-profdata merge -sparse *.profraw -o default.profdata && llvm-cov export ./ngx_http_datadog_module.so -format=lcov -instr-profile=default.profdata -ignore-filename-regex=src/coverage_fixup\.c > coverage.lcov
-	npx --yes @datadog/datadog-ci@latest coverage upload --format=lcov .musl-build/coverage.lcov
+	# datadog-ci package comes from https://www.npmjs.com/package/@datadog/datadog-ci?activeTab=versions
+	npx --yes @datadog/datadog-ci@5.18.0 coverage upload --format=lcov .musl-build/coverage.lcov

--- a/Makefile
+++ b/Makefile
@@ -304,4 +304,4 @@ endif
 	tar -C .musl-build -xzf test/coverage_data.tar.gz
 	cd .musl-build; llvm-profdata merge -sparse *.profraw -o default.profdata && llvm-cov export ./ngx_http_datadog_module.so -format=lcov -instr-profile=default.profdata -ignore-filename-regex=src/coverage_fixup\.c > coverage.lcov
 	# datadog-ci package comes from https://www.npmjs.com/package/@datadog/datadog-ci?activeTab=versions
-	npx --yes @datadog/datadog-ci@5.18.0 coverage upload --format=lcov .musl-build/coverage.lcov
+	DD_API_KEY=$$(vault kv get -field=key kv/k8s/gitlab-runner/nginx-datadog/datadoghq-api-key 2>/dev/null) npx --yes @datadog/datadog-ci@5.18.0 coverage upload --format=lcov .musl-build/coverage.lcov


### PR DESCRIPTION
This is a mitigation of the supply chain security vulnerability described in [APMSP-3393 Unpinned npm uploader runs in CI with Datadog API key](https://datadoghq.atlassian.net/browse/APMSP-3393).

For the upload of the code coverage results:

- Use a pinned version of the `datadog-ci` npm package.
- Narrow the scope of the `DD_API_KEY` secret (got from vault).