### PR TITLE
Add support for Nginx v1.30.4 and v1.31.3

### DIFF
--- a/.gitlab/build-and-test-all.yml
+++ b/.gitlab/build-and-test-all.yml
@@ -59,9 +59,11 @@ build-nginx-all:
           - "1.30.1"
           - "1.30.2"
           - "1.30.3"
+          - "1.30.4"
           - "1.31.0"
           - "1.31.1"
           - "1.31.2"
+          - "1.31.3"
         WAF: ["ON", "OFF"]
 
 build-nginx-rum-all:
@@ -104,9 +106,11 @@ build-nginx-rum-all:
           - "1.30.1"
           - "1.30.2"
           - "1.30.3"
+          - "1.30.4"
           - "1.31.0"
           - "1.31.1"
           - "1.31.2"
+          - "1.31.3"
         WAF: ["OFF"]
 
 build-ingress-nginx-all:
@@ -323,6 +327,10 @@ test-nginx-all-bis:
         NGINX_VERSION: ["1.30.3"]
         WAF: ["ON", "OFF"]
       - ARCH: ["amd64", "arm64"]
+        BASE_IMAGE: ["nginx:1.30.4", "nginx:1.30.4-alpine"]
+        NGINX_VERSION: ["1.30.4"]
+        WAF: ["ON", "OFF"]
+      - ARCH: ["amd64", "arm64"]
         BASE_IMAGE: ["nginx:1.31.0", "nginx:1.31.0-alpine"]
         NGINX_VERSION: ["1.31.0"]
         WAF: ["ON", "OFF"]
@@ -333,6 +341,10 @@ test-nginx-all-bis:
       - ARCH: ["amd64", "arm64"]
         BASE_IMAGE: ["nginx:1.31.2", "nginx:1.31.2-alpine"]
         NGINX_VERSION: ["1.31.2"]
+        WAF: ["ON", "OFF"]
+      - ARCH: ["amd64", "arm64"]
+        BASE_IMAGE: ["nginx:1.31.3", "nginx:1.31.3-alpine"]
+        NGINX_VERSION: ["1.31.3"]
         WAF: ["ON", "OFF"]
       - ARCH: ["amd64", "arm64"]
         BASE_IMAGE: ["amazonlinux:2023.11.20260427.1"]
@@ -474,6 +486,10 @@ test-nginx-rum-all:
         NGINX_VERSION: ["1.30.3"]
         WAF: ["OFF"]
       - ARCH: ["amd64", "arm64"]
+        BASE_IMAGE: ["nginx:1.30.4"]
+        NGINX_VERSION: ["1.30.4"]
+        WAF: ["OFF"]
+      - ARCH: ["amd64", "arm64"]
         BASE_IMAGE: ["nginx:1.31.0"]
         NGINX_VERSION: ["1.31.0"]
         WAF: ["OFF"]
@@ -484,6 +500,10 @@ test-nginx-rum-all:
       - ARCH: ["amd64", "arm64"]
         BASE_IMAGE: ["nginx:1.31.2"]
         NGINX_VERSION: ["1.31.2"]
+        WAF: ["OFF"]
+      - ARCH: ["amd64", "arm64"]
+        BASE_IMAGE: ["nginx:1.31.3"]
+        NGINX_VERSION: ["1.31.3"]
         WAF: ["OFF"]
 
 test-ingress-nginx-all:

--- a/.gitlab/build-and-test-fast.yml
+++ b/.gitlab/build-and-test-fast.yml
@@ -73,8 +73,8 @@ build-nginx-fast:
           - "1.27.5"
           - "1.28.3"
           - "1.29.8"
-          - "1.30.3"
-          - "1.31.2"
+          - "1.30.4"
+          - "1.31.3"
         WAF: ["ON", "OFF"]
 
 build-nginx-asan-fast:
@@ -83,7 +83,7 @@ build-nginx-asan-fast:
     - .build-nginx-asan
   variables:
     ARCH: "amd64"
-    NGINX_VERSION: "1.31.2"
+    NGINX_VERSION: "1.31.3"
     WAF: "ON"
 
 build-nginx-msan-fast:
@@ -92,7 +92,7 @@ build-nginx-msan-fast:
     - .build-nginx-msan
   variables:
     ARCH: "amd64"
-    NGINX_VERSION: "1.31.2"
+    NGINX_VERSION: "1.31.3"
     WAF: "ON"
 
 build-ingress-nginx-fast:
@@ -133,8 +133,8 @@ build-nginx-rum-fast:
           - "1.27.5"
           - "1.28.3"
           - "1.29.8"
-          - "1.30.3"
-          - "1.31.2"
+          - "1.30.4"
+          - "1.31.3"
         WAF: ["OFF"]
 
 test-nginx-fast:
@@ -165,12 +165,12 @@ test-nginx-fast:
         NGINX_VERSION: ["1.29.8"]
         WAF: ["ON", "OFF"]
       - ARCH: ["amd64", "arm64"]
-        BASE_IMAGE: ["nginx:1.30.3", "nginx:1.30.3-alpine"]
-        NGINX_VERSION: ["1.30.3"]
+        BASE_IMAGE: ["nginx:1.30.4", "nginx:1.30.4-alpine"]
+        NGINX_VERSION: ["1.30.4"]
         WAF: ["ON", "OFF"]
       - ARCH: ["amd64", "arm64"]
-        BASE_IMAGE: ["nginx:1.31.2", "nginx:1.31.2-alpine"]
-        NGINX_VERSION: ["1.31.2"]
+        BASE_IMAGE: ["nginx:1.31.3", "nginx:1.31.3-alpine"]
+        NGINX_VERSION: ["1.31.3"]
         WAF: ["ON", "OFF"]
       - ARCH: ["amd64", "arm64"]
         BASE_IMAGE: ["amazonlinux:2023.11.20260427.1"]
@@ -185,7 +185,7 @@ test-nginx-asan-fast:
     - build-nginx-asan-fast
   variables:
     ARCH: "amd64"
-    NGINX_VERSION: "1.31.2"
+    NGINX_VERSION: "1.31.3"
     WAF: "ON"
 
 test-nginx-msan-fast:
@@ -196,7 +196,7 @@ test-nginx-msan-fast:
     - build-nginx-msan-fast
   variables:
     ARCH: "amd64"
-    NGINX_VERSION: "1.31.2"
+    NGINX_VERSION: "1.31.3"
     WAF: "ON"
 
 test-ingress-nginx-fast:
@@ -254,12 +254,12 @@ test-nginx-rum-fast:
         NGINX_VERSION: ["1.29.8"]
         WAF: ["OFF"]
       - ARCH: ["amd64", "arm64"]
-        BASE_IMAGE: ["nginx:1.30.3"]
-        NGINX_VERSION: ["1.30.3"]
+        BASE_IMAGE: ["nginx:1.30.4"]
+        NGINX_VERSION: ["1.30.4"]
         WAF: ["OFF"]
       - ARCH: ["amd64", "arm64"]
-        BASE_IMAGE: ["nginx:1.31.2"]
-        NGINX_VERSION: ["1.31.2"]
+        BASE_IMAGE: ["nginx:1.31.3"]
+        NGINX_VERSION: ["1.31.3"]
         WAF: ["OFF"]
 
 coverage:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 cmake_policy(SET CMP0068 NEW)
 cmake_policy(SET CMP0135 NEW)
 
-set(NGINX_DATADOG_VERSION 1.20.0)
+set(NGINX_DATADOG_VERSION 1.21.0)
 project(ngx_http_datadog_module VERSION ${NGINX_DATADOG_VERSION})
 
 option(NGINX_DATADOG_ASM_ENABLED "Build with libddwaf" ON)


### PR DESCRIPTION
Add support for the latest versions of Nginx, released on July 15, 2026:
- [Nginx v1.30.4](https://github.com/nginx/nginx/releases/tag/release-1.30.4)
- [Nginx v1.31.3](https://github.com/nginx/nginx/releases/tag/release-1.31.3)

Jira ticket: [IDMPL-603 Add support for Nginx v1.30.4 and v1.31.3](https://datadoghq.atlassian.net/jira/software/c/projects/IDMPL/boards/26545?quickFilter=29105&selectedIssue=IDMPL-603)