### PR TITLE
Removes legacy secrets

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -43,9 +43,6 @@ jobs:
     needs:
     - build
     uses:  DataDog/system-tests/.github/workflows/system-tests.yml@main
-    secrets:
-      DD_API_KEY: ${{ secrets.DD_API_KEY }}
-      TEST_OPTIMIZATION_API_KEY: ${{ secrets.DD_API_KEY }}
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
This API key should ne be present anymore in our repo secrets. system-tests ships a mechanism to get the key for test optim, and does not require any more a key for testing.