### PR TITLE
Option to check the downloaded tarball when running the tracing example

### DIFF
--- a/example/openresty/bin/run
+++ b/example/openresty/bin/run
@@ -6,7 +6,7 @@ cd "$(dirname "$0")"/..
 DEFAULT_OPENRESTY_VERSION=1.29.2.1
 
 usage() {
-    echo "Usage: $0 [--openresty OpenResty_version] [--nginx-datadog Nginx_Datadog_version] [--no-cache]"
+    echo "Usage: $0 [--openresty OpenResty_version] [--nginx-datadog Nginx_Datadog_version] [--no-cache] [--show-docker-build]"
     echo "  -h, --help"
     echo "      show this help message"
     echo "  --openresty OpenResty_version"
@@ -15,6 +15,8 @@ usage() {
     echo "      Nginx Datadog release tag (example: 1.0.0, default: latest one)"
     echo "  --no-cache"
     echo "      disable cache when building Docker images"
+    echo "  --show-docker-build"
+    echo "      show the full Docker build log"
 }
 
 while [ $# -gt 0 ]; do
@@ -37,6 +39,10 @@ while [ $# -gt 0 ]; do
             NO_CACHE=true
             shift
             ;;
+        --show-docker-build)
+            SHOW_DOCKER_BUILD=true
+            shift
+            ;;
         *)
             usage >&2
             exit 1
@@ -53,7 +59,5 @@ if [ "$DD_API_KEY" = '' ]; then
     exit 1
 fi
 
-if [ -n "$NO_CACHE" ]; then
-    docker compose build --no-cache
-fi
-docker compose up --build --abort-on-container-exit --remove-orphans
+docker compose build ${SHOW_DOCKER_BUILD:+--progress=plain} ${NO_CACHE:+--no-cache}
+docker compose up --abort-on-container-exit --remove-orphans

--- a/example/openresty/services/openresty/install_datadog.sh
+++ b/example/openresty/services/openresty/install_datadog.sh
@@ -25,6 +25,8 @@ else
   nginx_datadog_release_tag=$(get_latest_release "$repository")
 fi
 
-wget "https://github.com/$repository/releases/download/$nginx_datadog_release_tag/$tarball"
+url="https://github.com/$repository/releases/download/$nginx_datadog_release_tag/$tarball"
+wget "$url"
+printf '\033[1;32m--- Downloaded %s for Nginx Datadog %s from %s\033[0m\n' "$tarball" "$nginx_datadog_release_tag" "$url"
 tar -xzf "$tarball" -C /usr/local/openresty/nginx/modules
 rm "$tarball"

--- a/example/tracing/bin/run
+++ b/example/tracing/bin/run
@@ -6,7 +6,7 @@ cd "$(dirname "$0")"/..
 DEFAULT_NGINX_VERSION=1.29.7
 
 usage() {
-    echo "Usage: $0 [--nginx Nginx_version] [--nginx-datadog Nginx_Datadog_version] [--no-cache]"
+    echo "Usage: $0 [--nginx Nginx_version] [--nginx-datadog Nginx_Datadog_version] [--no-cache] [--show-docker-build]"
     echo "  -h, --help"
     echo "      show this help message"
     echo "  --nginx Nginx_version"
@@ -15,6 +15,8 @@ usage() {
     echo "      Nginx Datadog release tag (example: 1.0.0, default: latest one)"
     echo "  --no-cache"
     echo "      disable cache when building Docker images"
+    echo "  --show-docker-build"
+    echo "      show the full Docker build log"
 }
 
 while [ $# -gt 0 ]; do
@@ -35,6 +37,10 @@ while [ $# -gt 0 ]; do
             ;;
         --no-cache)
             NO_CACHE=true
+            shift
+            ;;
+        --show-docker-build)
+            SHOW_DOCKER_BUILD=true
             shift
             ;;
         *)
@@ -66,7 +72,5 @@ if [ "$DD_API_KEY" = '' ]; then
     exit 1
 fi
 
-if [ -n "$NO_CACHE" ]; then
-    docker compose build --no-cache
-fi
-docker compose up --build --abort-on-container-exit --remove-orphans
+docker compose build ${SHOW_DOCKER_BUILD:+--progress=plain} ${NO_CACHE:+--no-cache}
+docker compose up --abort-on-container-exit --remove-orphans

--- a/example/tracing/services/nginx/install_datadog.sh
+++ b/example/tracing/services/nginx/install_datadog.sh
@@ -60,6 +60,8 @@ else
   nginx_datadog_release_tag=$(get_latest_release "$repository")
 fi
 
-wget "https://github.com/$repository/releases/download/$nginx_datadog_release_tag/$tarball"
+url="https://github.com/$repository/releases/download/$nginx_datadog_release_tag/$tarball"
+wget "$url"
+printf '\033[1;32m--- Downloaded %s for Nginx Datadog %s from %s\033[0m\n' "$tarball" "$nginx_datadog_release_tag" "$url"
 tar -xzf "$tarball" -C "$nginx_modules_path"
 rm "$tarball"


### PR DESCRIPTION
For the `tracing` and `openresty` examples, add an option to the `bin/run` script and a log line in `install_datadog.sh` so that to easily check that the correct version of the module has been downloaded, when [running the smoke tests](https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/6059131694/Delivery+Nginx#Run-Smoke-Tests).

Example:
```
bin/run --show-docker-build --nginx 1.29.8 --nginx-datadog 1.18.0
[…]
#23 [nginx 4/5] RUN /tmp/install_datadog.sh
#23 3.760   1600K .......... .......... .......... .......... .......... 94% 1021K 0s
#23 3.802   1650K .......... .......... .......... .......... .......... 97% 1.24M 0s
#23 3.841   1700K .......... .......... .......... ..........           100% 1.09M=2.7s
#23 3.878
#23 3.878 2026-06-10 14:10:56 (648 KB/s) - 'ngx_http_datadog_module-appsec-arm64-1.29.8.so.tgz' saved [1782483/1782483]
#23 3.878
#23 3.879 --- Downloaded ngx_http_datadog_module-appsec-arm64-1.29.8.so.tgz for Nginx Datadog v1.18.0 from https://github.com/DataDog/nginx-datadog/releases/download/v1.18.0/ngx_http_datadog_module-appsec-arm64-1.29.8.so.tgz
#23 3.879 + printf '\033[1;32m--- Downloaded %s for Nginx Datadog %s from %s\033[0m\n' ngx_http_datadog_module-appsec-arm64-1.29.8.so.tgz v1.18.0 https://github.com/DataDog/nginx-datadog/releases/download/v1.18.0/ngx_http_datadog_module-appsec-arm64-1.29.8.so.tgz
#23 3.879 + tar -xzf ngx_http_datadog_module-appsec-arm64-1.29.8.so.tgz -C /usr/lib/nginx/modules
#23 3.920 + rm ngx_http_datadog_module-appsec-arm64-1.29.8.so.tgz
#23 DONE 3.9s
```
(The `--- Downloaded […]` line appears in bold and green in the terminal.)