### PR TITLE
Avoid loading on ubuntu debian

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,6 +225,12 @@ target_sources(ngx_http_datadog_objs
     src/tracing_library.cpp
 )
 
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  target_compile_definitions(ngx_http_datadog_objs PRIVATE
+    DD_NGINX_DEBIAN_UBUNTU_BUILD=${NGINX_DEBIAN_UBUNTU_BUILD})
+  target_sources(ngx_http_datadog_objs PRIVATE src/nginx_package_abi.cpp)
+endif()
+
 if(NGINX_DATADOG_ASM_ENABLED)
   target_sources(ngx_http_datadog_objs
     PRIVATE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,7 @@ include(./cmake/deps/rapidjson.cmake)
 include(./cmake/deps/cppcodec.cmake)
 
 add_subdirectory(./dd-trace-cpp EXCLUDE_FROM_ALL)
+set_property(TARGET dd-trace-cpp-static PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 if(ENABLE_ASAN OR ENABLE_MSAN)
   foreach(target_name IN ITEMS

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,12 @@ ifeq ($(ARCH),arm64)
 	ARCH := aarch64
 endif
 
-NGINX_SRC_DIR ?= $(PWD)/nginx
+NGINX_SRC_DIR ?=
+ifneq ($(strip $(NGINX_SRC_DIR)),)
+	NGINX_SRC_DIR_DOCKER_ARGS := \
+		--env NGINX_SRC_DIR=/mnt/nginx-src \
+		--mount "type=bind,source=$(abspath $(NGINX_SRC_DIR)),destination=/mnt/nginx-src"
+endif
 
 DOCKER_PLATFORM := linux/$(ARCH)
 ifeq ($(DOCKER_PLATFORM),linux/x86_64)
@@ -165,6 +170,7 @@ clean:
 .PHONY: build
 build: dd-trace-cpp-deps
 	cmake -B $(BUILD_DIR) -DNGINX_VERSION=$(NGINX_VERSION) \
+		-DNGINX_SRC_DIR="$(NGINX_SRC_DIR)" \
 		-DNGINX_COVERAGE=$(COVERAGE) -DCMAKE_BUILD_TYPE=$(BUILD_TYPE) -DNGINX_DATADOG_ASM_ENABLED=$(WAF) -DNGINX_DATADOG_RUM_ENABLED=$(RUM) . \
 		-DBUILD_TESTING=$(BUILD_TESTING) $(CMAKE_PCRE_OPTIONS)\
 		&& cmake --build $(BUILD_DIR) -j $(MAKE_JOB_COUNT) -v
@@ -184,7 +190,7 @@ else
 		--env ARCH=$(ARCH) \
 		--env BUILD_TYPE=$(BUILD_TYPE) \
 		--env NGINX_VERSION=$(NGINX_VERSION) \
-		--env NGINX_SRC_DIR=$(NGINX_SRC_DIR) \
+		$(NGINX_SRC_DIR_DOCKER_ARGS) \
 		--env WAF=$(WAF) \
 		--env RUM=$(RUM) \
 		--env ASAN=$(ASAN) \
@@ -202,6 +208,7 @@ build-musl-aux build-musl-cov-aux:
 		-DNGINX_PATCH_AWAY_LIBC=ON \
 		-DCMAKE_BUILD_TYPE=$(BUILD_TYPE) \
 		-DNGINX_VERSION="$(NGINX_VERSION)" \
+		-DNGINX_SRC_DIR="$(NGINX_SRC_DIR)" \
 		-DNGINX_DATADOG_ASM_ENABLED="$(WAF)" . \
 		-DNGINX_DATADOG_RUM_ENABLED="$(RUM)" . \
 		-DNGINX_COVERAGE=$(COVERAGE) \

--- a/cmake/deps/nginx-module.cmake
+++ b/cmake/deps/nginx-module.cmake
@@ -46,6 +46,23 @@ else()
   set(nginx_SOURCE_DIR ${NGINX_SRC_DIR})
 endif()
 
+set(NGINX_DEBIAN_UBUNTU_BUILD 0)
+set(NGINX_PACKAGE_ABI_FILE
+  "${nginx_SOURCE_DIR}/debian/libnginx-mod.abisubstvars")
+if(EXISTS "${NGINX_PACKAGE_ABI_FILE}")
+  file(READ "${NGINX_PACKAGE_ABI_FILE}" NGINX_PACKAGE_ABI_METADATA)
+  string(REGEX MATCH "nginx:abi=nginx-abi-[A-Za-z0-9.+:~_-]+"
+    NGINX_PACKAGE_ABI_DECLARATION
+    "${NGINX_PACKAGE_ABI_METADATA}")
+  if(NGINX_PACKAGE_ABI_DECLARATION STREQUAL "")
+    message(FATAL_ERROR
+      "Could not read the nginx package ABI from ${NGINX_PACKAGE_ABI_FILE}")
+  endif()
+  set(NGINX_DEBIAN_UBUNTU_BUILD 1)
+endif()
+message(STATUS
+  "nginx Debian/Ubuntu package build=[${NGINX_DEBIAN_UBUNTU_BUILD}]")
+
 set(module_file ${nginx_SOURCE_DIR}/objs/ngx_http_datadog_module_modules.c)
 set_source_files_properties(${module_file} PROPERTIES GENERATED TRUE)
 

--- a/src/common/directives.h
+++ b/src/common/directives.h
@@ -1,5 +1,20 @@
 #pragma once
 
+#if defined(__clang__)
+#define PRAGMA_PUSH_IGNORE_INVALID_OFFSETOF \
+  _Pragma("clang diagnostic push")          \
+      _Pragma("clang diagnostic ignored \"-Winvalid-offsetof\"")
+#define PRAGMA_POP_IGNORE_INVALID_OFFSETOF _Pragma("clang diagnostic pop")
+#elif defined(__GNUC__)
+#define PRAGMA_PUSH_IGNORE_INVALID_OFFSETOF \
+  _Pragma("GCC diagnostic push")            \
+      _Pragma("GCC diagnostic ignored \"-Winvalid-offsetof\"")
+#define PRAGMA_POP_IGNORE_INVALID_OFFSETOF _Pragma("GCC diagnostic pop")
+#else
+#define PRAGMA_PUSH_IGNORE_INVALID_OFFSETOF
+#define PRAGMA_POP_IGNORE_INVALID_OFFSETOF
+#endif
+
 extern "C" {
 #include <ngx_core.h>
 }

--- a/src/nginx_package_abi.cpp
+++ b/src/nginx_package_abi.cpp
@@ -1,0 +1,155 @@
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include "nginx_package_abi.h"
+
+#include <dlfcn.h>
+#include <sys/mman.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <array>
+#include <cerrno>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <string_view>
+
+#ifndef DD_NGINX_DEBIAN_UBUNTU_BUILD
+#define DD_NGINX_DEBIAN_UBUNTU_BUILD 0
+#endif
+
+namespace datadog::nginx::package_abi {
+namespace {
+
+using NginxMain = int (*)(int, char *const *);
+
+constexpr std::string_view kUbuntuVersionMarker = "(Ubuntu)";
+constexpr std::string_view kUbuntuConfigureMarker = "--build=Ubuntu";
+constexpr std::string_view kDebianBuildPath =
+    "-ffile-prefix-map=/build/reproducible-path/nginx-";
+constexpr std::array<std::string_view, 3> kDebianPackagingLayout = {
+    "--prefix=/usr/share/nginx",
+    "--modules-path=/usr/lib/nginx/modules",
+    "--http-client-body-temp-path=/var/lib/nginx/body",
+};
+
+bool contains(std::string_view text, std::string_view marker) noexcept {
+  return text.find(marker) != std::string_view::npos;
+}
+
+class FileDescriptor {
+ public:
+  explicit FileDescriptor(int value) : value_{value} {}
+  ~FileDescriptor() {
+    if (value_ >= 0) {
+      close(value_);
+    }
+  }
+
+  FileDescriptor(const FileDescriptor &) = delete;
+  FileDescriptor &operator=(const FileDescriptor &) = delete;
+
+  int get() const { return value_; }
+
+ private:
+  int value_;
+};
+
+std::optional<std::string> running_nginx_version_info() {
+  const auto nginx_main =
+      reinterpret_cast<NginxMain>(dlsym(RTLD_DEFAULT, "main"));
+  auto *const test_config = reinterpret_cast<std::uintptr_t *>(
+      dlsym(RTLD_DEFAULT, "ngx_test_config"));
+  if (nginx_main == nullptr || test_config == nullptr) {
+    return std::nullopt;
+  }
+
+  FileDescriptor output{memfd_create("nginx-version", MFD_CLOEXEC)};
+  if (output.get() == -1) {
+    return std::nullopt;
+  }
+
+  const pid_t child = fork();
+  if (child == -1) {
+    return std::nullopt;
+  }
+
+  if (child == 0) {
+    // The parent may be processing `nginx -t`. Without clearing this flag,
+    // nginx's main() continues into a second configuration after printing
+    // its version instead of returning immediately.
+    *test_config = 0;
+
+    if (dup2(output.get(), STDERR_FILENO) == -1) {
+      _exit(1);
+    }
+
+    char executable[] = "nginx";
+    char version[] = "-V";
+    char *arguments[] = {executable, version, nullptr};
+    _exit(nginx_main(2, arguments) == 0 ? 0 : 1);
+  }
+
+  int status = 0;
+  pid_t waited;
+  do {
+    waited = waitpid(child, &status, 0);
+  } while (waited == -1 && errno == EINTR);
+
+  if (waited != child || !WIFEXITED(status) || WEXITSTATUS(status) != 0 ||
+      lseek(output.get(), 0, SEEK_SET) == -1) {
+    return std::nullopt;
+  }
+
+  std::string result;
+  std::array<char, 4096> buffer;
+  for (;;) {
+    const ssize_t count = read(output.get(), buffer.data(), buffer.size());
+    if (count > 0) {
+      result.append(buffer.data(), static_cast<size_t>(count));
+    } else if (count == -1 && errno == EINTR) {
+      continue;
+    } else if (count == 0) {
+      return result;
+    } else {
+      return std::nullopt;
+    }
+  }
+}
+
+}  // namespace
+
+bool is_debian_or_ubuntu_build(std::string_view version_info) noexcept {
+  if (contains(version_info, kUbuntuVersionMarker) ||
+      contains(version_info, kUbuntuConfigureMarker)) {
+    return true;
+  }
+
+  if (!contains(version_info, kDebianBuildPath)) {
+    return false;
+  }
+
+  for (const auto marker : kDebianPackagingLayout) {
+    if (!contains(version_info, marker)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool running_nginx_is_debian_or_ubuntu() noexcept {
+  try {
+    const auto version_info = running_nginx_version_info();
+    return version_info && is_debian_or_ubuntu_build(*version_info);
+  } catch (...) {
+    return false;
+  }
+}
+
+bool module_was_built_for_debian_or_ubuntu() noexcept {
+  return DD_NGINX_DEBIAN_UBUNTU_BUILD;
+}
+
+}  // namespace datadog::nginx::package_abi

--- a/src/nginx_package_abi.cpp
+++ b/src/nginx_package_abi.cpp
@@ -139,7 +139,7 @@ bool is_debian_or_ubuntu_build(std::string_view version_info) noexcept {
   return true;
 }
 
-bool running_nginx_is_debian_or_ubuntu() noexcept {
+bool is_running_nginx_is_debian_or_ubuntu() noexcept {
   try {
     const auto version_info = running_nginx_version_info();
     return version_info && is_debian_or_ubuntu_build(*version_info);
@@ -148,7 +148,7 @@ bool running_nginx_is_debian_or_ubuntu() noexcept {
   }
 }
 
-bool module_was_built_for_debian_or_ubuntu() noexcept {
+bool is_module_built_for_debian_or_ubuntu() noexcept {
   return DD_NGINX_DEBIAN_UBUNTU_BUILD;
 }
 

--- a/src/nginx_package_abi.h
+++ b/src/nginx_package_abi.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <string_view>
+
+namespace datadog::nginx::package_abi {
+
+bool is_debian_or_ubuntu_build(std::string_view version_info) noexcept;
+bool running_nginx_is_debian_or_ubuntu() noexcept;
+bool module_was_built_for_debian_or_ubuntu() noexcept;
+
+}  // namespace datadog::nginx::package_abi

--- a/src/nginx_package_abi.h
+++ b/src/nginx_package_abi.h
@@ -5,7 +5,7 @@
 namespace datadog::nginx::package_abi {
 
 bool is_debian_or_ubuntu_build(std::string_view version_info) noexcept;
-bool running_nginx_is_debian_or_ubuntu() noexcept;
-bool module_was_built_for_debian_or_ubuntu() noexcept;
+bool is_running_nginx_is_debian_or_ubuntu() noexcept;
+bool is_module_built_for_debian_or_ubuntu() noexcept;
 
 }  // namespace datadog::nginx::package_abi

--- a/src/ngx_http_datadog_module.cpp
+++ b/src/ngx_http_datadog_module.cpp
@@ -57,8 +57,13 @@ static char *merge_datadog_loc_conf(ngx_conf_t *, void *parent, void *child) noe
 
 using namespace datadog::nginx;
 
+#if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Winvalid-offsetof"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Winvalid-offsetof"
+#endif
 constexpr datadog::nginx::directive module_directives[] = {
     WARN_DEPRECATED_COMMAND("datadog_enable", anywhere | NGX_CONF_NOARGS,
                             "Use datadog_tracing instead"),
@@ -93,7 +98,11 @@ constexpr datadog::nginx::directive module_directives[] = {
     ALIAS_COMMAND("datadog_agent_url", "opentelemetry_otlp_traces_endpoint",
                   NGX_HTTP_MAIN_CONF | NGX_CONF_TAKE1),
 };
+#if defined(__clang__)
 #pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 static auto datadog_commands =
     generate_directives(tracing_directives, module_directives

--- a/src/ngx_http_datadog_module.cpp
+++ b/src/ngx_http_datadog_module.cpp
@@ -18,6 +18,9 @@
 #include "dd.h"
 #include "defer.h"
 #include "global_tracer.h"
+#if defined(__linux__)
+#include "nginx_package_abi.h"
+#endif
 #include "ngx_logger.h"
 #include "tracing/directives.h"
 #if defined(WITH_WAF)
@@ -194,6 +197,18 @@ static int set_handler(ngx_log_t *log,
 
 static ngx_int_t datadog_master_process_post_config(
     ngx_cycle_t *cycle) noexcept {
+#if defined(__linux__)
+  if (datadog::nginx::package_abi::running_nginx_is_debian_or_ubuntu() &&
+      !datadog::nginx::package_abi::module_was_built_for_debian_or_ubuntu()) {
+    ngx_log_error(
+        NGX_LOG_EMERG, cycle->log, 0,
+        "nginx-datadog: refusing to load an upstream-built module into "
+        "Debian/Ubuntu nginx; rebuild the module against the distribution's "
+        "nginx-dev package or nginx source package");
+    return NGX_ERROR;
+  }
+#endif
+
   ngx_log_error(NGX_LOG_NOTICE, cycle->log, 0, "nginx-datadog status: enabled");
   ngx_log_error(NGX_LOG_NOTICE, cycle->log, 0, "nginx-datadog version: %s (%s)",
                 datadog_semver_nginx_mod, datadog_build_id_nginx_mod);

--- a/src/ngx_http_datadog_module.cpp
+++ b/src/ngx_http_datadog_module.cpp
@@ -10,6 +10,7 @@
 #include <string_view>
 #include <utility>
 
+#include "common/directives.h"
 #include "datadog_conf.h"
 #include "datadog_conf_handler.h"
 #include "datadog_directive.h"
@@ -57,13 +58,7 @@ static char *merge_datadog_loc_conf(ngx_conf_t *, void *parent, void *child) noe
 
 using namespace datadog::nginx;
 
-#if defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Winvalid-offsetof"
-#elif defined(__GNUC__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Winvalid-offsetof"
-#endif
+PRAGMA_PUSH_IGNORE_INVALID_OFFSETOF
 constexpr datadog::nginx::directive module_directives[] = {
     WARN_DEPRECATED_COMMAND("datadog_enable", anywhere | NGX_CONF_NOARGS,
                             "Use datadog_tracing instead"),
@@ -98,11 +93,7 @@ constexpr datadog::nginx::directive module_directives[] = {
     ALIAS_COMMAND("datadog_agent_url", "opentelemetry_otlp_traces_endpoint",
                   NGX_HTTP_MAIN_CONF | NGX_CONF_TAKE1),
 };
-#if defined(__clang__)
-#pragma clang diagnostic pop
-#elif defined(__GNUC__)
-#pragma GCC diagnostic pop
-#endif
+PRAGMA_POP_IGNORE_INVALID_OFFSETOF
 
 static auto datadog_commands =
     generate_directives(tracing_directives, module_directives
@@ -207,8 +198,8 @@ static int set_handler(ngx_log_t *log,
 static ngx_int_t datadog_master_process_post_config(
     ngx_cycle_t *cycle) noexcept {
 #if defined(__linux__)
-  if (datadog::nginx::package_abi::running_nginx_is_debian_or_ubuntu() &&
-      !datadog::nginx::package_abi::module_was_built_for_debian_or_ubuntu()) {
+  if (datadog::nginx::package_abi::is_running_nginx_is_debian_or_ubuntu() &&
+      !datadog::nginx::package_abi::is_module_built_for_debian_or_ubuntu()) {
     ngx_log_error(
         NGX_LOG_EMERG, cycle->log, 0,
         "nginx-datadog: refusing to load an upstream-built module into "

--- a/src/security/directives.h
+++ b/src/security/directives.h
@@ -15,8 +15,13 @@ namespace datadog::nginx::security {
 char *waf_thread_pool_name(ngx_conf_t *cf, ngx_command_t *command,
                            void *conf) noexcept;
 
+#if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Winvalid-offsetof"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Winvalid-offsetof"
+#endif
 constexpr directive kAppsecDirectives[] = {
     {"datadog_waf_thread_pool_name",
      NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF |
@@ -141,7 +146,11 @@ constexpr directive kAppsecDirectives[] = {
         nullptr,
     },
 };
+#if defined(__clang__)
 #pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 #endif  // WITH_WAF
 
 }  // namespace datadog::nginx::security

--- a/src/security/directives.h
+++ b/src/security/directives.h
@@ -15,13 +15,7 @@ namespace datadog::nginx::security {
 char *waf_thread_pool_name(ngx_conf_t *cf, ngx_command_t *command,
                            void *conf) noexcept;
 
-#if defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Winvalid-offsetof"
-#elif defined(__GNUC__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Winvalid-offsetof"
-#endif
+PRAGMA_PUSH_IGNORE_INVALID_OFFSETOF
 constexpr directive kAppsecDirectives[] = {
     {"datadog_waf_thread_pool_name",
      NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF |
@@ -146,11 +140,7 @@ constexpr directive kAppsecDirectives[] = {
         nullptr,
     },
 };
-#if defined(__clang__)
-#pragma clang diagnostic pop
-#elif defined(__GNUC__)
-#pragma GCC diagnostic pop
-#endif
+PRAGMA_POP_IGNORE_INVALID_OFFSETOF
 #endif  // WITH_WAF
 
 }  // namespace datadog::nginx::security

--- a/src/tracing/directives.h
+++ b/src/tracing/directives.h
@@ -45,8 +45,13 @@ char *set_datadog_sample_rate(ngx_conf_t *cf, ngx_command_t *command,
 char *set_datadog_propagation_styles(ngx_conf_t *cf, ngx_command_t *command,
                                      void *conf) noexcept;
 
+#if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Winvalid-offsetof"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Winvalid-offsetof"
+#endif
 constexpr datadog::nginx::directive tracing_directives[] = {
     {
         "datadog_tracing",
@@ -263,6 +268,10 @@ constexpr datadog::nginx::directive tracing_directives[] = {
     WARN_DEPRECATED_COMMAND("datadog_grpc_propagate_context",
                             anywhere | NGX_CONF_NOARGS, nullptr),
 };
+#if defined(__clang__)
 #pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 }  // namespace datadog::nginx

--- a/src/tracing/directives.h
+++ b/src/tracing/directives.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "common/directives.h"
 #include "datadog_conf.h"
 #include "datadog_directive.h"
 
@@ -45,13 +46,7 @@ char *set_datadog_sample_rate(ngx_conf_t *cf, ngx_command_t *command,
 char *set_datadog_propagation_styles(ngx_conf_t *cf, ngx_command_t *command,
                                      void *conf) noexcept;
 
-#if defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Winvalid-offsetof"
-#elif defined(__GNUC__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Winvalid-offsetof"
-#endif
+PRAGMA_PUSH_IGNORE_INVALID_OFFSETOF
 constexpr datadog::nginx::directive tracing_directives[] = {
     {
         "datadog_tracing",
@@ -268,10 +263,6 @@ constexpr datadog::nginx::directive tracing_directives[] = {
     WARN_DEPRECATED_COMMAND("datadog_grpc_propagate_context",
                             anywhere | NGX_CONF_NOARGS, nullptr),
 };
-#if defined(__clang__)
-#pragma clang diagnostic pop
-#elif defined(__GNUC__)
-#pragma GCC diagnostic pop
-#endif
+PRAGMA_POP_IGNORE_INVALID_OFFSETOF
 
 }  // namespace datadog::nginx

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -10,6 +10,10 @@ FetchContent_MakeAvailable(Catch2)
 
 set(UNIT_TEST_SOURCES stub_nginx.c)
 
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    list(APPEND UNIT_TEST_SOURCES nginx_package_abi.cpp)
+endif()
+
 if(NGINX_DATADOG_ASM_ENABLED)
     list(APPEND UNIT_TEST_SOURCES
         json.cpp multipart.cpp urlencoded.cpp test_limiter.cpp client_ip.cpp)

--- a/test/unit/nginx_package_abi.cpp
+++ b/test/unit/nginx_package_abi.cpp
@@ -1,0 +1,60 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <string>
+
+#include "nginx_package_abi.h"
+
+namespace package_abi = datadog::nginx::package_abi;
+
+TEST_CASE("recognize an Ubuntu nginx build") {
+  CHECK(package_abi::is_debian_or_ubuntu_build(
+      "nginx version: nginx/1.28.3 (Ubuntu)"));
+  CHECK(package_abi::is_debian_or_ubuntu_build(
+      "configure arguments: --with-compat --build=Ubuntu"));
+}
+
+TEST_CASE("recognize a Debian nginx build") {
+  constexpr std::string_view version_info = R"(
+nginx version: nginx/1.30.1
+configure arguments:
+--with-cc-opt='-g -O2 -ffile-prefix-map=/build/reproducible-path/nginx-1.30.1=.'
+--prefix=/usr/share/nginx
+--modules-path=/usr/lib/nginx/modules
+--http-client-body-temp-path=/var/lib/nginx/body
+)";
+
+  CHECK(package_abi::is_debian_or_ubuntu_build(version_info));
+}
+
+TEST_CASE("do not mistake a Debian compiler for a Debian nginx package") {
+  constexpr std::string_view version_info = R"(
+nginx version: nginx/1.28.3
+built by gcc 14.2.0 (Debian 14.2.0-19)
+configure arguments: --prefix=/etc/nginx --modules-path=/usr/lib/nginx/modules
+)";
+
+  CHECK_FALSE(package_abi::is_debian_or_ubuntu_build(version_info));
+}
+
+TEST_CASE("require the complete Debian package fingerprint") {
+  constexpr std::string_view build_path =
+      "-ffile-prefix-map=/build/reproducible-path/nginx-1.30.1=.";
+
+  CHECK_FALSE(package_abi::is_debian_or_ubuntu_build(build_path));
+  CHECK_FALSE(package_abi::is_debian_or_ubuntu_build(
+      std::string{build_path} + " --prefix=/usr/share/nginx"));
+  CHECK_FALSE(package_abi::is_debian_or_ubuntu_build(
+      std::string{build_path} + " --prefix=/usr/share/nginx "
+                               "--modules-path=/usr/lib/nginx/modules"));
+}
+
+TEST_CASE("do not identify an upstream nginx build as Debian or Ubuntu") {
+  constexpr std::string_view version_info = R"(
+nginx version: nginx/1.28.3
+configure arguments: --prefix=/etc/nginx
+--modules-path=/usr/lib/nginx/modules
+--http-client-body-temp-path=/var/cache/nginx/client_temp
+)";
+
+  CHECK_FALSE(package_abi::is_debian_or_ubuntu_build(version_info));
+}


### PR DESCRIPTION
Debian/Ubuntu builds have an incompatible ABI, in fact, they seem to break the ABI even after security updates. They also don't respect the nginx convention for detecting ABI compatibility and have their own.

Therefore, reject loading on Debian/Ubuntu builds unless the module was built against Debian/Ubuntu sources (e.g. the nginx-dev package).

Additionally, have the Makefile propagate NGINX_SRC_DIR to cmake and cmake internally propagate it to the docker container.