### PR TITLE
fix resource renaming not enabled if appsec enabled via env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -304,4 +304,8 @@ endif
 	tar -C .musl-build -xzf test/coverage_data.tar.gz
 	cd .musl-build; llvm-profdata merge -sparse *.profraw -o default.profdata && llvm-cov export ./ngx_http_datadog_module.so -format=lcov -instr-profile=default.profdata -ignore-filename-regex=src/coverage_fixup\.c > coverage.lcov
 	# datadog-ci package comes from https://www.npmjs.com/package/@datadog/datadog-ci?activeTab=versions
-	DD_API_KEY=$$(vault kv get -field=key kv/k8s/gitlab-runner/nginx-datadog/datadoghq-api-key 2>/dev/null) npx --yes @datadog/datadog-ci@5.18.0 coverage upload --format=lcov .musl-build/coverage.lcov
+	DD_API_KEY=$$(vault kv get -field=key kv/k8s/gitlab-runner/nginx-datadog/datadoghq-api-key); \
+	vault_status=$$?; \
+	if [ $$vault_status -ne 0 ]; then exit $$vault_status; fi; \
+	echo "Retrieved DD_API_KEY from Vault ($${#DD_API_KEY} bytes)"; \
+	DD_API_KEY="$$DD_API_KEY" npx --yes @datadog/datadog-ci@5.18.0 coverage upload --format=lcov .musl-build/coverage.lcov

--- a/src/tracing_library.cpp
+++ b/src/tracing_library.cpp
@@ -14,6 +14,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cstdio>
+#include <cstdlib>
 #include <iterator>
 
 extern "C" {
@@ -23,6 +24,7 @@ extern "C" {
 #include "datadog_conf.h"
 #include "ngx_event_scheduler.h"
 #ifdef WITH_WAF
+#include "security/library.h"
 #include "security/waf_remote_cfg.h"
 #endif
 #include "nginx_flavors.h"
@@ -84,7 +86,8 @@ dd::Expected<dd::Tracer> TracingLibrary::make_tracer(
     const char *env_renaming =
         std::getenv("DD_TRACE_RESOURCE_RENAMING_ENABLED");
     if (!env_renaming || !env_renaming[0]) {
-      config.resource_renaming_enabled = {nginx_conf.appsec_enabled == 1};
+      config.resource_renaming_enabled = {
+          bool{security::Library::get_handle()}};
     }
   }
 #endif

--- a/test/cases/case.py
+++ b/test/cases/case.py
@@ -1,5 +1,6 @@
 """Boilerplate for test cases"""
 
+import functools
 import os
 import queue
 import re
@@ -7,6 +8,17 @@ import time
 import unittest
 
 from . import orchestration
+
+
+def skip_if_waf_disabled(func):
+
+    @functools.wraps(func)
+    def wrapper(self, *args, **kwargs):
+        if self.waf_disabled:
+            self.skipTest("WAF is disabled - appsec test requires WAF support")
+        return func(self, *args, **kwargs)
+
+    return wrapper
 
 
 class TestCase(unittest.TestCase):

--- a/test/cases/endpoint_renaming/conf/appsec_enabled_env.conf
+++ b/test/cases/endpoint_renaming/conf/appsec_enabled_env.conf
@@ -1,0 +1,41 @@
+# Test configuration for endpoint renaming with appsec enabled by environment
+# This configuration tests that endpoint renaming defaults to enabled when
+# DD_APPSEC_ENABLED=true, without explicit nginx directives for appsec or
+# resource renaming.
+
+thread_pool waf_thread_pool threads=2 max_queue=5;
+
+load_module /datadog-tests/ngx_http_datadog_module.so;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    datadog_agent_url http://agent:8126;
+    datadog_service_name test-service;
+    datadog_waf_thread_pool_name waf_thread_pool;
+
+    # No datadog_appsec_enabled directive.
+    # No datadog_resource_renaming_enabled directive.
+    # AppSec is enabled only by DD_APPSEC_ENABLED=true in the nginx process env.
+
+    server {
+        listen 80;
+        server_name localhost;
+
+        location /healthcheck {
+            datadog_tracing off;
+            return 200 "ok";
+        }
+
+        location /api/users {
+            return 200 "User endpoint";
+        }
+
+        location /api/orders {
+            datadog_tag "http.route" "/api/orders/:id";
+            return 200 "Order endpoint";
+        }
+    }
+}

--- a/test/cases/endpoint_renaming/test_endpoint_renaming.py
+++ b/test/cases/endpoint_renaming/test_endpoint_renaming.py
@@ -24,36 +24,33 @@ class TestEndpointRenaming(case.TestCase):
             self.assertEqual(0, status, log_lines)
             TestEndpointRenaming.last_config = new_config
 
-    def send_request_and_get_span(self, url, config_name):
-        self.replace_config(config_name)
+    def send_request_and_get_span(
+            self,
+            url: str,
+            config_name: str,
+            extra_env: dict[str, str] | None = None) -> tuple[int, dict]:
         self.orch.sync_service('agent')
 
-        status, _, _ = self.orch.send_nginx_http_request(url)
-
-        self.orch.reload_nginx()
-        log_lines = self.orch.sync_service('agent')
-
-        spans = formats.parse_spans(log_lines)
-        nginx_spans = [s for s in spans if s.get('service') == 'test-service']
-
-        self.assertEqual(len(nginx_spans), 1, "Expected exactly one span")
-
-        return status, nginx_spans[0]
-
-    def send_request_and_get_span_with_env(self, url, config_name, extra_env):
-        conf_path = Path(__file__).parent / "conf" / config_name
-        conf_text = conf_path.read_text()
-
-        self.orch.sync_service('agent')
-        try:
-            with self.orch.custom_nginx(conf_text,
-                                        extra_env=extra_env,
-                                        healthcheck_port=80):
-                self.orch.sync_service('agent')
-                status, _, _ = self.orch.send_nginx_http_request(url)
-                self.assertEqual(200, status)
-        finally:
-            TestEndpointRenaming.last_config = ''
+        if extra_env is not None:
+            conf_path = Path(__file__).parent / "conf" / config_name
+            conf_text = conf_path.read_text()
+            try:
+                with self.orch.custom_nginx(conf_text,
+                                            extra_env=extra_env,
+                                            healthcheck_port=80):
+                    self.orch.sync_service('agent')
+                    status, _, _ = self.orch.send_nginx_http_request(url)
+                    self.assertEqual(200, status)
+            finally:
+                # after custom_nginx calls reload_nginx_with_empty_config()
+                # to release ports, the main nginx has no server blocks.
+                # Resetting last_config ensures the next replace_config call
+                # actually replaces it.
+                TestEndpointRenaming.last_config = ''
+        else:
+            self.replace_config(config_name)
+            status, _, _ = self.orch.send_nginx_http_request(url)
+            self.orch.reload_nginx()
 
         log_lines = self.orch.sync_service('agent')
         spans = formats.parse_spans(log_lines)
@@ -61,14 +58,12 @@ class TestEndpointRenaming(case.TestCase):
             s for s in spans if s.get('service') == 'test-service'
             and s.get('meta', {}).get('http.url', '').endswith(url)
         ]
-
         self.assertEqual(len(nginx_spans), 1, {
             "url": url,
             "spans": nginx_spans,
             "log_lines": log_lines,
         })
-
-        return 200, nginx_spans[0]
+        return status, nginx_spans[0]
 
     def test_endpoint_renaming_disabled_by_default(self):
         """Verify that endpoint renaming is disabled by default.
@@ -149,6 +144,7 @@ class TestEndpointRenaming(case.TestCase):
         self.assertEqual(meta['http.route'], '/api/orders/:id')
         self.assertEqual(meta['http.endpoint'], '/api/orders/{param:int}')
 
+    @case.skip_if_waf_disabled
     def test_appsec_enables_fallback_mode_by_default(self):
         """Verify that when appsec is enabled, endpoint renaming defaults to fallback mode.
 
@@ -157,9 +153,6 @@ class TestEndpointRenaming(case.TestCase):
         - http.endpoint calculated when http.route not present
         - http.endpoint NOT calculated when http.route is present
         """
-        if self.waf_disabled:
-            self.skipTest("WAF is disabled - appsec test requires WAF support")
-
         # Test without http.route - should calculate endpoint
         status, span = self.send_request_and_get_span("/api/users/456",
                                                       "appsec_enabled.conf")
@@ -187,14 +180,13 @@ class TestEndpointRenaming(case.TestCase):
             "http.endpoint should NOT be set when http.route exists in fallback mode (appsec enabled)"
         )
 
+    @case.skip_if_waf_disabled
     def test_appsec_env_enables_fallback_mode_by_default(self):
         """Verify that DD_APPSEC_ENABLED=true enables endpoint renaming by default."""
-        if self.waf_disabled:
-            self.skipTest("WAF is disabled - appsec test requires WAF support")
-
-        status, span = self.send_request_and_get_span_with_env(
-            "/api/users/456", "appsec_enabled_env.conf",
-            {"DD_APPSEC_ENABLED": "true"})
+        status, span = self.send_request_and_get_span(
+            "/api/users/456",
+            "appsec_enabled_env.conf",
+            extra_env={"DD_APPSEC_ENABLED": "true"})
         self.assertEqual(200, status)
 
         meta = span.get('meta', {})

--- a/test/cases/endpoint_renaming/test_endpoint_renaming.py
+++ b/test/cases/endpoint_renaming/test_endpoint_renaming.py
@@ -40,6 +40,36 @@ class TestEndpointRenaming(case.TestCase):
 
         return status, nginx_spans[0]
 
+    def send_request_and_get_span_with_env(self, url, config_name, extra_env):
+        conf_path = Path(__file__).parent / "conf" / config_name
+        conf_text = conf_path.read_text()
+
+        self.orch.sync_service('agent')
+        try:
+            with self.orch.custom_nginx(conf_text,
+                                        extra_env=extra_env,
+                                        healthcheck_port=80):
+                self.orch.sync_service('agent')
+                status, _, _ = self.orch.send_nginx_http_request(url)
+                self.assertEqual(200, status)
+        finally:
+            TestEndpointRenaming.last_config = ''
+
+        log_lines = self.orch.sync_service('agent')
+        spans = formats.parse_spans(log_lines)
+        nginx_spans = [
+            s for s in spans if s.get('service') == 'test-service'
+            and s.get('meta', {}).get('http.url', '').endswith(url)
+        ]
+
+        self.assertEqual(len(nginx_spans), 1, {
+            "url": url,
+            "spans": nginx_spans,
+            "log_lines": log_lines,
+        })
+
+        return 200, nginx_spans[0]
+
     def test_endpoint_renaming_disabled_by_default(self):
         """Verify that endpoint renaming is disabled by default.
 
@@ -156,3 +186,21 @@ class TestEndpointRenaming(case.TestCase):
             'http.endpoint', meta,
             "http.endpoint should NOT be set when http.route exists in fallback mode (appsec enabled)"
         )
+
+    def test_appsec_env_enables_fallback_mode_by_default(self):
+        """Verify that DD_APPSEC_ENABLED=true enables endpoint renaming by default."""
+        if self.waf_disabled:
+            self.skipTest("WAF is disabled - appsec test requires WAF support")
+
+        status, span = self.send_request_and_get_span_with_env(
+            "/api/users/456", "appsec_enabled_env.conf",
+            {"DD_APPSEC_ENABLED": "true"})
+        self.assertEqual(200, status)
+
+        meta = span.get('meta', {})
+        self.assertIn(
+            'http.endpoint', meta,
+            "http.endpoint should be present when appsec is enabled by env")
+        self.assertEqual(
+            meta['http.endpoint'], '/api/users/{param:int}',
+            f"Expected /api/users/{{param:int}}, got {meta['http.endpoint']}")


### PR DESCRIPTION
When resource renaming is not explicitly enabled or disabled, it should get enabled if appsec is explicitly enabled (not via remote config). However, we were only checking for the enablement via nginx config file, not the env var. Fix that