### PR TITLE
Add support for Nginx 1.30.3 and 1.31.2

### DIFF
--- a/.gitlab/build-and-test-all.yml
+++ b/.gitlab/build-and-test-all.yml
@@ -58,8 +58,10 @@ build-nginx-all:
           - "1.30.0"
           - "1.30.1"
           - "1.30.2"
+          - "1.30.3"
           - "1.31.0"
           - "1.31.1"
+          - "1.31.2"
         WAF: ["ON", "OFF"]
 
 build-nginx-rum-all:
@@ -101,8 +103,10 @@ build-nginx-rum-all:
           - "1.30.0"
           - "1.30.1"
           - "1.30.2"
+          - "1.30.3"
           - "1.31.0"
           - "1.31.1"
+          - "1.31.2"
         WAF: ["OFF"]
 
 build-ingress-nginx-all:
@@ -315,12 +319,20 @@ test-nginx-all-bis:
         NGINX_VERSION: ["1.30.2"]
         WAF: ["ON", "OFF"]
       - ARCH: ["amd64", "arm64"]
+        BASE_IMAGE: ["nginx:1.30.3", "nginx:1.30.3-alpine"]
+        NGINX_VERSION: ["1.30.3"]
+        WAF: ["ON", "OFF"]
+      - ARCH: ["amd64", "arm64"]
         BASE_IMAGE: ["nginx:1.31.0", "nginx:1.31.0-alpine"]
         NGINX_VERSION: ["1.31.0"]
         WAF: ["ON", "OFF"]
       - ARCH: ["amd64", "arm64"]
         BASE_IMAGE: ["nginx:1.31.1", "nginx:1.31.1-alpine"]
         NGINX_VERSION: ["1.31.1"]
+        WAF: ["ON", "OFF"]
+      - ARCH: ["amd64", "arm64"]
+        BASE_IMAGE: ["nginx:1.31.2", "nginx:1.31.2-alpine"]
+        NGINX_VERSION: ["1.31.2"]
         WAF: ["ON", "OFF"]
       - ARCH: ["amd64", "arm64"]
         BASE_IMAGE: ["amazonlinux:2023.11.20260427.1"]
@@ -458,12 +470,20 @@ test-nginx-rum-all:
         NGINX_VERSION: ["1.30.2"]
         WAF: ["OFF"]
       - ARCH: ["amd64", "arm64"]
+        BASE_IMAGE: ["nginx:1.30.3"]
+        NGINX_VERSION: ["1.30.3"]
+        WAF: ["OFF"]
+      - ARCH: ["amd64", "arm64"]
         BASE_IMAGE: ["nginx:1.31.0"]
         NGINX_VERSION: ["1.31.0"]
         WAF: ["OFF"]
       - ARCH: ["amd64", "arm64"]
         BASE_IMAGE: ["nginx:1.31.1"]
         NGINX_VERSION: ["1.31.1"]
+        WAF: ["OFF"]
+      - ARCH: ["amd64", "arm64"]
+        BASE_IMAGE: ["nginx:1.31.2"]
+        NGINX_VERSION: ["1.31.2"]
         WAF: ["OFF"]
 
 test-ingress-nginx-all:

--- a/.gitlab/build-and-test-fast.yml
+++ b/.gitlab/build-and-test-fast.yml
@@ -73,8 +73,8 @@ build-nginx-fast:
           - "1.27.5"
           - "1.28.3"
           - "1.29.8"
-          - "1.30.2"
-          - "1.31.1"
+          - "1.30.3"
+          - "1.31.2"
         WAF: ["ON", "OFF"]
 
 build-nginx-asan-fast:
@@ -83,7 +83,7 @@ build-nginx-asan-fast:
     - .build-nginx-asan
   variables:
     ARCH: "amd64"
-    NGINX_VERSION: "1.31.1"
+    NGINX_VERSION: "1.31.2"
     WAF: "ON"
 
 build-nginx-msan-fast:
@@ -92,7 +92,7 @@ build-nginx-msan-fast:
     - .build-nginx-msan
   variables:
     ARCH: "amd64"
-    NGINX_VERSION: "1.31.1"
+    NGINX_VERSION: "1.31.2"
     WAF: "ON"
 
 build-ingress-nginx-fast:
@@ -133,8 +133,8 @@ build-nginx-rum-fast:
           - "1.27.5"
           - "1.28.3"
           - "1.29.8"
-          - "1.30.2"
-          - "1.31.1"
+          - "1.30.3"
+          - "1.31.2"
         WAF: ["OFF"]
 
 test-nginx-fast:
@@ -165,12 +165,12 @@ test-nginx-fast:
         NGINX_VERSION: ["1.29.8"]
         WAF: ["ON", "OFF"]
       - ARCH: ["amd64", "arm64"]
-        BASE_IMAGE: ["nginx:1.30.2", "nginx:1.30.2-alpine"]
-        NGINX_VERSION: ["1.30.2"]
+        BASE_IMAGE: ["nginx:1.30.3", "nginx:1.30.3-alpine"]
+        NGINX_VERSION: ["1.30.3"]
         WAF: ["ON", "OFF"]
       - ARCH: ["amd64", "arm64"]
-        BASE_IMAGE: ["nginx:1.31.1", "nginx:1.31.1-alpine"]
-        NGINX_VERSION: ["1.31.1"]
+        BASE_IMAGE: ["nginx:1.31.2", "nginx:1.31.2-alpine"]
+        NGINX_VERSION: ["1.31.2"]
         WAF: ["ON", "OFF"]
       - ARCH: ["amd64", "arm64"]
         BASE_IMAGE: ["amazonlinux:2023.11.20260427.1"]
@@ -185,7 +185,7 @@ test-nginx-asan-fast:
     - build-nginx-asan-fast
   variables:
     ARCH: "amd64"
-    NGINX_VERSION: "1.31.1"
+    NGINX_VERSION: "1.31.2"
     WAF: "ON"
 
 test-nginx-msan-fast:
@@ -196,7 +196,7 @@ test-nginx-msan-fast:
     - build-nginx-msan-fast
   variables:
     ARCH: "amd64"
-    NGINX_VERSION: "1.31.1"
+    NGINX_VERSION: "1.31.2"
     WAF: "ON"
 
 test-ingress-nginx-fast:
@@ -254,12 +254,12 @@ test-nginx-rum-fast:
         NGINX_VERSION: ["1.29.8"]
         WAF: ["OFF"]
       - ARCH: ["amd64", "arm64"]
-        BASE_IMAGE: ["nginx:1.30.2"]
-        NGINX_VERSION: ["1.30.2"]
+        BASE_IMAGE: ["nginx:1.30.3"]
+        NGINX_VERSION: ["1.30.3"]
         WAF: ["OFF"]
       - ARCH: ["amd64", "arm64"]
-        BASE_IMAGE: ["nginx:1.31.1"]
-        NGINX_VERSION: ["1.31.1"]
+        BASE_IMAGE: ["nginx:1.31.2"]
+        NGINX_VERSION: ["1.31.2"]
         WAF: ["OFF"]
 
 coverage:


### PR DESCRIPTION
Add support for Nginx [1.30.3](https://github.com/nginx/nginx/releases/tag/release-1.30.3) and [1.31.2](https://github.com/nginx/nginx/releases/tag/release-1.31.2).