### PR TITLE
Use dd-sts instead of vault because it is more robust

### DIFF
--- a/.gitlab/build-and-test-fast.yml
+++ b/.gitlab/build-and-test-fast.yml
@@ -271,6 +271,9 @@ coverage:
     BASE_IMAGE: "nginx:1.26.0"
     NGINX_VERSION: "1.26.0"
     WAF: "ON"
+  id_tokens:
+    DD_STS_OIDC_TOKEN:
+      aud: rapid-seceng-sit
   tags: ["docker-in-docker:$ARCH"]
   script:
     - make coverage

--- a/.gitlab/common.yml
+++ b/.gitlab/common.yml
@@ -1,7 +1,7 @@
 variables:
   CI_REGISTRY: "registry.ddbuild.io/ci/nginx-datadog"
   TESTS_IMAGES_REGISTRY: "$CI_REGISTRY/mirror"
-  MUSL_TOOLCHAIN_IMAGE: "registry.ddbuild.io/ci/nginx-datadog/nginx_musl_toolchain@sha256:13cb0e881bdf0e14f17bbe0ae40c376bc57d54530781ac47895c660f0b2db743"
+  MUSL_TOOLCHAIN_IMAGE: "registry.ddbuild.io/ci/nginx-datadog/nginx_musl_toolchain@sha256:af5dfa69cf9f4f66f2f87c6161c32f6839dda62560d396aa8f19d1ac6140e4dd"
   # To get the sha256 digest after running make build-push-images-for-CI :
   # docker buildx imagetools inspect registry.ddbuild.io/ci/nginx-datadog/nginx_musl_toolchain:latest
 

--- a/.gitlab/common.yml
+++ b/.gitlab/common.yml
@@ -1,7 +1,10 @@
 variables:
   CI_REGISTRY: "registry.ddbuild.io/ci/nginx-datadog"
   TESTS_IMAGES_REGISTRY: "$CI_REGISTRY/mirror"
-  MUSL_TOOLCHAIN_IMAGE: "registry.ddbuild.io/ci/nginx-datadog/nginx_musl_toolchain@sha256:31b7e3f9130758552262b65df76c0cbd8ba95091c7bdd572bb8abeb1b840efdc"
+  MUSL_TOOLCHAIN_IMAGE: "registry.ddbuild.io/ci/nginx-datadog/nginx_musl_toolchain@sha256:13cb0e881bdf0e14f17bbe0ae40c376bc57d54530781ac47895c660f0b2db743"
+  # To get the sha256 digest after running make build-push-images-for-CI :
+  # docker buildx imagetools inspect registry.ddbuild.io/ci/nginx-datadog/nginx_musl_toolchain:latest
+
 
 # Git config for repo-defined jobs: submodule cloning and GitHub→GitLab URL
 # rewriting via CI job token. Defined as a hidden job (not global) so

--- a/Makefile
+++ b/Makefile
@@ -310,15 +310,20 @@ coverage:
 ifndef GITLAB_CI
 	$(error make coverage should be run only from GitLab CI)
 endif
+	apk add gcompat
+	wget https://binaries.ddbuild.io/dd-source/dd-sts/v0.1.5/dd-sts-tar.tar.gz
+	tar -vxzf dd-sts-tar.tar.gz
+	ls -l
+	install -m 0755 dd-sts-linux-amd64 /usr/local/bin/dd-sts
+	ls -l /usr/local/bin/dd-sts
+	/usr/local/bin/dd-sts debug
+	dd-sts debug
 	COVERAGE=ON BUILD_TESTING=ON $(MAKE) build-musl-cov
 	cd .musl-build; LLVM_PROFILE_FILE=unit_tests.profraw test/unit/unit_tests
 	rm -f test/coverage_data.tar.gz
 	uv run --project test test/bin/run.py --image ${BASE_IMAGE} --module-path .musl-build/ngx_http_datadog_module.so -- --verbose --failfast
 	tar -C .musl-build -xzf test/coverage_data.tar.gz
 	cd .musl-build; llvm-profdata merge -sparse *.profraw -o default.profdata && llvm-cov export ./ngx_http_datadog_module.so -format=lcov -instr-profile=default.profdata -ignore-filename-regex=src/coverage_fixup\.c > coverage.lcov
-	# datadog-ci package comes from https://www.npmjs.com/package/@datadog/datadog-ci?activeTab=versions
-	DD_API_KEY=$$(vault kv get -field=key kv/k8s/gitlab-runner/nginx-datadog/datadoghq-api-key); \
-	vault_status=$$?; \
-	if [ $$vault_status -ne 0 ]; then exit $$vault_status; fi; \
-	echo "Retrieved DD_API_KEY from Vault ($${#DD_API_KEY} bytes)"; \
-	DD_API_KEY="$$DD_API_KEY" npx --yes @datadog/datadog-ci@5.18.0 coverage upload --format=lcov .musl-build/coverage.lcov
+	# datadog-ci versions: https://github.com/DataDog/datadog-ci/releases
+	# datadog-ci packages: https://www.npmjs.com/package/@datadog/datadog-ci?activeTab=versions
+	dd-sts exchange --policy apm-sdks-api-key -- npx --yes @datadog/datadog-ci@5.18.0 coverage upload --format=lcov .musl-build/coverage.lcov

--- a/Makefile
+++ b/Makefile
@@ -311,13 +311,20 @@ coverage:
 ifndef GITLAB_CI
 	$(error make coverage should be run only from GitLab CI)
 endif
-	dd-sts debug
+ifneq ($(ARCH),x86_64)
+	$(error make coverage supports only amd64)
+endif
 	COVERAGE=ON BUILD_TESTING=ON $(MAKE) build-musl-cov
 	cd .musl-build; LLVM_PROFILE_FILE=unit_tests.profraw test/unit/unit_tests
 	rm -f test/coverage_data.tar.gz
 	uv run --project test test/bin/run.py --image ${BASE_IMAGE} --module-path .musl-build/ngx_http_datadog_module.so -- --verbose --failfast
 	tar -C .musl-build -xzf test/coverage_data.tar.gz
 	cd .musl-build; llvm-profdata merge -sparse *.profraw -o default.profdata && llvm-cov export ./ngx_http_datadog_module.so -format=lcov -instr-profile=default.profdata -ignore-filename-regex=src/coverage_fixup\.c > coverage.lcov
+	# dd-sts latest version: https://github.com/DataDog/dd-source/blob/main/domains/seceng/sit/apps/apis/dd-sts/cmd/cli/version.bzl#L6
+	apk add --no-cache gcompat
+	wget --quiet https://binaries.ddbuild.io/dd-source/dd-sts/v0.1.5/dd-sts-tar.tar.gz
+	tar -xzf dd-sts-tar.tar.gz
+	install -m 0755 dd-sts-linux-amd64 /usr/local/bin/dd-sts
 	# datadog-ci versions: https://github.com/DataDog/datadog-ci/releases
 	# datadog-ci packages: https://www.npmjs.com/package/@datadog/datadog-ci?activeTab=versions
 	dd-sts exchange --policy apm-sdks-api-key -- npx --yes @datadog/datadog-ci@5.18.0 coverage upload --format=lcov .musl-build/coverage.lcov

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,7 @@ build-local-uwsgi-test-image:
 	docker build --progress=plain --platform $(DOCKER_PLATFORM) -t $(UWSGI_TEST_IMAGE):latest test/services/uwsgi
 
 # build-push-images-for-CI must be run, once, from a developer machine, to put in registry.ddbuild.io the needed Docker images.
+# Once done, update the sha256 digest in .gitlab/common.yml.
 .PHONY: build-push-images-for-CI
 build-push-images-for-CI: build-push-musl-toolchain build-push-test-image build-push-uwsgi-test-image
 
@@ -310,13 +311,6 @@ coverage:
 ifndef GITLAB_CI
 	$(error make coverage should be run only from GitLab CI)
 endif
-	apk add gcompat
-	wget https://binaries.ddbuild.io/dd-source/dd-sts/v0.1.5/dd-sts-tar.tar.gz
-	tar -vxzf dd-sts-tar.tar.gz
-	ls -l
-	install -m 0755 dd-sts-linux-amd64 /usr/local/bin/dd-sts
-	ls -l /usr/local/bin/dd-sts
-	/usr/local/bin/dd-sts debug
 	dd-sts debug
 	COVERAGE=ON BUILD_TESTING=ON $(MAKE) build-musl-cov
 	cd .musl-build; LLVM_PROFILE_FILE=unit_tests.profraw test/unit/unit_tests

--- a/build_env/Dockerfile
+++ b/build_env/Dockerfile
@@ -227,14 +227,6 @@ COPY pyproject.toml .
 RUN uv sync
 ENV PATH="/.venv/bin:$PATH"
 
-# dd-sts
-# latest version is defined in https://github.com/DataDog/dd-source/blob/main/domains/seceng/sit/apps/apis/dd-sts/cmd/cli/version.bzl#L6
-RUN apk add --no-cache gcompat
-RUN LINUX_ARCH=linux-$(echo ${ARCH} | sed 's/x86_64/amd64/;s/aarch64/arm64/') && \
-  wget --quiet https://binaries.ddbuild.io/dd-source/dd-sts/v0.1.5/dd-sts-tar.tar.gz && \
-  tar -xzf dd-sts-tar.tar.gz && \
-  install -m 0755 dd-sts-${LINUX_ARCH} /usr/local/bin/dd-sts
-
 FROM scratch
 COPY --from=sysroot / /
 ENV PATH="/.venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"

--- a/build_env/Dockerfile
+++ b/build_env/Dockerfile
@@ -1,8 +1,14 @@
-# Dockerfile for registry.ddbuild.io/ci/nginx-datadog/nginx_musl_toolchain
+# Dockerfile for registry.ddbuild.io/ci/nginx-datadog/nginx_musl_toolchain.
+# The Docker images are:
+#   - built by make build-push-images-for-CI;
+#   - used in .gitlab/common.yml.
 
 ARG MIRROR_REGISTRY=registry.ddbuild.io/ci/nginx-datadog/mirror/
 FROM ${MIRROR_REGISTRY}ghcr.io/astral-sh/uv:0.9.28 AS uv
 FROM ${MIRROR_REGISTRY}alpine:3.23.4 AS sysroot
+# When the base images are updated, mirror them:
+# docker buildx imagetools create -t registry.ddbuild.io/ci/nginx-datadog/mirror/alpine:3.23.4 docker.io/library/alpine:3.23.4
+# docker buildx imagetools create -t registry.ddbuild.io/ci/nginx-datadog/mirror/ghcr.io/astral-sh/uv:0.9.28 ghcr.io/astral-sh/uv:0.9.28
 
 ARG LLVM_VERSION=21.1.2
 ARG ARCH
@@ -221,10 +227,13 @@ COPY pyproject.toml .
 RUN uv sync
 ENV PATH="/.venv/bin:$PATH"
 
-RUN LINUX_ARCH=linux_$(echo ${ARCH} | sed 's/x86_64/amd64/;s/aarch64/arm64/') && \
-  wget -qO- https://releases.hashicorp.com/vault/1.21.2/vault_1.21.2_${LINUX_ARCH}.zip | busybox unzip - && \
-  chmod +x vault && mv vault /usr/local/bin/ && \
-  llvm-strip --strip-debug /usr/local/bin/vault
+# dd-sts
+# latest version is defined in https://github.com/DataDog/dd-source/blob/main/domains/seceng/sit/apps/apis/dd-sts/cmd/cli/version.bzl#L6
+RUN apk add --no-cache gcompat
+RUN LINUX_ARCH=linux-$(echo ${ARCH} | sed 's/x86_64/amd64/;s/aarch64/arm64/') && \
+  wget --quiet https://binaries.ddbuild.io/dd-source/dd-sts/v0.1.5/dd-sts-tar.tar.gz && \
+  tar -xzf dd-sts-tar.tar.gz && \
+  install -m 0755 dd-sts-${LINUX_ARCH} /usr/local/bin/dd-sts
 
 FROM scratch
 COPY --from=sysroot / /


### PR DESCRIPTION
The code coverage CI jobs used to fail quite often, as follows ([example](https://gitlab.ddbuild.io/DataDog/apm-reliability/nginx-datadog/-/jobs/1773482436)):
```
DD_API_KEY=$(vault kv get -field=key kv/k8s/gitlab-runner/nginx-datadog/datadoghq-api-key 2>/dev/null) npx --yes @datadog/datadog-ci@5.18.0 coverage upload --format=lcov .musl-build/coverage.lcov
Failed getting commits to exclude: RequestError: Request failed with status code 401
```

We now use [dd-sts[(https://datadoghq.atlassian.net/wiki/x/KwTmVwE) instead of `vault` because it should be much more reliable.

Reference documentation:
- [dd-sts User guide](https://datadoghq.atlassian.net/wiki/x/KwTmVwE)
- [ID tokens reference for Datadog services](https://datadoghq.atlassian.net/wiki/x/-YOkbQE)