### PR TITLE
Fix potential request user-after-free in AppSec tasks

### DIFF
--- a/.gitlab/build-and-test-fast.yml
+++ b/.gitlab/build-and-test-fast.yml
@@ -9,6 +9,16 @@ include:
       when: never
     - when: on_success
 
+build-and-sign-ci-images:
+  stage: build-and-test-fast
+  resource_group: ci-images
+  trigger:
+    include: ".gitlab/build-ci-images.yml"
+    strategy: mirror
+  rules:
+    - when: manual
+      allow_failure: true
+
 build-formatter-image:
   extends: .build-and-test-fast
   image: registry.ddbuild.io/images/nydus:v2.3.8-dd

--- a/.gitlab/build-ci-images.yml
+++ b/.gitlab/build-ci-images.yml
@@ -1,0 +1,96 @@
+include:
+  - local: ".gitlab/common.yml"
+
+stages:
+  - build
+  - sign
+
+build-ci-images:
+  stage: build
+  image: registry.ddbuild.io/images/nydus:v2.3.8-dd
+  tags: ["docker-in-docker:$ARCH"]
+  interruptible: false
+  parallel:
+    matrix:
+      - ARCH: amd64
+        TOOLCHAIN_ARCH: x86_64
+      - ARCH: arm64
+        TOOLCHAIN_ARCH: aarch64
+  variables:
+    CI_ENABLE_CONTAINER_IMAGE_BUILDS: "true"
+  script:
+    - |
+      set -euo pipefail
+
+      daemon_arch=$(docker info --format '{{.Architecture}}')
+      if [ "$daemon_arch" != "$TOOLCHAIN_ARCH" ]; then
+        echo "Expected a $TOOLCHAIN_ARCH Docker daemon, got $daemon_arch" >&2
+        exit 1
+      fi
+
+      toolchain_image="$CI_REGISTRY/nginx_musl_toolchain"
+      docker build \
+        --provenance=false \
+        --sbom=false \
+        --progress=plain \
+        --platform "linux/$ARCH" \
+        --build-arg "ARCH=$TOOLCHAIN_ARCH" \
+        --tag "$toolchain_image:latest-$ARCH" \
+        build_env
+      docker push "$toolchain_image:latest-$ARCH"
+
+      test_image="$CI_REGISTRY/test"
+      docker build \
+        --provenance=false \
+        --sbom=false \
+        --progress=plain \
+        --platform "linux/$ARCH" \
+        --tag "$test_image:latest-$ARCH" \
+        test
+      docker push "$test_image:latest-$ARCH"
+
+      uwsgi_image="$CI_REGISTRY/uwsgi"
+      docker build \
+        --provenance=false \
+        --sbom=false \
+        --progress=plain \
+        --platform "linux/$ARCH" \
+        --tag "$uwsgi_image:latest-$ARCH" \
+        test/services/uwsgi
+      docker push "$uwsgi_image:latest-$ARCH"
+
+assemble-and-sign-ci-images:
+  stage: sign
+  image: registry.ddbuild.io/images/nydus:v2.3.8-dd
+  tags: ["docker-in-docker:amd64"]
+  interruptible: false
+  needs:
+    - build-ci-images
+  id_tokens:
+    DDSIGN_ID_TOKEN:
+      aud: image-integrity
+  script:
+    - |
+      set -euo pipefail
+
+      for image_name in nginx_musl_toolchain test uwsgi; do
+        image="$CI_REGISTRY/$image_name"
+        docker buildx imagetools create \
+          --tag "$image:latest" \
+          "$image:latest-amd64" \
+          "$image:latest-arm64"
+
+        digest=$(crane digest "$image:latest")
+        ddsign sign "$image:latest@$digest"
+        ddsign verify "$image:latest@$digest"
+
+        case "$image_name" in
+          nginx_musl_toolchain) variable=MUSL_TOOLCHAIN_IMAGE ;;
+          test) variable=TEST_IMAGE ;;
+          uwsgi) variable=UWSGI_TEST_IMAGE ;;
+        esac
+        printf '%s=%s@%s\n' "$variable" "$image" "$digest" | tee -a ci-images.env
+      done
+  artifacts:
+    reports:
+      dotenv: ci-images.env

--- a/.gitlab/common.yml
+++ b/.gitlab/common.yml
@@ -1,7 +1,9 @@
 variables:
   CI_REGISTRY: "registry.ddbuild.io/ci/nginx-datadog"
   TESTS_IMAGES_REGISTRY: "$CI_REGISTRY/mirror"
-  MUSL_TOOLCHAIN_IMAGE: "registry.ddbuild.io/ci/nginx-datadog/nginx_musl_toolchain@sha256:af5dfa69cf9f4f66f2f87c6161c32f6839dda62560d396aa8f19d1ac6140e4dd"
+  MUSL_TOOLCHAIN_IMAGE: "registry.ddbuild.io/ci/nginx-datadog/nginx_musl_toolchain@sha256:75e497fa34d8afbb2ee583b242a8129581eb601968a82eb8a3bae5bf48178b75"
+  TEST_IMAGE: "registry.ddbuild.io/ci/nginx-datadog/test@sha256:205560e0e734696e0eeaac735581317b2c45054b6ad64c7f9041e48559559e24"
+  UWSGI_TEST_IMAGE: "registry.ddbuild.io/ci/nginx-datadog/uwsgi@sha256:ee04b2d9841367c4247f01d0ba4a140894bdd16ba35c2f67dc8d1da9255ae1d3"
   # To get the sha256 digest after running make build-push-images-for-CI :
   # docker buildx imagetools inspect registry.ddbuild.io/ci/nginx-datadog/nginx_musl_toolchain:latest
 
@@ -99,7 +101,7 @@ variables:
 
 .test:
   extends: .git-config
-  image: $CI_REGISTRY/test
+  image: $TEST_IMAGE
   tags: ["docker-in-docker:$ARCH"]
 
 .test-nginx:

--- a/bin/nginx-log-format-tidy.sh
+++ b/bin/nginx-log-format-tidy.sh
@@ -114,8 +114,8 @@ fi
 common_args=(
     -p "$build_dir"
     "-load=$plugin"
-    '-checks=-*,nginx-datadog-ngx-log-format'
-    '-warnings-as-errors=nginx-datadog-ngx-log-format'
+    '-checks=-*,nginx-datadog-*'
+    '-warnings-as-errors=nginx-datadog-*'
     "-header-filter=^$container_repo/src/.*"
     -quiet
     -extra-arg=-DNGX_DEBUG=1

--- a/src/datadog_conf.h
+++ b/src/datadog_conf.h
@@ -159,6 +159,28 @@ struct datadog_main_conf_t {
   // Bit 2: final WAF task (PolFinalWafCtx)
   ngx_int_t appsec_test_task_post_failure_mask{NGX_CONF_UNSET};
 
+  // (only nginx configuration: datadog_appsec_test_task_delay_ms)
+  // (Undocumented) For testing: artificially delay (via a blocking sleep) the
+  // execution of WAF tasks on the thread pool by this many milliseconds,
+  // right before the task's completion event is posted back to the main
+  // thread. This widens the window during which the task is known to still
+  // be in flight so tests can deterministically exercise asynchronous request
+  // termination.
+  ngx_int_t appsec_test_task_delay_ms{NGX_CONF_UNSET};
+
+  // (only nginx configuration:
+  // datadog_appsec_test_task_termination_delay_ms)
+  // (Undocumented) For testing: force-terminate a request this many
+  // milliseconds after a WAF task is submitted. Used with
+  // appsec_test_task_delay_ms to exercise nginx's asynchronous request
+  // termination path while a task is still running.
+  ngx_int_t appsec_test_task_termination_delay_ms{NGX_CONF_UNSET};
+
+  // (only nginx configuration: datadog_appsec_test_task_termination_mask)
+  // (Undocumented) For testing: bit mask selecting which WAF task types the
+  // forced-termination hook applies to. Uses the kTaskPostFailureMask* values.
+  ngx_int_t appsec_test_task_termination_mask{NGX_CONF_UNSET};
+
   // (only nginx configuration: datadog_appsec_stats_host_port)
   // (Undocumented) Host and port to send statsd stats to
   ngx_str_t appsec_stats_host_port = ngx_null_string;

--- a/src/ngx_logger.cpp
+++ b/src/ngx_logger.cpp
@@ -62,8 +62,8 @@ void NgxLogger::log_debug(std::string_view message) {
   const ngx_str_t ngx_message = to_ngx_str(message);
 
   std::lock_guard<std::mutex> lock(mutex_);
-  ngx_log_debug1(NGX_LOG_DEBUG_HTTP, ngx_cycle->log, 0, "datadog: %V",
-                 &ngx_message);
+  ngx_log_debug(NGX_LOG_DEBUG_HTTP, ngx_cycle->log, 0, "datadog: %V",
+                &ngx_message);
 #endif
 }
 

--- a/src/ngx_script.cpp
+++ b/src/ngx_script.cpp
@@ -40,9 +40,9 @@ ngx_str_t NgxScript::run(ngx_http_request_t *request) const noexcept {
     return {0, nullptr};
   }
 
-  ngx_log_debug2(NGX_LOG_DEBUG_HTTP, request->connection->log, 0,
-                 "executing Datadog script \"%V\" for request %p", &pattern_,
-                 request);
+  ngx_log_debug(NGX_LOG_DEBUG_HTTP, request->connection->log, 0,
+                "executing Datadog script \"%V\" for request %p", &pattern_,
+                request);
 
   // If the script has no variables, we can just return the pattern.
   if (!lengths_) return pattern_;

--- a/src/request_tracing.cpp
+++ b/src/request_tracing.cpp
@@ -189,8 +189,8 @@ RequestTracing::RequestTracing(ngx_http_request_t *request,
   auto *tracer = global_tracer();
   if (!tracer) throw std::runtime_error{"no global tracer set"};
 
-  ngx_log_debug1(NGX_LOG_DEBUG_HTTP, request_->connection->log, 0,
-                 "starting Datadog request span for %p", request_);
+  ngx_log_debug(NGX_LOG_DEBUG_HTTP, request_->connection->log, 0,
+                "starting Datadog request span for %p", request_);
 
   std::optional<std::string> service =
       common::eval_complex_value(loc_conf_->service_name, request_);
@@ -257,10 +257,9 @@ RequestTracing::RequestTracing(ngx_http_request_t *request,
   }
 
   if (loc_conf_->enable_locations) {
-    ngx_log_debug3(
-        NGX_LOG_DEBUG_HTTP, request_->connection->log, 0,
-        "starting Datadog location span for \"%V\"(%p) in request %p",
-        &core_loc_conf->name, loc_conf_, request_);
+    ngx_log_debug(NGX_LOG_DEBUG_HTTP, request_->connection->log, 0,
+                  "starting Datadog location span for \"%V\"(%p) in request %p",
+                  &core_loc_conf->name, loc_conf_, request_);
     dd::SpanConfig config;
     config.service = service;
     config.environment = env;
@@ -281,10 +280,9 @@ void RequestTracing::on_change_block(ngx_http_core_loc_conf_t *core_loc_conf,
   loc_conf_ = loc_conf;
 
   if (loc_conf->enable_locations) {
-    ngx_log_debug3(
-        NGX_LOG_DEBUG_HTTP, request_->connection->log, 0,
-        "starting Datadog location span for \"%V\"(%p) in request %p",
-        &core_loc_conf->name, loc_conf_, request_);
+    ngx_log_debug(NGX_LOG_DEBUG_HTTP, request_->connection->log, 0,
+                  "starting Datadog location span for \"%V\"(%p) in request %p",
+                  &core_loc_conf->name, loc_conf_, request_);
     dd::SpanConfig config;
     config.service =
         common::eval_complex_value(loc_conf_->service_name, request_);
@@ -317,9 +315,9 @@ void RequestTracing::on_exit_block(
   // available when a block is first entered, so set tags when the block is
   // exited instead.
   if (loc_conf_->enable_locations) {
-    ngx_log_debug2(NGX_LOG_DEBUG_HTTP, request_->connection->log, 0,
-                   "finishing Datadog location span for %p in request %p",
-                   loc_conf_, request_);
+    ngx_log_debug(NGX_LOG_DEBUG_HTTP, request_->connection->log, 0,
+                  "finishing Datadog location span for %p in request %p",
+                  loc_conf_, request_);
     add_script_tags(main_conf_->tags, request_, *span_);
     add_script_tags(loc_conf_->tags, request_, *span_);
     add_status_tags(request_, *span_);
@@ -348,8 +346,8 @@ void RequestTracing::on_log_request() {
   auto finish_timestamp = std::chrono::steady_clock::now();
   on_exit_block(finish_timestamp);
 
-  ngx_log_debug1(NGX_LOG_DEBUG_HTTP, request_->connection->log, 0,
-                 "finishing Datadog request span for %p", request_);
+  ngx_log_debug(NGX_LOG_DEBUG_HTTP, request_->connection->log, 0,
+                "finishing Datadog request span for %p", request_);
   add_status_tags(request_, *request_span_);
   add_upstream_name(request_, *request_span_);
 

--- a/src/security/blocking.cpp
+++ b/src/security/blocking.cpp
@@ -358,8 +358,8 @@ ngx_int_t BlockingService::block(BlockSpecification spec,
   req.lingering_close = 0;
 
   ngx_int_t res = ngx_http_send_header(&req);
-  ngx_log_debug1(NGX_LOG_DEBUG, req.connection->log, 0,
-                 "block(): status %i returned by ngx_http_send_header", res);
+  ngx_log_debug(NGX_LOG_DEBUG, req.connection->log, 0,
+                "block(): status %i returned by ngx_http_send_header", res);
   if (res != NGX_OK) {
     return res;
   }

--- a/src/security/body_parse/body_json.cpp
+++ b/src/security/body_parse/body_json.cpp
@@ -286,9 +286,9 @@ bool parse_json(ddwaf_obj &slot, const ngx_http_request_t &req,
   ddwaf_obj *json_obj = handler.finish(req);
   if (res.IsError()) {
     if (json_obj) {
-      ngx_log_debug1(NGX_LOG_DEBUG_HTTP, req.connection->log, 0,
-                     "json parsing failed after producing some output: %s",
-                     rapidjson::GetParseError_En(res.Code()));
+      ngx_log_debug(NGX_LOG_DEBUG_HTTP, req.connection->log, 0,
+                    "json parsing failed after producing some output: %s",
+                    rapidjson::GetParseError_En(res.Code()));
     } else {
       ngx_log_error(NGX_LOG_NOTICE, req.connection->log, 0,
                     "json parsing failed without producing any output: %s",

--- a/src/security/body_parse/body_multipart.cpp
+++ b/src/security/body_parse/body_multipart.cpp
@@ -151,8 +151,8 @@ bool parse_multipart(ddwaf_obj &slot, const ngx_http_request_t &req,
     ngx_log_error(NGX_LOG_NOTICE, req.connection->log, 0,
                   "multipart boundary is invalid: %s", ct.boundary.c_str());
   } else {
-    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, req.connection->log, 0,
-                   "multipart boundary: %s", ct.boundary.c_str());
+    ngx_log_debug(NGX_LOG_DEBUG_HTTP, req.connection->log, 0,
+                  "multipart boundary: %s", ct.boundary.c_str());
   }
   NgxChainInputStream stream{&chain};
 
@@ -184,8 +184,8 @@ start_part:
   std::optional<MimeContentDisposition> cd =
       MimeContentDisposition::for_stream(stream);
   if (!cd) {
-    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, req.connection->log, 0,
-                   "multipart: did not find Content-Disposition header");
+    ngx_log_debug(NGX_LOG_DEBUG_HTTP, req.connection->log, 0,
+                  "multipart: did not find Content-Disposition header");
   }
 
   // content
@@ -207,8 +207,8 @@ start_part:
       }
 
       if (line_type == LineType::END_OF_FILE) {
-        ngx_log_debug0(NGX_LOG_DEBUG_HTTP, req.connection->log, 0,
-                       "multipart: eof before end boundary");
+        ngx_log_debug(NGX_LOG_DEBUG_HTTP, req.connection->log, 0,
+                      "multipart: eof before end boundary");
         // we could have been followed by a boundary that was truncated,
         // so remove final CRLF, LF, or CR
         remove_final_crlf(content);

--- a/src/security/body_parse/body_parsing.cpp
+++ b/src/security/body_parse/body_parsing.cpp
@@ -189,9 +189,9 @@ bool parse_body_req(ddwaf_obj &slot, const ngx_http_request_t &req,
     return parse_urlencoded(slot, chain, size, memres);
   }
 
-  ngx_log_debug1(NGX_LOG_DEBUG_HTTP, req.connection->log, 0,
-                 "unsupported content-type: %V",
-                 &req.headers_in.content_type->value);
+  ngx_log_debug(NGX_LOG_DEBUG_HTTP, req.connection->log, 0,
+                "unsupported content-type: %V",
+                &req.headers_in.content_type->value);
   return false;
 }
 

--- a/src/security/context.cpp
+++ b/src/security/context.cpp
@@ -1,9 +1,11 @@
 #include "context.h"
 
 #include <atomic>
+#include <chrono>
 #include <climits>
 #include <optional>
 #include <stdexcept>
+#include <thread>
 #include <type_traits>
 #include <utility>
 
@@ -153,6 +155,7 @@ class PolTaskCtx {
     as_self().replace_handlers();
 
     req_.main->count++;
+    req_.main->blocked++;
 
     bool simulate_task_post_failure = false;
     auto *main_conf = static_cast<datadog_main_conf_t *>(
@@ -172,6 +175,7 @@ class PolTaskCtx {
       Stats::task_submission_failed();
 
       req_.main->count--;
+      req_.main->blocked--;
       as_self().restore_handlers();
 
       as_self().~Self();
@@ -179,6 +183,8 @@ class PolTaskCtx {
     }
 
     Stats::task_submitted();
+
+    maybe_schedule_test_termination(main_conf);
 
     ngx_log_debug2(NGX_LOG_DEBUG_HTTP, req_log(), 0,
                    "task %p submitted. Request refcount: %d", &get_task(),
@@ -203,6 +209,33 @@ class PolTaskCtx {
     static_cast<Self *>(self)->handle(tp_log);
   }
 
+  void maybe_schedule_test_termination(
+      datadog_main_conf_t *main_conf) noexcept {
+    if (main_conf &&
+        main_conf->appsec_test_task_termination_delay_ms != NGX_CONF_UNSET &&
+        main_conf->appsec_test_task_termination_delay_ms > 0 &&
+        main_conf->appsec_test_task_termination_mask != NGX_CONF_UNSET &&
+        (main_conf->appsec_test_task_termination_mask &
+         Self::get_task_failure_flag())) {
+      terminate_test_event_.handler = &PolTaskCtx::test_terminate_request;
+      terminate_test_event_.data = this;
+      terminate_test_event_.log = req_log();
+      ngx_add_timer(&terminate_test_event_,
+                    main_conf->appsec_test_task_termination_delay_ms);
+    }
+  }
+
+  // runs on the main thread; test-only forced-termination hook
+  static void test_terminate_request(ngx_event_t *evt) noexcept {
+    auto *self = static_cast<PolTaskCtx *>(evt->data);
+    ngx_connection_t *connection = self->req_.connection;
+
+    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, self->req_log(), 0,
+                   "test hook: terminating request while WAF task is active");
+    ngx_http_finalize_request(&self->req_, NGX_ERROR);
+    ngx_http_run_posted_requests(connection);
+  }
+
   // runs on the thread pool
   void handle(ngx_log_t *tp_log) noexcept {
     try {
@@ -211,6 +244,19 @@ class PolTaskCtx {
       block_spec_ = as_self().do_handle(*tp_log);
       // test long libddwaf call
       // ::usleep(2000000);
+
+      // For testing: artificially delay the completion of this task (see
+      // datadog_appsec_test_task_delay_ms). This is used to deterministically
+      // widen the window during which the task is known to still be in flight
+      // so tests can terminate the request before the completion handler runs.
+      auto *main_conf = static_cast<datadog_main_conf_t *>(
+          ngx_http_get_module_main_conf(&req_, ngx_http_datadog_module));
+      if (main_conf && main_conf->appsec_test_task_delay_ms != NGX_CONF_UNSET &&
+          main_conf->appsec_test_task_delay_ms > 0) {
+        std::this_thread::sleep_for(
+            std::chrono::milliseconds(main_conf->appsec_test_task_delay_ms));
+      }
+
       ngx_log_debug(NGX_LOG_DEBUG_HTTP, req_log(), 0, "after task %p main",
                     &get_task());
       ran_on_thread_.store(true, std::memory_order_release);
@@ -234,6 +280,16 @@ class PolTaskCtx {
   }
 
   void completion_handler_impl() noexcept {
+    if (terminate_test_event_.timer_set) {
+      ngx_del_timer(&terminate_test_event_);
+    }
+
+    // The task is no longer in flight now that its completion handler is
+    // running on the main thread; release the "blocked" reference that kept
+    // ngx_http_terminate_request() from force-freeing the request pool
+    // while the task ran on the thread pool.
+    req_.main->blocked--;
+
     as_self().restore_handlers();
 
     auto count = req_.main->count;
@@ -247,6 +303,21 @@ class PolTaskCtx {
     alignas(Self) char self_copy_storage[sizeof(Self)];
     std::memcpy(self_copy_storage, this, sizeof(Self));
     Self *self_copy = reinterpret_cast<Self *>(self_copy_storage);
+
+    if (req_.main->terminated) {
+      ngx_log_debug(NGX_LOG_DEBUG_HTTP, req_log(), 0,
+                    "request was terminated while task %p was active; "
+                    "running the connection write handler",
+                    &get_task());
+
+      req_.main->count--;
+      ngx_event_t *write_event = req_.connection->write;
+      write_event->handler(write_event);
+
+      // The request pool may have been destroyed by the write handler.
+      self_copy->~Self();
+      return;
+    }
 
     if (count > 1) {
       // ngx_del_event(connection->read, NGX_READ_EVENT, 0) may've been called
@@ -322,6 +393,7 @@ class PolTaskCtx {
   ngx_http_event_handler_pt prev_read_evt_handler_;
   ngx_http_event_handler_pt prev_write_evt_handler_;
   std::atomic<bool> ran_on_thread_{false};
+  ngx_event_t terminate_test_event_{};
 };
 
 class Pol1stWafCtx : public PolTaskCtx<Pol1stWafCtx> {

--- a/src/security/context.cpp
+++ b/src/security/context.cpp
@@ -609,14 +609,40 @@ class PolFinalWafCtx : public PolTaskCtx<PolFinalWafCtx> {
     }
   }
 
-  static void empty_handler_read(ngx_event_t *wev) {
-    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, wev->log, 0,
+  static void empty_handler_read(ngx_event_t *rev) {
+    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, rev->log, 0,
                    "PolFinalWafCtx: http empty handler (read)");
+
+    // Avoid a busy loop on level-triggered event backends, matching
+    // ngx_http_block_reading. PolTaskCtx::complete() re-arms the event after
+    // restoring the original handler.
+    if ((ngx_event_flags & NGX_USE_LEVEL_EVENT) && rev->active) {
+      if (ngx_del_event(rev, NGX_READ_EVENT, 0) != NGX_OK) {
+        ngx_log_error(NGX_LOG_ERR, rev->log, 0,
+                      "failed to suspend downstream read event");
+      } else {
+        ngx_log_debug0(NGX_LOG_DEBUG_HTTP, rev->log, 0,
+                       "PolFinalWafCtx: suspended downstream read event");
+      }
+    }
   }
 
   static void empty_handler_write(ngx_event_t *wev) {
     ngx_log_debug0(NGX_LOG_DEBUG_HTTP, wev->log, 0,
                    "PolFinalWafCtx: http empty handler (write)");
+
+    // Avoid a busy loop on level-triggered event backends, matching nginx's
+    // own direct empty-write-handler call sites. PolFinalWafCtx::complete()
+    // posts the event after restoring its original handler.
+    if ((ngx_event_flags & NGX_USE_LEVEL_EVENT) && wev->active) {
+      if (ngx_del_event(wev, NGX_WRITE_EVENT, 0) != NGX_OK) {
+        ngx_log_error(NGX_LOG_ERR, wev->log, 0,
+                      "failed to suspend downstream write event");
+      } else {
+        ngx_log_debug0(NGX_LOG_DEBUG_HTTP, wev->log, 0,
+                       "PolFinalWafCtx: suspended downstream write event");
+      }
+    }
   }
 
   static void empty_upstream_handler_read(ngx_event_t *wev) {

--- a/src/security/context.cpp
+++ b/src/security/context.cpp
@@ -186,9 +186,9 @@ class PolTaskCtx {
 
     maybe_schedule_test_termination(main_conf);
 
-    ngx_log_debug2(NGX_LOG_DEBUG_HTTP, req_log(), 0,
-                   "task %p submitted. Request refcount: %d", &get_task(),
-                   req_.main->count);
+    ngx_log_debug(NGX_LOG_DEBUG_HTTP, req_log(), 0,
+                  "task %p submitted. Request refcount: %d", &get_task(),
+                  req_.main->count);
 
     return true;
   }
@@ -230,8 +230,8 @@ class PolTaskCtx {
     auto *self = static_cast<PolTaskCtx *>(evt->data);
     ngx_connection_t *connection = self->req_.connection;
 
-    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, self->req_log(), 0,
-                   "test hook: terminating request while WAF task is active");
+    ngx_log_debug(NGX_LOG_DEBUG_HTTP, self->req_log(), 0,
+                  "test hook: terminating request while WAF task is active");
     ngx_http_finalize_request(&self->req_, NGX_ERROR);
     ngx_http_run_posted_requests(connection);
   }
@@ -329,13 +329,13 @@ class PolTaskCtx {
                       &get_task());
       } else {
         req_.main->count--;
-        ngx_log_debug1(NGX_LOG_DEBUG_HTTP, req_log(), 0,
-                       "calling complete on task %p", &get_task());
+        ngx_log_debug(NGX_LOG_DEBUG_HTTP, req_log(), 0,
+                      "calling complete on task %p", &get_task());
         as_self().complete();
         // req_ may be invalid at this point
       }
     } else {
-      ngx_log_debug1(
+      ngx_log_debug(
           NGX_LOG_DEBUG_HTTP, req_log(), 0,
           "skipping run of completion handler for task %p because "
           "we're the only reference to the request; finalizing instead",
@@ -375,8 +375,8 @@ class PolTaskCtx {
   Self &as_self() { return *static_cast<Self *>(this); }
 
   static void empty_write_handler(ngx_http_request_t *req) {
-    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, req->connection->log, 0,
-                   "task wait empty handler");
+    ngx_log_debug(NGX_LOG_DEBUG_HTTP, req->connection->log, 0,
+                  "task wait empty handler");
 
     ngx_event_t *wev = req->connection->write;
 
@@ -408,8 +408,8 @@ class Pol1stWafCtx : public PolTaskCtx<Pol1stWafCtx> {
   }
 
   void complete() noexcept {
-    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, req_.connection->log, 0,
-                   "completion handler of waf start task: start");
+    ngx_log_debug(NGX_LOG_DEBUG_HTTP, req_.connection->log, 0,
+                  "completion handler of waf start task: start");
 
     bool const ran = ran_on_thread_.load(std::memory_order_acquire);
     if (ran && block_spec_) {
@@ -440,8 +440,8 @@ class Pol1stWafCtx : public PolTaskCtx<Pol1stWafCtx> {
     } else {
       req_.phase_handler++;  // move past us
       ngx_post_event(req_.connection->write, &ngx_posted_events);
-      ngx_log_debug0(NGX_LOG_DEBUG_HTTP, req_.connection->log, 0,
-                     "completion handler of waf start task: normal finish");
+      ngx_log_debug(NGX_LOG_DEBUG_HTTP, req_.connection->log, 0,
+                    "completion handler of waf start task: normal finish");
     }
   }
 
@@ -462,8 +462,8 @@ bool Context::do_on_request_start(ngx_http_request_t &request, dd::Span &span) {
 
   stage st = stage_->load(std::memory_order_relaxed);
   if (st != stage::START) {
-    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, request.connection->log, 0,
-                   "WAF context is not in the start stage. Internal redirect?");
+    ngx_log_debug(NGX_LOG_DEBUG_HTTP, request.connection->log, 0,
+                  "WAF context is not in the start stage. Internal redirect?");
     return false;
   }
 
@@ -565,8 +565,8 @@ class PolReqBodyWafCtx : public PolTaskCtx<PolReqBodyWafCtx> {
   }
 
   void complete() noexcept {
-    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, req_.connection->log, 0,
-                   "completion handler of waf req post task: start");
+    ngx_log_debug(NGX_LOG_DEBUG_HTTP, req_.connection->log, 0,
+                  "completion handler of waf req post task: start");
     bool const ran = ran_on_thread_.load(std::memory_order_acquire);
 
     if (ran && block_spec_) {
@@ -621,10 +621,10 @@ class PolFinalWafCtx : public PolTaskCtx<PolFinalWafCtx> {
 
   void complete() noexcept {
     bool const ran = ran_on_thread_.load(std::memory_order_acquire);
-    ngx_log_debug2(NGX_LOG_DEBUG_HTTP, req_.connection->log, 0,
-                   "completion handler of waf req final task (ran: %s, "
-                   "blocked: %s): start",
-                   ran ? "true" : "false", block_spec_ ? "true" : "false");
+    ngx_log_debug(NGX_LOG_DEBUG_HTTP, req_.connection->log, 0,
+                  "completion handler of waf req final task (ran: %s, "
+                  "blocked: %s): start",
+                  ran ? "true" : "false", block_spec_ ? "true" : "false");
 
     if (ran && block_spec_) {
       span_.set_tag("appsec.blocked"sv, "true"sv);
@@ -682,8 +682,8 @@ class PolFinalWafCtx : public PolTaskCtx<PolFinalWafCtx> {
   }
 
   static void empty_handler_read(ngx_event_t *rev) {
-    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, rev->log, 0,
-                   "PolFinalWafCtx: http empty handler (read)");
+    ngx_log_debug(NGX_LOG_DEBUG_HTTP, rev->log, 0,
+                  "PolFinalWafCtx: http empty handler (read)");
 
     // Avoid a busy loop on level-triggered event backends, matching
     // ngx_http_block_reading. PolTaskCtx::complete() re-arms the event after
@@ -693,15 +693,15 @@ class PolFinalWafCtx : public PolTaskCtx<PolFinalWafCtx> {
         ngx_log_error(NGX_LOG_ERR, rev->log, 0,
                       "failed to suspend downstream read event");
       } else {
-        ngx_log_debug0(NGX_LOG_DEBUG_HTTP, rev->log, 0,
-                       "PolFinalWafCtx: suspended downstream read event");
+        ngx_log_debug(NGX_LOG_DEBUG_HTTP, rev->log, 0,
+                      "PolFinalWafCtx: suspended downstream read event");
       }
     }
   }
 
   static void empty_handler_write(ngx_event_t *wev) {
-    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, wev->log, 0,
-                   "PolFinalWafCtx: http empty handler (write)");
+    ngx_log_debug(NGX_LOG_DEBUG_HTTP, wev->log, 0,
+                  "PolFinalWafCtx: http empty handler (write)");
 
     // Avoid a busy loop on level-triggered event backends, matching nginx's
     // own direct empty-write-handler call sites. PolFinalWafCtx::complete()
@@ -711,8 +711,8 @@ class PolFinalWafCtx : public PolTaskCtx<PolFinalWafCtx> {
         ngx_log_error(NGX_LOG_ERR, wev->log, 0,
                       "failed to suspend downstream write event");
       } else {
-        ngx_log_debug0(NGX_LOG_DEBUG_HTTP, wev->log, 0,
-                       "PolFinalWafCtx: suspended downstream write event");
+        ngx_log_debug(NGX_LOG_DEBUG_HTTP, wev->log, 0,
+                      "PolFinalWafCtx: suspended downstream write event");
       }
     }
   }
@@ -723,8 +723,8 @@ class PolFinalWafCtx : public PolTaskCtx<PolFinalWafCtx> {
         *static_cast<ngx_http_request_t *>(upstream_c.data);
     ngx_connection_t &downstream_c = *req.connection;
 
-    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, downstream_c.log, 0,
-                   "PolFinalWafCtx: http empty upstream read handler");
+    ngx_log_debug(NGX_LOG_DEBUG_HTTP, downstream_c.log, 0,
+                  "PolFinalWafCtx: http empty upstream read handler");
 
     // avoid busy loop on level-triggered (see ngx_http_block_reading)
     if ((ngx_event_flags & NGX_USE_LEVEL_EVENT) && upstream_c.read->active) {
@@ -750,8 +750,8 @@ class PolFinalWafCtx : public PolTaskCtx<PolFinalWafCtx> {
     if (req_.upstream && req_.upstream->upgrade) {
       // the upstream read handler bypasses the downstream handlers and calls
       // connection->send directly. We need to neuter it
-      ngx_log_debug0(NGX_LOG_DEBUG_HTTP, req_.connection->log, 0,
-                     "PolFinalWafCtx: replacing upstream read handler");
+      ngx_log_debug(NGX_LOG_DEBUG_HTTP, req_.connection->log, 0,
+                    "PolFinalWafCtx: replacing upstream read handler");
       auto &upstream_read_handler =
           req_.upstream->peer.connection->read->handler;
       orig_upstream_read_handler_ = upstream_read_handler;
@@ -771,8 +771,8 @@ class PolFinalWafCtx : public PolTaskCtx<PolFinalWafCtx> {
   void trigger_upstream_read() noexcept {
     ngx_connection_t &upstream_c = *req_.upstream->peer.connection;
 
-    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, req_log(), 0,
-                   "PolFinalWafCtx: triggering upstream read");
+    ngx_log_debug(NGX_LOG_DEBUG_HTTP, req_log(), 0,
+                  "PolFinalWafCtx: triggering upstream read");
 
     // re-arm after possible del_event
     ngx_handle_read_event(upstream_c.read, 0);
@@ -825,15 +825,15 @@ class PolFinalWafCtx : public PolTaskCtx<PolFinalWafCtx> {
 ngx_int_t Context::do_request_body_filter(ngx_http_request_t &request,
                                           ngx_chain_t *in, dd::Span &span) {
   auto st = stage_->load(std::memory_order_acquire);
-  ngx_log_debug4(NGX_LOG_DEBUG_HTTP, request.connection->log, 0,
-                 "waf request body filter %s in chain. accumulated=%uz, "
-                 "copied=%uz, Stage: %d",
-                 in ? "with" : "without", filter_ctx_.out_total,
-                 filter_ctx_.copied_total, static_cast<int>(st));
+  ngx_log_debug(NGX_LOG_DEBUG_HTTP, request.connection->log, 0,
+                "waf request body filter %s in chain. accumulated=%uz, "
+                "copied=%uz, Stage: %d",
+                in ? "with" : "without", filter_ctx_.out_total,
+                filter_ctx_.copied_total, static_cast<int>(st));
 
   if (st == stage::AFTER_BEGIN_WAF) {
-    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, request.connection->log, 0,
-                   "first filter call, req refcount=%d", request.main->count);
+    ngx_log_debug(NGX_LOG_DEBUG_HTTP, request.connection->log, 0,
+                  "first filter call, req refcount=%d", request.main->count);
     // buffer the request body during reading
     // https://github.com/nginx/nginx/commit/67d160bf25e02ba6679bb6c3b9cbdfeb29b759de
     // https://nginx.org/en/docs/dev/development_guide.html#http_request_body_filters
@@ -849,8 +849,8 @@ ngx_int_t Context::do_request_body_filter(ngx_http_request_t &request,
       // preread call by ngx_http_read_client_request_body.
       // read and write handlers were not set yet, so don't launch the
       // waf now. We'll do it on the next call.
-      ngx_log_debug0(NGX_LOG_DEBUG_HTTP, request.connection->log, 0,
-                     "1st preread call, no waf task submission yet");
+      ngx_log_debug(NGX_LOG_DEBUG_HTTP, request.connection->log, 0,
+                    "1st preread call, no waf task submission yet");
       st = transition_to_stage(stage::COLLECTING_ON_REQ_DATA_PREREAD);
     } else {
       st = transition_to_stage(stage::COLLECTING_ON_REQ_DATA);
@@ -884,15 +884,15 @@ ngx_int_t Context::do_request_body_filter(ngx_http_request_t &request,
       }
 
       if (filter_ctx_.out_total == 0) {
-        ngx_log_debug0(NGX_LOG_DEBUG_HTTP, request.connection->log, 0,
-                       "no data to run WAF on");
+        ngx_log_debug(NGX_LOG_DEBUG_HTTP, request.connection->log, 0,
+                      "no data to run WAF on");
         transition_to_stage(stage::AFTER_ON_REQ_WAF);
         goto pass_downstream;
       }
 
-      ngx_log_debug2(NGX_LOG_DEBUG_HTTP, request.connection->log, 0,
-                     "running WAF on %uz bytes of data (found last: %s)",
-                     new_size, is_last ? "true" : "false");
+      ngx_log_debug(NGX_LOG_DEBUG_HTTP, request.connection->log, 0,
+                    "running WAF on %uz bytes of data (found last: %s)",
+                    new_size, is_last ? "true" : "false");
 
       PolReqBodyWafCtx &task_ctx =
           PolReqBodyWafCtx::create(request, *this, span);
@@ -920,9 +920,9 @@ ngx_int_t Context::do_request_body_filter(ngx_http_request_t &request,
   } else if (st == stage::AFTER_ON_REQ_WAF ||
              st == stage::AFTER_ON_REQ_WAF_BLOCK) {
     if (filter_ctx_.out) {  // first call after WAF ended
-      ngx_log_debug1(NGX_LOG_DEBUG_HTTP, request.connection->log, 0,
-                     "first filter call after WAF ended, req refcount=%d",
-                     request.main->count);
+      ngx_log_debug(NGX_LOG_DEBUG_HTTP, request.connection->log, 0,
+                    "first filter call after WAF ended, req refcount=%d",
+                    request.main->count);
       if (buffer_chain(filter_ctx_, RequestPool{request}, in, false) !=
           NGX_OK) {
         return NGX_HTTP_INTERNAL_SERVER_ERROR;
@@ -1155,8 +1155,8 @@ Context *get_sec_ctx(ngx_http_request_t *random_data) noexcept {
 
 void Context::drain_buffered_data_write_handler(
     ngx_http_request_t *r) noexcept {
-  ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
-                 "drain_buffered_data_write_handler called");
+  ngx_log_debug(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                "drain_buffered_data_write_handler called");
 
   Context *ctx = get_sec_ctx(r);
   if (!ctx) {
@@ -1182,8 +1182,8 @@ void Context::drain_buffered_data_write_handler(
   }
 
   if (wev->delayed || r->aio) {
-    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, wev->log, 0,
-                   "drain_buffered_data_write_handler: http writer delayed");
+    ngx_log_debug(NGX_LOG_DEBUG_HTTP, wev->log, 0,
+                  "drain_buffered_data_write_handler: http writer delayed");
 
     if (!wev->delayed) {
       ngx_add_timer(wev, clcf->send_timeout);
@@ -1201,10 +1201,10 @@ void Context::drain_buffered_data_write_handler(
                 "ngx_http_output_filter");
   ngx_int_t rc = ngx_http_output_filter(r, NULL);
 
-  ngx_log_debug3(NGX_LOG_DEBUG_HTTP, c->log, 0,
-                 "drain_buffered_data_write_handler: http writer output "
-                 "filter: %i, \"%V?%V\"",
-                 rc, &r->uri, &r->args);
+  ngx_log_debug(NGX_LOG_DEBUG_HTTP, c->log, 0,
+                "drain_buffered_data_write_handler: http writer output "
+                "filter: %i, \"%V?%V\"",
+                rc, &r->uri, &r->args);
 
   if (rc == NGX_ERROR) {
     ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
@@ -1232,9 +1232,9 @@ void Context::drain_buffered_data_write_handler(
     return;
   }
 
-  ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
-                 "drain_buffered_header_write_handler: send_buffered_header "
-                 "succeeded; restoring handler and triggering write");
+  ngx_log_debug(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                "drain_buffered_header_write_handler: send_buffered_header "
+                "succeeded; restoring handler and triggering write");
   r->write_event_handler = ctx->prev_req_write_evt_handler_;
   ngx_post_event(r->connection->write, &ngx_posted_events);
 }
@@ -1446,12 +1446,12 @@ Http2TemporarySendChain Http2TemporarySendChain::instance;
 ngx_int_t Context::do_header_filter(ngx_http_request_t &request,
                                     dd::Span &span) {
   auto st = stage_->load(std::memory_order_acquire);
-  ngx_log_debug4(NGX_LOG_DEBUG_HTTP, request.connection->log, 0,
-                 "waf header filter in stage %V, header_sent=%d, "
-                 "buf_header_data_(len,size)=(%uz,%uz)",
-                 to_ngx_str(st), request.header_sent,
-                 chain::length(header_filter_ctx_.out),
-                 chain::size(header_filter_ctx_.out));
+  ngx_log_debug(NGX_LOG_DEBUG_HTTP, request.connection->log, 0,
+                "waf header filter in stage %V, header_sent=%d, "
+                "buf_header_data_(len,size)=(%uz,%uz)",
+                to_ngx_str(st), request.header_sent,
+                chain::length(header_filter_ctx_.out),
+                chain::size(header_filter_ctx_.out));
 
   if (st != stage::AFTER_BEGIN_WAF && st != stage::AFTER_ON_REQ_WAF) {
     return ngx_http_next_header_filter(&request);
@@ -1564,10 +1564,10 @@ ngx_int_t Context::do_output_body_filter(ngx_http_request_t &request,
       return NGX_HTTP_INTERNAL_SERVER_ERROR;
     }
 
-    ngx_log_debug2(NGX_LOG_DEBUG_HTTP, request.connection->log, 0,
-                   "waf output body filter: there are now %uz bytes of "
-                   "accumulated output data (%uz copied)",
-                   out_filter_ctx_.out_total, out_filter_ctx_.copied_total);
+    ngx_log_debug(NGX_LOG_DEBUG_HTTP, request.connection->log, 0,
+                  "waf output body filter: there are now %uz bytes of "
+                  "accumulated output data (%uz copied)",
+                  out_filter_ctx_.out_total, out_filter_ctx_.copied_total);
 
     const bool start_waf =
         st == stage::COLLECTING_ON_RESP_DATA &&
@@ -1609,10 +1609,10 @@ ngx_int_t Context::do_output_body_filter(ngx_http_request_t &request,
   if (st == stage::WAF_END_BLOCK_COMMIT) {
     // commit of body of blocking response
     assert(request.header_sent == 1);
-    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, request.connection->log, 0,
-                   "waf output body filter: discarding %uz bytes of "
-                   "accumulated data and passing down blocking response data",
-                   out_filter_ctx_.out_total);
+    ngx_log_debug(NGX_LOG_DEBUG_HTTP, request.connection->log, 0,
+                  "waf output body filter: discarding %uz bytes of "
+                  "accumulated data and passing down blocking response data",
+                  out_filter_ctx_.out_total);
     header_filter_ctx_.clear(RequestPool{request});
     out_filter_ctx_.clear(RequestPool{request});
 
@@ -1688,8 +1688,8 @@ std::optional<BlockSpecification> Context::run_waf_req_post(
                                 filter_ctx_.out_total, memres_);
 
   if (!success) {
-    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, request.connection->log, 0,
-                   "failed to parse request body for WAF");
+    ngx_log_debug(NGX_LOG_DEBUG_HTTP, request.connection->log, 0,
+                  "failed to parse request body for WAF");
     return std::nullopt;
   }
 

--- a/src/security/ddwaf_req.cpp
+++ b/src/security/ddwaf_req.cpp
@@ -260,8 +260,8 @@ bool handle_schema(ngx_log_t &log, const ddwaf_obj &obj, Func &&f) {
     return false;
   }
 
-  ngx_log_debug1(NGX_LOG_DEBUG_HTTP, &log, 0,
-                 "ddwaf_req: handling attribute %V", &key);
+  ngx_log_debug(NGX_LOG_DEBUG_HTTP, &log, 0, "ddwaf_req: handling attribute %V",
+                &key);
 
   rapidjson::StringBuffer buffer;
   JsonWriter w(buffer);
@@ -309,8 +309,8 @@ void handle_non_schema_attribute(ngx_log_t &log, const ddwaf_obj &obj,
     return;
   }
 
-  ngx_log_debug1(NGX_LOG_DEBUG_HTTP, &log, 0,
-                 "ddwaf_req: handling non-schema attribute %V", &key);
+  ngx_log_debug(NGX_LOG_DEBUG_HTTP, &log, 0,
+                "ddwaf_req: handling non-schema attribute %V", &key);
 
   std::variant<std::string_view, double> v;
   if (obj.is_numeric()) {

--- a/src/security/directives.h
+++ b/src/security/directives.h
@@ -115,6 +115,33 @@ constexpr directive kAppsecDirectives[] = {
     },
 
     {
+        "datadog_appsec_test_task_delay_ms",
+        NGX_HTTP_MAIN_CONF | NGX_CONF_TAKE1,
+        ngx_conf_set_num_slot,
+        NGX_HTTP_MAIN_CONF_OFFSET,
+        offsetof(datadog_main_conf_t, appsec_test_task_delay_ms),
+        nullptr,
+    },
+
+    {
+        "datadog_appsec_test_task_termination_delay_ms",
+        NGX_HTTP_MAIN_CONF | NGX_CONF_TAKE1,
+        ngx_conf_set_num_slot,
+        NGX_HTTP_MAIN_CONF_OFFSET,
+        offsetof(datadog_main_conf_t, appsec_test_task_termination_delay_ms),
+        nullptr,
+    },
+
+    {
+        "datadog_appsec_test_task_termination_mask",
+        NGX_HTTP_MAIN_CONF | NGX_CONF_TAKE1,
+        ngx_conf_set_num_slot,
+        NGX_HTTP_MAIN_CONF_OFFSET,
+        offsetof(datadog_main_conf_t, appsec_test_task_termination_mask),
+        nullptr,
+    },
+
+    {
         "datadog_appsec_stats_host_port",
         NGX_HTTP_MAIN_CONF | NGX_CONF_TAKE1,
         ngx_conf_set_str_slot,

--- a/test/cases/case.py
+++ b/test/cases/case.py
@@ -110,6 +110,7 @@ class TestCase(unittest.TestCase):
         nginx_log_queue = self.orch.logs['nginx']
         deadline = time.monotonic() + timeout_secs
         crash_lines = []
+        observed_lines = []
         while True:
             remaining = deadline - time.monotonic()
             if remaining <= 0:
@@ -118,10 +119,12 @@ class TestCase(unittest.TestCase):
                 line = nginx_log_queue.get(timeout=remaining)
             except queue.Empty:
                 break
+            observed_lines.append(line)
             if crash_re.search(line):
                 crash_lines.append(line.strip())
         self.assertEqual([], crash_lines,
                          f'nginx worker crashed: {crash_lines}')
+        return observed_lines
 
     def tearDown(self):
         end = time.monotonic()

--- a/test/cases/orchestration.py
+++ b/test/cases/orchestration.py
@@ -645,6 +645,43 @@ class Orchestration:
         )
         return result.returncode, result.stdout
 
+    def send_nginx_request_until_close(self, request_text, port=80):
+        """Send a raw HTTP request and read until nginx closes the socket.
+
+        `request_text` must contain the full request, including its terminating
+        blank line. Returns the data received before the close. Connection,
+        send, and receive failures raise an exception.
+        """
+        script = f"""
+import socket
+import sys
+
+s = socket.create_connection(("nginx", {port}), timeout=5)
+try:
+    s.sendall({request_text!r}.encode())
+    chunks = []
+    while True:
+        chunk = s.recv(65536)
+        if not chunk:
+            break
+        chunks.append(chunk)
+    sys.stdout.buffer.write(b''.join(chunks))
+finally:
+    s.close()
+"""
+        command = docker_compose_command("exec", "-T", "--", "client",
+                                         "python3", "-c", script)
+        result = subprocess.run(
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=child_env(),
+            encoding="utf8",
+            errors="replace",
+            check=True,
+        )
+        return result.stdout
+
     def send_nginx_http_request(
         self,
         path,

--- a/test/cases/sec_blocking/test_task_teardown_race.py
+++ b/test/cases/sec_blocking/test_task_teardown_race.py
@@ -1,0 +1,161 @@
+"""Regression test for request termination while an AppSec WAF task runs.
+
+`PolTaskCtx::submit()` (src/security/context.cpp) increments
+`req_.main->count` to keep the request alive while a WAF task runs on a
+background thread, but historically failed to also increment
+`req_.main->blocked`. nginx's `ngx_http_terminate_request()` resets
+`r->main->count` and force-frees the request pool unless
+`r->main->blocked` is nonzero. An error that terminates a request while the
+task is queued or running could therefore destroy the pool while the task and
+its completion handler still held pointers into it.
+
+The test-only delay directive holds the task in flight, while the test-only
+termination directive schedules `ngx_http_finalize_request(..., NGX_ERROR)`
+on nginx's main thread. This deterministically exercises the same termination
+branch used by real request errors without relying on socket-close timing.
+"""
+
+from pathlib import Path
+
+from .. import case
+from .. import orchestration
+
+
+class TestTaskTeardownRace(case.TestCase):
+    requires_waf = True
+    min_nginx_version = '1.26.0'
+
+    # How long (ms) to artificially hold each WAF task "in flight" on the
+    # thread pool before its completion handler is allowed to run.
+    TASK_DELAY_MS = 1000
+    TERMINATION_DELAY_MS = 500
+
+    INITIAL_WAF_TASK = 1 << 0
+    REQUEST_BODY_WAF_TASK = 1 << 1
+    FINAL_WAF_TASK = 1 << 2
+
+    TERMINATION_MASKS = {
+        'test_initial_waf_task_survives_request_termination': INITIAL_WAF_TASK,
+        'test_request_body_waf_task_survives_request_termination':
+        REQUEST_BODY_WAF_TASK,
+        'test_final_waf_task_survives_request_termination': FINAL_WAF_TASK,
+    }
+
+    def setUp(self):
+        super().setUp()
+        waf_path = Path(__file__).parent / './conf/waf.json'
+        waf_text = waf_path.read_text()
+        self.orch.nginx_replace_file('/tmp/waf.json', waf_text)
+
+        termination_mask = self.TERMINATION_MASKS[self._testMethodName]
+
+        config = f"""
+thread_pool waf_thread_pool threads=2 max_queue=5;
+
+load_module /datadog-tests/ngx_http_datadog_module.so;
+
+error_log stderr debug;
+
+events {{
+    worker_connections  1024;
+}}
+
+http {{
+    datadog_agent_url http://agent:8126;
+    datadog_appsec_enabled on;
+    datadog_appsec_ruleset_file /tmp/waf.json;
+    datadog_appsec_waf_timeout 2s;
+    datadog_waf_thread_pool_name waf_thread_pool;
+    datadog_appsec_max_saved_output_data 64k;
+    datadog_appsec_test_task_delay_ms {self.TASK_DELAY_MS};
+    datadog_appsec_test_task_termination_delay_ms {self.TERMINATION_DELAY_MS};
+    datadog_appsec_test_task_termination_mask {termination_mask};
+
+    client_max_body_size 10m;
+
+    server {{
+        listen              80;
+
+        location /http {{
+            proxy_pass http://http:8080;
+        }}
+    }}
+}}
+"""
+        status, log_lines = self.orch.nginx_replace_config(
+            config, 'task_teardown_race.conf')
+        self.assertEqual(0, status, log_lines)
+
+        # Drain any log lines accumulated so far so that
+        # assert_no_worker_crash only observes what happens during this test.
+        nginx_log_queue = self.orch.logs['nginx']
+        while not nginx_log_queue.empty():
+            try:
+                nginx_log_queue.get_nowait()
+            except Exception:
+                break
+
+    def assert_task_survives_request_termination(self,
+                                                 request_text,
+                                                 expect_empty_response=True):
+        nginx_container = self.orch.containers['nginx']
+        worker_pids_before = orchestration.nginx_worker_pids(
+            nginx_container, self.orch.verbose)
+        self.assertTrue(worker_pids_before,
+                        "expected to find at least one nginx worker process")
+
+        # The hooks terminate this request on nginx's main thread while the
+        # selected WAF task remains delayed on the thread pool. The client
+        # waits until nginx finishes the termination and closes the socket.
+        response = self.orch.send_nginx_request_until_close(request_text,
+                                                            port=80)
+        if expect_empty_response:
+            self.assertEqual('', response)
+
+        # Poll through the delayed task's completion. Without blocked, nginx
+        # frees the request before this point and the worker uses freed state.
+        log_lines = self.assert_no_worker_crash(
+            timeout_secs=(self.TASK_DELAY_MS / 1000.0) + 2)
+
+        self.assertTrue(
+            any('request was terminated while task' in line
+                and 'running the connection write handler' in line
+                for line in log_lines),
+            'the WAF task did not take the safe asynchronous request '
+            'termination completion path')
+
+        # The nginx worker(s) present before the race should still be
+        # running (i.e. nginx did not crash and get respawned by the
+        # master process).
+        worker_pids_after = orchestration.nginx_worker_pids(
+            nginx_container, self.orch.verbose)
+        self.assertEqual(
+            worker_pids_before, worker_pids_after,
+            "nginx worker process(es) changed, indicating a crash/respawn")
+
+    def test_initial_waf_task_survives_request_termination(self):
+        request_text = ("GET /http HTTP/1.1\r\n"
+                        "Host: nginx\r\n"
+                        "Connection: close\r\n"
+                        "\r\n")
+        self.assert_task_survives_request_termination(request_text)
+
+    def test_request_body_waf_task_survives_request_termination(self):
+        body = '{"test":"safe"}'
+        request_text = ("POST /http HTTP/1.1\r\n"
+                        "Host: nginx\r\n"
+                        "Content-Type: application/json\r\n"
+                        f"Content-Length: {len(body)}\r\n"
+                        "Connection: close\r\n"
+                        "\r\n"
+                        f"{body}")
+        self.assert_task_survives_request_termination(request_text)
+
+    def test_final_waf_task_survives_request_termination(self):
+        request_text = (
+            "GET /http/response_body_test?trigger=safe&format=json HTTP/1.1\r\n"
+            "Host: nginx\r\n"
+            "Connection: close\r\n"
+            "\r\n")
+        self.assert_task_survives_request_termination(
+            request_text, expect_empty_response=False)

--- a/test/cases/sec_blocking/test_task_teardown_race.py
+++ b/test/cases/sec_blocking/test_task_teardown_race.py
@@ -43,7 +43,7 @@ class TestTaskTeardownRace(case.TestCase):
 
     def setUp(self):
         super().setUp()
-        waf_path = Path(__file__).parent / './conf/waf.json'
+        waf_path = Path(__file__).parent / 'conf/waf.json'
         waf_text = waf_path.read_text()
         self.orch.nginx_replace_file('/tmp/waf.json', waf_text)
 

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -90,7 +90,7 @@ services:
   # the service ("uwsgi") and the request's headers.  This way, tests can see
   # which trace context, if any, was propagated to the reverse proxied server.
   uwsgi:
-    image: registry.ddbuild.io/ci/nginx-datadog/uwsgi
+    image: ${UWSGI_TEST_IMAGE:-registry.ddbuild.io/ci/nginx-datadog/uwsgi}
     stop_signal: SIGQUIT
     environment:
       - DD_ENV=prod

--- a/tools/clang-tidy/CMakeLists.txt
+++ b/tools/clang-tidy/CMakeLists.txt
@@ -7,7 +7,8 @@ find_package(Clang REQUIRED CONFIG)
 
 add_library(NginxDatadogClangTidy MODULE
   NginxDatadogModule.cpp
-  NginxLogFormatCheck.cpp)
+  NginxLogFormatCheck.cpp
+  NoNumberedNgxLogDebugCheck.cpp)
 
 target_compile_features(NginxDatadogClangTidy PRIVATE cxx_std_17)
 target_include_directories(NginxDatadogClangTidy PRIVATE

--- a/tools/clang-tidy/NginxDatadogModule.cpp
+++ b/tools/clang-tidy/NginxDatadogModule.cpp
@@ -1,4 +1,5 @@
 #include "NginxLogFormatCheck.h"
+#include "NoNumberedNgxLogDebugCheck.h"
 #include "clang-tidy/ClangTidyModule.h"
 #include "clang-tidy/ClangTidyModuleRegistry.h"
 
@@ -10,6 +11,8 @@ class NginxDatadogModule : public ClangTidyModule {
   void addCheckFactories(ClangTidyCheckFactories& CheckFactories) override {
     CheckFactories.registerCheck<NginxLogFormatCheck>(
         "nginx-datadog-ngx-log-format");
+    CheckFactories.registerCheck<NoNumberedNgxLogDebugCheck>(
+        "nginx-datadog-no-numbered-ngx-log-debug");
   }
 };
 

--- a/tools/clang-tidy/NoNumberedNgxLogDebugCheck.cpp
+++ b/tools/clang-tidy/NoNumberedNgxLogDebugCheck.cpp
@@ -1,0 +1,55 @@
+#include "NoNumberedNgxLogDebugCheck.h"
+
+#include <memory>
+
+#include "clang/Basic/Diagnostic.h"
+#include "clang/Basic/IdentifierTable.h"
+#include "clang/Lex/PPCallbacks.h"
+#include "clang/Lex/Preprocessor.h"
+#include "llvm/ADT/StringRef.h"
+
+namespace clang::tidy::nginx_datadog {
+namespace {
+
+bool isNumberedNgxLogDebug(llvm::StringRef Name) {
+  constexpr llvm::StringLiteral Prefix = "ngx_log_debug";
+  return Name.size() == Prefix.size() + 1 && Name.starts_with(Prefix) &&
+         Name.back() >= '0' && Name.back() <= '8';
+}
+
+class NoNumberedNgxLogDebugPPCallbacks : public PPCallbacks {
+ public:
+  explicit NoNumberedNgxLogDebugPPCallbacks(NoNumberedNgxLogDebugCheck& Check)
+      : Check(Check) {}
+
+  void MacroExpands(const Token& MacroNameToken, const MacroDefinition&,
+                    SourceRange, const MacroArgs*) override {
+    const IdentifierInfo* Identifier = MacroNameToken.getIdentifierInfo();
+    if (Identifier == nullptr ||
+        !isNumberedNgxLogDebug(Identifier->getName())) {
+      return;
+    }
+
+    Check.diag(MacroNameToken.getLocation(),
+               "use variadic macro 'ngx_log_debug' instead of non-variadic "
+               "macro '%0'")
+        << Identifier->getName()
+        << FixItHint::CreateReplacement(
+               CharSourceRange::getTokenRange(MacroNameToken.getLocation(),
+                                              MacroNameToken.getLocation()),
+               "ngx_log_debug");
+  }
+
+ private:
+  NoNumberedNgxLogDebugCheck& Check;
+};
+
+}  // namespace
+
+void NoNumberedNgxLogDebugCheck::registerPPCallbacks(const SourceManager&,
+                                                     Preprocessor* PP,
+                                                     Preprocessor*) {
+  PP->addPPCallbacks(std::make_unique<NoNumberedNgxLogDebugPPCallbacks>(*this));
+}
+
+}  // namespace clang::tidy::nginx_datadog

--- a/tools/clang-tidy/NoNumberedNgxLogDebugCheck.h
+++ b/tools/clang-tidy/NoNumberedNgxLogDebugCheck.h
@@ -1,0 +1,19 @@
+#ifndef NGINX_DATADOG_NO_NUMBERED_NGX_LOG_DEBUG_CHECK_H
+#define NGINX_DATADOG_NO_NUMBERED_NGX_LOG_DEBUG_CHECK_H
+
+#include "clang-tidy/ClangTidyCheck.h"
+
+namespace clang::tidy::nginx_datadog {
+
+class NoNumberedNgxLogDebugCheck : public ClangTidyCheck {
+ public:
+  NoNumberedNgxLogDebugCheck(StringRef Name, ClangTidyContext* Context)
+      : ClangTidyCheck(Name, Context) {}
+
+  void registerPPCallbacks(const SourceManager& SourceManager, Preprocessor* PP,
+                           Preprocessor* ModuleExpanderPP) override;
+};
+
+}  // namespace clang::tidy::nginx_datadog
+
+#endif  // NGINX_DATADOG_NO_NUMBERED_NGX_LOG_DEBUG_CHECK_H

--- a/tools/clang-tidy/README.md
+++ b/tools/clang-tidy/README.md
@@ -1,10 +1,13 @@
-# nginx log format clang-tidy check
+# nginx clang-tidy checks
 
-This directory contains an out-of-tree clang-tidy module with one check:
+This directory contains an out-of-tree clang-tidy module with these checks:
 
-- `nginx-datadog-ngx-log-format`
+- `nginx-datadog-ngx-log-format` validates literal nginx log format strings and
+  their arguments.
+- `nginx-datadog-no-numbered-ngx-log-debug` rejects the non-variadic
+  `ngx_log_debug0` ... `ngx_log_debug8` macros. Use `ngx_log_debug` instead.
 
-The check validates literal format strings passed to `ngx_log_error`,
+The format check validates literal format strings passed to `ngx_log_error`,
 `ngx_log_debug`, `ngx_log_debug0` ... `ngx_log_debug8`, and direct
 `ngx_log_error_core` calls.  It implements the format grammar used by nginx's
 `ngx_vslprintf` in `src/core/ngx_string.c`.

--- a/tools/clang-tidy/test/no-numbered-ngx-log-debug.cpp
+++ b/tools/clang-tidy/test/no-numbered-ngx-log-debug.cpp
@@ -1,0 +1,47 @@
+#define ngx_log_debug(...) ((void)0)
+#define ngx_log_debug0(...) ngx_log_debug(__VA_ARGS__)
+#define ngx_log_debug1(...) ngx_log_debug(__VA_ARGS__)
+#define ngx_log_debug2(...) ngx_log_debug(__VA_ARGS__)
+#define ngx_log_debug3(...) ngx_log_debug(__VA_ARGS__)
+#define ngx_log_debug4(...) ngx_log_debug(__VA_ARGS__)
+#define ngx_log_debug5(...) ngx_log_debug(__VA_ARGS__)
+#define ngx_log_debug6(...) ngx_log_debug(__VA_ARGS__)
+#define ngx_log_debug7(...) ngx_log_debug(__VA_ARGS__)
+#define ngx_log_debug8(...) ngx_log_debug(__VA_ARGS__)
+
+void valid() { ngx_log_debug(0, nullptr, 0, "message"); }
+
+void invalid() {
+  ngx_log_debug0(0, nullptr, 0, "message");
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use variadic macro
+  // CHECK-FIXES: ngx_log_debug(0, nullptr, 0, "message");
+  ngx_log_debug1(0, nullptr, 0, "message %d", 1);
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use variadic macro
+  // CHECK-FIXES: ngx_log_debug(0, nullptr, 0, "message %d", 1);
+  ngx_log_debug2(0, nullptr, 0, "%d %d", 1, 2);
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use variadic macro
+  // CHECK-FIXES: ngx_log_debug(0, nullptr, 0, "%d %d", 1, 2);
+  ngx_log_debug3(0, nullptr, 0, "%d %d %d", 1, 2, 3);
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use variadic macro
+  // CHECK-FIXES: ngx_log_debug(0, nullptr, 0, "%d %d %d", 1, 2, 3);
+  ngx_log_debug4(0, nullptr, 0, "%d %d %d %d", 1, 2, 3, 4);
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use variadic macro
+  // CHECK-FIXES: ngx_log_debug(0, nullptr, 0, "%d %d %d %d", 1, 2, 3, 4);
+  ngx_log_debug5(0, nullptr, 0, "%d %d %d %d %d", 1, 2, 3, 4, 5);
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use variadic macro
+  // CHECK-FIXES: ngx_log_debug(0, nullptr, 0, "%d %d %d %d %d", 1, 2, 3, 4,
+  // CHECK-FIXES-NEXT: 5);
+  ngx_log_debug6(0, nullptr, 0, "%d %d %d %d %d %d", 1, 2, 3, 4, 5, 6);
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use variadic macro
+  // CHECK-FIXES: ngx_log_debug(0, nullptr, 0, "%d %d %d %d %d %d", 1, 2, 3,
+  // CHECK-FIXES-NEXT: 4, 5, 6);
+  ngx_log_debug7(0, nullptr, 0, "%d %d %d %d %d %d %d", 1, 2, 3, 4, 5, 6, 7);
+  // CHECK-MESSAGES: :[[@LINE-2]]:3: warning: use variadic macro
+  // CHECK-FIXES: ngx_log_debug(0, nullptr, 0, "%d %d %d %d %d %d %d", 1, 2,
+  // CHECK-FIXES-NEXT: 3, 4, 5, 6, 7);
+  ngx_log_debug8(0, nullptr, 0, "%d %d %d %d %d %d %d %d", 1, 2, 3, 4, 5, 6, 7,
+                 8);
+  // CHECK-MESSAGES: :[[@LINE-2]]:3: warning: use variadic macro
+  // CHECK-FIXES: ngx_log_debug(0, nullptr, 0, "%d %d %d %d %d %d %d %d", 1,
+  // CHECK-FIXES-NEXT: 2, 3, 4, 5, 6, 7, 8);
+}


### PR DESCRIPTION
 ## What does this change?

  Keep nginx requests alive while asynchronous WAF tasks are running.

  ## Why is this needed?

  WAF task submission incremented `r->main->count`, but not `r->main->blocked`.

During request termination, nginx may discard the request count and destroy the request pool when `blocked == 0`. Because  the WAF task and its completion state contain pool-owned data, the task could then complete against freed memory, causing request corruption or a worker crash.

  ## How is it fixed?

  - Increment both `r->main->count` and `r->main->blocked` before posting a WAF task.
  - Roll back both references if task submission fails.
  - Decrement `blocked` when completion returns to nginx’s main thread.
  - If the request was terminated while the task was running, release the task’s count reference and invoke the connection write handler so nginx can finish deferred termination.
  - Do not resume normal WAF processing for an already terminated request.

## Testing

It is not easy to force a request termination in test code, especially given that we cut most paths that would lead to it by replacing either the request or the connection read/write handlers. However, it remains a possibility -- anything calling `ngx_http_finalize_request` e.g. from a timer would trigger the bug. For testing, we add special testing flags that inject delays in the task and start a timer that calls `ngx_http_finalize_request`.