### PR TITLE
Remove dead NGINX_SRC_DIR export when building for macrobenchmarks CI

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -36,7 +36,6 @@ build-nginx-module:
     BUILD_TYPE: Release
     ARCH: x86_64
   script:
-    - export NGINX_SRC_DIR="$PWD/nginx"
     - make build-musl-aux
   artifacts:
     name: "artifacts"


### PR DESCRIPTION
Since August 11, the `build-nginx-datadog` job of the ‘Nightly macrobenchmarks run’ pipeline fails as follows ([example](https://gitlab.ddbuild.io/DataDog/apm-reliability/nginx-datadog/-/jobs/1955990384)):
```
cd /go/src/github.com/DataDog/apm-reliability/nginx-datadog/nginx && ./configure --add-dynamic-module="/go/src/github.com/DataDog/apm-reliability/nginx-datadog/module/" --add-dynamic-module=/go/src/github.com/DataDog/apm-reliability/nginx-datadog/module/ --with-compat
/bin/sh: cd: line 0: can't cd to /go/src/github.com/DataDog/apm-reliability/nginx-datadog/nginx: No such file or directory
```

This was because the `build-nginx-module` job set `NGINX_SRC_DIR="$PWD/nginx"`, a directory that is never created.

This used to be harmless because the build never passed `NGINX_SRC_DIR` to CMake. But since https://github.com/DataDog/nginx-datadog/pull/412, it now passes `NGINX_SRC_DIR` to CMake. So CMake tries to use the missing folder instead of downloading Nginx itself.

Validation: [successful build on this branch](https://gitlab.ddbuild.io/DataDog/apm-reliability/nginx-datadog/-/pipelines/131282855].

[IDMPL-769 [Nginx] [CI] Nightly macrobenchmarks run broken since August 11](https://datadoghq.atlassian.net/browse/IDMPL-769)