### PR TITLE
Use latest Nginx version, 1.31.3, in system tests

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -17,7 +17,7 @@ jobs:
       # The Nginx version must match the one in System Tests, in
       # https://github.com/DataDog/system-tests/blob/main/utils/build/docker/cpp_nginx/nginx.Dockerfile#L3,
       # and must be one of the versions built in GitLab CI build-and-test-fast.
-      NGINX_VERSION: 1.29.8
+      NGINX_VERSION: 1.31.3
       WAF: ON
       MIRROR_REGISTRY: ""
     steps:


### PR DESCRIPTION
Following [delivery of Datadog Nginx module v1.21.0](https://github.com/DataDog/nginx-datadog/releases/tag/v1.21.0), which notably adds support to Nginx 1.31.3, and following https://github.com/DataDog/system-tests/pull/7331, update the Nginx version in System Tests to this latest Nginx version.