### PR TITLE
ci: forward BP_EXTERNAL_S3_URL through benchmark trigger

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,6 +17,10 @@ include:
   - local: ".gitlab/one-pipeline.locked.yml"
 
 variables:
+  # Default so the benchmark trigger forwards an empty value on normal runs
+  # (an unset reference would forward the literal "$BP_EXTERNAL_S3_URL"). An
+  # external orchestrator overrides it to redirect benchmark uploads.
+  BP_EXTERNAL_S3_URL: ""
   OCI_PACKAGE_NAME: datadog-apm-library-nginx
   OCI_AGENT_REGISTRY_PACKAGE_NAME: apm-library-nginx-package
   AGENT_REPO_PRODUCT_NAME: auto_inject-nginx

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,10 +17,6 @@ include:
   - local: ".gitlab/one-pipeline.locked.yml"
 
 variables:
-  # Benchmark trigger jobs forward $BP_EXTERNAL_S3_URL to downstream pipelines so
-  # an external orchestrator can override the S3 destination of benchmark results.
-  # Defaulted to empty here so an unset value forwards as "" rather than a literal.
-  BP_EXTERNAL_S3_URL: ""
   OCI_PACKAGE_NAME: datadog-apm-library-nginx
   OCI_AGENT_REGISTRY_PACKAGE_NAME: apm-library-nginx-package
   AGENT_REPO_PRODUCT_NAME: auto_inject-nginx
@@ -68,9 +64,10 @@ macrobenchmarks:
   needs: []
   trigger:
     include: ".gitlab/benchmarks.yml"
-  # Forward the external S3 destination override to the benchmark child pipeline.
-  variables:
-    BP_EXTERNAL_S3_URL: $BP_EXTERNAL_S3_URL
+    # Forward pipeline variables so an external orchestrator can pass
+    # BP_EXTERNAL_S3_URL down to override the S3 destination of benchmark results.
+    forward:
+      pipeline_variables: true
   rules:
     - if: $NIGHTLY_BENCHMARKS || $CI_COMMIT_REF_NAME == "master" || $CI_COMMIT_REF_NAME =~ /^release\/v/
       when: always

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,9 +17,9 @@ include:
   - local: ".gitlab/one-pipeline.locked.yml"
 
 variables:
-  # Default so the benchmark trigger forwards an empty value on normal runs
-  # (an unset reference would forward the literal "$BP_EXTERNAL_S3_URL"). An
-  # external orchestrator overrides it to redirect benchmark uploads.
+  # Benchmark trigger jobs forward $BP_EXTERNAL_S3_URL to downstream pipelines so
+  # an external orchestrator can override the S3 destination of benchmark results.
+  # Defaulted to empty here so an unset value forwards as "" rather than a literal.
   BP_EXTERNAL_S3_URL: ""
   OCI_PACKAGE_NAME: datadog-apm-library-nginx
   OCI_AGENT_REGISTRY_PACKAGE_NAME: apm-library-nginx-package

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -64,6 +64,9 @@ macrobenchmarks:
   needs: []
   trigger:
     include: ".gitlab/benchmarks.yml"
+  # Forward the external S3 destination override to the benchmark child pipeline.
+  variables:
+    BP_EXTERNAL_S3_URL: $BP_EXTERNAL_S3_URL
   rules:
     - if: $NIGHTLY_BENCHMARKS || $CI_COMMIT_REF_NAME == "master" || $CI_COMMIT_REF_NAME =~ /^release\/v/
       when: always


### PR DESCRIPTION
## Description

Forwards pipeline variables through the benchmark child-pipeline trigger (`forward: pipeline_variables: true`), so an external orchestrator (benchmarking-platform-tools) can pass `BP_EXTERNAL_S3_URL` to override the S3 destination of benchmark results.

GitLab _does not_ forward pipeline variables to child pipelines by default:
- https://gitlab.com/gitlab-org/gitlab/-/merge_requests/82676
- https://docs.gitlab.com/ci/yaml/#triggerforward

When the orchestrator does not set `BP_EXTERNAL_S3_URL`, nothing is forwarded and uploads use the default destination.

## Testing

Verified on dd-trace-py: the variable set at the orchestrator arrives in a downstream microbenchmarks pipeline with the real value. https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-py/-/jobs/1848086621

## Risks

Minimal. Only manual and scheduled pipeline variables are forwarded (not predefined `CI_*` or top-level YAML variables). Normal runs set none.

## Additional Notes

Motivation: [APMSP-2893 Set up flaky benchmark monitoring](https://datadoghq.atlassian.net/browse/APMSP-2893).