### PR TITLE
Fix a call to ngx_log_error: values must be passed by reference

### DIFF
--- a/src/security/ddwaf_req.cpp
+++ b/src/security/ddwaf_req.cpp
@@ -289,7 +289,7 @@ bool handle_schema(ngx_log_t &log, const ddwaf_obj &obj, Func &&f) {
     if (b64.size() > kMaxSchemaSize) {
       ngx_log_error(NGX_LOG_INFO, ngx_cycle->log, 0,
                     "ddwaf_req: base-64 encoded attribute %V is too large",
-                    key);
+                    &key);
       return true;
     }
 


### PR DESCRIPTION
This is a follow-up of https://github.com/DataDog/nginx-datadog/pull/394.

Investigating [an issue on with test_failed_regenerate_does_not_crash (with Nginx 1.25.1)](https://gitlab.ddbuild.io/DataDog/apm-reliability/nginx-datadog/-/jobs/1755515506), I found one remaining wrong call to `ngx_log_error` (values must be passed by reference, not by value; this can't be checked at compile time because of the usage of C variadics).