### PR TITLE
ci: forward BP_EXTERNAL_S3_URL explicitly on benchmark trigger

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -64,10 +64,12 @@ macrobenchmarks:
   needs: []
   trigger:
     include: ".gitlab/benchmarks.yml"
-    # Forward pipeline variables so an external orchestrator can pass
-    # BP_EXTERNAL_S3_URL down to override the S3 destination of benchmark results.
-    forward:
-      pipeline_variables: true
+  variables:
+    # Forward BP_EXTERNAL_S3_URL so an external orchestrator can override the S3 destination.
+    # This avoids 'forward: pipeline_variables: true', which forwards every parent variable and may be unsafe.
+    # When the orchestrator leaves it unset, GitLab forwards the literal '$BP_EXTERNAL_S3_URL' (not empty),
+    # so downstream code must treat that literal as unset.
+    BP_EXTERNAL_S3_URL: $BP_EXTERNAL_S3_URL
   rules:
     - if: $NIGHTLY_BENCHMARKS || $CI_COMMIT_REF_NAME == "master" || $CI_COMMIT_REF_NAME =~ /^release\/v/
       when: always


### PR DESCRIPTION
## Description

Replace `forward: pipeline_variables: true` on the macrobenchmark trigger with an explicit `BP_EXTERNAL_S3_URL: $BP_EXTERNAL_S3_URL` passthrough.

`forward: pipeline_variables: true` was cleaner but passed every parent variable down to the child pipeline, which can be unsafe (a caller could override sensitive child settings such as the clone target, branch, region, or cleanup). Only `BP_EXTERNAL_S3_URL` is forwarded now, via the trigger job's `variables:` block (default `yaml_variables` forwarding). When an orchestrator leaves it unset, GitLab forwards the unexpanded literal `$BP_EXTERNAL_S3_URL`, which downstream code (bp-runner) treats as unset.

## Testing

This was tested when authoring https://github.com/DataDog/dd-trace-py/pull/18955 on dd-trace-py. On that work, I tested the `BP_EXTERNAL_S3_URL: $BP_EXTERNAL_S3_URL` explicit forwarding behavior before switching to `forward: pipeline_variables`.

- CI job used for testing, echoing the substituted env var passed down from an orchestrator: https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-py/-/jobs/1844147454
    - The "orchestrator" is a benchmark stability monitoring pipeline triggered from benchmarking-platform-tools: https://github.com/DataDog/benchmarking-platform-tools/blob/main/scripts/stability/.gitlab/monitor-stability.yml
- Line of code setting the explicit forwarding on that commit: https://github.com/DataDog/dd-trace-py/blob/92dc737fa2a14745f4ab7453b402bfe149c6022f/.gitlab-ci.yml#L189-L190