### PR TITLE
Run final WAF only for main requests

### DIFF
--- a/src/datadog_context.cpp
+++ b/src/datadog_context.cpp
@@ -126,7 +126,7 @@ ngx_int_t DatadogContext::on_header_filter(ngx_http_request_t *request) {
 #endif
 
 #ifdef WITH_WAF
-  if (sec_ctx_ && trace) {
+  if (sec_ctx_ && trace && request == request->main) {
     dd::Span &span = trace->active_span();
     return sec_ctx_->header_filter(*request, span);
   }

--- a/test/cases/sec_addresses/conf/http_auth_subrequest_final_waf.conf
+++ b/test/cases/sec_addresses/conf/http_auth_subrequest_final_waf.conf
@@ -1,0 +1,37 @@
+# "/datadog-tests" is a directory created by the docker build
+# of the nginx test image. It contains the module, the
+# nginx config, and "index.html".
+
+thread_pool waf_thread_pool threads=2 max_queue=5;
+
+load_module /datadog-tests/ngx_http_datadog_module.so;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    datadog_agent_url http://agent:8126;
+    datadog_appsec_enabled on;
+    datadog_appsec_waf_timeout 2s;
+    datadog_appsec_ruleset_file /tmp/waf.json;
+    datadog_waf_thread_pool_name waf_thread_pool;
+
+    # Give the auth subrequest a RequestTracing object. This makes its header
+    # filter find the DatadogContext shared with the main request.
+    log_subrequest on;
+
+    server {
+        listen 80;
+
+        location /http {
+            auth_request /auth;
+            proxy_pass http://http:8080;
+        }
+
+        location = /auth {
+            internal;
+            return 204;
+        }
+    }
+}

--- a/test/cases/sec_addresses/conf/waf_auth_subrequest_final.json
+++ b/test/cases/sec_addresses/conf/waf_auth_subrequest_final.json
@@ -1,0 +1,56 @@
+{
+  "version": "2.1",
+  "metadata": {
+    "rules_version": "1.2.6"
+  },
+  "rules": [
+    {
+      "id": "main-response-status",
+      "name": "Match the main response status",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.response.status"
+              }
+            ],
+            "regex": "^200$"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": [
+        "values_only"
+      ]
+    },
+    {
+      "id": "auth-subrequest-status",
+      "name": "Match the auth subrequest status",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.response.status"
+              }
+            ],
+            "regex": "^204$"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": [
+        "values_only"
+      ]
+    }
+  ]
+}

--- a/test/cases/sec_addresses/test_sec_auth_subrequest_final_waf.py
+++ b/test/cases/sec_addresses/test_sec_auth_subrequest_final_waf.py
@@ -1,0 +1,52 @@
+"""Regression coverage for final-WAF ownership across subrequests."""
+
+from pathlib import Path
+
+from .. import case
+
+
+class TestSecAuthSubrequestFinalWaf(case.TestCase):
+    requires_waf = True
+    config_setup_done = False
+
+    def setUp(self):
+        super().setUp()
+        if not TestSecAuthSubrequestFinalWaf.config_setup_done:
+            conf_dir = Path(__file__).parent / "conf"
+            waf_path = conf_dir / "waf_auth_subrequest_final.json"
+            self.orch.nginx_replace_file("/tmp/waf.json", waf_path.read_text())
+
+            conf_path = conf_dir / "http_auth_subrequest_final_waf.conf"
+            status, log_lines = self.orch.nginx_replace_config(
+                conf_path.read_text(), conf_path.name)
+            self.assertEqual(0, status, log_lines)
+
+            TestSecAuthSubrequestFinalWaf.config_setup_done = True
+
+        self.orch.sync_service("agent")
+
+    def test_final_waf_runs_for_main_request_not_auth_subrequest(self):
+        # The auth subrequest returns 204 while the main upstream returns 200.
+        # The ruleset has one server.response.status rule for each response,
+        # so the rule recorded in the AppSec report identifies which request
+        # supplied the response data to the one final WAF run. The correct
+        # result is main-response-status only; auth-subrequest-status means
+        # the traced auth subrequest incorrectly consumed the shared final
+        # WAF run before the main response reached the header filter.
+        status, _, _ = self.orch.send_nginx_http_request("/http", 80)
+
+        report = self.orch.find_first_appsec_report()
+        self.assertIsNotNone(report, "final WAF did not produce a report")
+
+        rule_ids = {trigger["rule"]["id"] for trigger in report["triggers"]}
+        self.assertNotIn(
+            "auth-subrequest-status",
+            rule_ids,
+            "the auth subrequest incorrectly owned the final WAF run",
+        )
+        self.assertIn(
+            "main-response-status",
+            rule_ids,
+            "the main response did not own the final WAF run",
+        )
+        self.assertEqual(200, status)


### PR DESCRIPTION
## Summary

- restrict AppSec final-WAF dispatch in the header filter to the main nginx request
- add regression coverage combining `auth_request`, `log_subrequest on`, and distinct response-status WAF rules
- verify that the main response, rather than the auth subrequest response, supplies the final WAF data

## Root cause

nginx runs module header filters for subrequests. With `log_subrequest on`, the auth subrequest has its own tracing state but shares the main request's Datadog security context, including the final-WAF stage and response-filter state.

The auth subrequest is `header_only` and returns `204`. Before dispatching final WAF from a header filter, AppSec saves that state in the shared `Context::header_only_`, temporarily clears `request.header_only`, and expects its output-body filter to restore the flag on the same request and flush the header buffered around the asynchronous WAF run. However, the Datadog output-body-filter wrapper intentionally bypasses subrequests. The auth subrequest therefore consumes the shared final-WAF run, but the saved `header_only_` state remains in the shared context.

When the parent resumes and its upstream returns `200`, the shared WAF stage is already `AFTER_RUN_WAF_END`, so the main header filter does not run final WAF. More importantly, the next main-request body-filter call sees the stale shared `header_only_` and sets the **main** request's `header_only` flag.

That corrupts nginx's response-finalization path. In the reproduced HTTP/1 request, nginx's write filter had buffered the response header and a 490-byte upstream body because the chain had neither `last` nor `flush` and was below `postpone_output`. At upstream EOF, `ngx_http_upstream_finalize_request()` saw the incorrectly set `r->header_only` and skipped `ngx_http_send_special(r, NGX_HTTP_LAST)`. With no terminal buffer to flush the pending chain, nginx logged the main request as `200 0`, left the client with no response bytes, and eventually closed the keepalive connection; curl reported exit 52, `Empty reply from server`.

This failure does not go through the blocking-response branch that reads `req_.count`: the regression rules report a match but do not block, and the asynchronous task's lifetime claim is correctly taken from `req_.main->count`. The direct `req_.count` use is therefore not the cause of this particular empty response. Restricting final-WAF dispatch to main requests also prevents a subrequest from reaching that blocking-only count check.

## Impact

This is a response-delivery failure, not only incorrect AppSec attribution. A traced auth subrequest can steal the final WAF run and cause an otherwise successful main `200` response to deliver no HTTP response at all.

The fix leaves nginx's normal subrequest header-filter chain intact but prevents AppSec final-WAF dispatch and its main-request response-buffering state machine from running on subrequests.

## Validation

- negative control with the main-request guard removed: the auth `204` triggers `auth-subrequest-status`; nginx logs the main request as `200 0`; curl receives no bytes and exits 52
- fixed regression test: the main `200` triggers `main-response-status`, curl receives status 200, and the test passes on nginx 1.28.3 with AppSec enabled
- `WAF=ON NGINX_VERSION=1.28.3 TOOLCHAIN_DEPENDENCY= make build-musl`
- `make lint`
