### PR TITLE
Add support for Nginx 1.31.4

### DIFF
--- a/.gitlab/build-and-test-all.yml
+++ b/.gitlab/build-and-test-all.yml
@@ -62,6 +62,7 @@ build-nginx-all:
           - "1.31.1"
           - "1.31.2"
           - "1.31.3"
+          - "1.31.4"
         WAF: ["ON", "OFF"]
 
 build-nginx-rum-all:
@@ -107,6 +108,7 @@ build-nginx-rum-all:
           - "1.31.1"
           - "1.31.2"
           - "1.31.3"
+          - "1.31.4"
         WAF: ["OFF"]
 
 build-ingress-nginx-all:
@@ -254,6 +256,10 @@ test-nginx-all:
         BASE_IMAGE: ["nginx:1.28.3", "nginx:1.28.3-alpine"]
         NGINX_VERSION: ["1.28.3"]
         WAF: ["ON", "OFF"]
+      - ARCH: ["amd64", "arm64"]
+        BASE_IMAGE: ["amazonlinux:2023.11.20260427.1"]
+        NGINX_VERSION: ["1.28.3"]
+        WAF: ["ON", "OFF"]
 
 # GitLab is not able to handle a matrix with more than 200 jobs!
 test-nginx-all-bis:
@@ -335,8 +341,8 @@ test-nginx-all-bis:
         NGINX_VERSION: ["1.31.3"]
         WAF: ["ON", "OFF"]
       - ARCH: ["amd64", "arm64"]
-        BASE_IMAGE: ["amazonlinux:2023.11.20260427.1"]
-        NGINX_VERSION: ["1.28.3"]
+        BASE_IMAGE: ["nginx:1.31.4", "nginx:1.31.4-alpine"]
+        NGINX_VERSION: ["1.31.4"]
         WAF: ["ON", "OFF"]
 
 test-nginx-rum-all:
@@ -484,6 +490,10 @@ test-nginx-rum-all:
       - ARCH: ["amd64", "arm64"]
         BASE_IMAGE: ["nginx:1.31.3"]
         NGINX_VERSION: ["1.31.3"]
+        WAF: ["OFF"]
+      - ARCH: ["amd64", "arm64"]
+        BASE_IMAGE: ["nginx:1.31.4"]
+        NGINX_VERSION: ["1.31.4"]
         WAF: ["OFF"]
 
 test-ingress-nginx-all:

--- a/.gitlab/build-and-test-all.yml
+++ b/.gitlab/build-and-test-all.yml
@@ -27,8 +27,6 @@ build-nginx-all:
     matrix:
       - ARCH: ["amd64", "arm64"]
         NGINX_VERSION:
-          - "1.25.1"
-          - "1.25.2"
           - "1.25.3"
           - "1.25.4"
           - "1.25.5"
@@ -74,8 +72,6 @@ build-nginx-rum-all:
     matrix:
       - ARCH: ["amd64", "arm64"]
         NGINX_VERSION:
-          - "1.25.1"
-          - "1.25.2"
           - "1.25.3"
           - "1.25.4"
           - "1.25.5"
@@ -190,14 +186,6 @@ test-nginx-all:
     - .test-nginx
   parallel:
     matrix:
-      - ARCH: ["amd64", "arm64"]
-        BASE_IMAGE: ["nginx:1.25.1", "nginx:1.25.1-alpine"]
-        NGINX_VERSION: ["1.25.1"]
-        WAF: ["ON", "OFF"]
-      - ARCH: ["amd64", "arm64"]
-        BASE_IMAGE: ["nginx:1.25.2", "nginx:1.25.2-alpine"]
-        NGINX_VERSION: ["1.25.2"]
-        WAF: ["ON", "OFF"]
       - ARCH: ["amd64", "arm64"]
         BASE_IMAGE: ["nginx:1.25.3", "nginx:1.25.3-alpine"]
         NGINX_VERSION: ["1.25.3"]
@@ -357,14 +345,6 @@ test-nginx-rum-all:
     - .test-nginx-rum
   parallel:
     matrix:
-      - ARCH: ["amd64", "arm64"]
-        BASE_IMAGE: ["nginx:1.25.1"]
-        NGINX_VERSION: ["1.25.1"]
-        WAF: ["OFF"]
-      - ARCH: ["amd64", "arm64"]
-        BASE_IMAGE: ["nginx:1.25.2"]
-        NGINX_VERSION: ["1.25.2"]
-        WAF: ["OFF"]
       - ARCH: ["amd64", "arm64"]
         BASE_IMAGE: ["nginx:1.25.3"]
         NGINX_VERSION: ["1.25.3"]

--- a/.gitlab/build-and-test-fast.yml
+++ b/.gitlab/build-and-test-fast.yml
@@ -85,6 +85,7 @@ build-nginx-fast:
           - "1.29.8"
           - "1.30.4"
           - "1.31.3"
+          - "1.31.4"
         WAF: ["ON", "OFF"]
 
 build-nginx-asan-fast:
@@ -93,7 +94,7 @@ build-nginx-asan-fast:
     - .build-nginx-asan
   variables:
     ARCH: "amd64"
-    NGINX_VERSION: "1.31.3"
+    NGINX_VERSION: "1.31.4"
     WAF: "ON"
 
 build-nginx-msan-fast:
@@ -102,7 +103,7 @@ build-nginx-msan-fast:
     - .build-nginx-msan
   variables:
     ARCH: "amd64"
-    NGINX_VERSION: "1.31.3"
+    NGINX_VERSION: "1.31.4"
     WAF: "ON"
 
 build-ingress-nginx-fast:
@@ -144,7 +145,7 @@ build-nginx-rum-fast:
           - "1.28.3"
           - "1.29.8"
           - "1.30.4"
-          - "1.31.3"
+          - "1.31.4"
         WAF: ["OFF"]
 
 test-nginx-fast:
@@ -183,6 +184,10 @@ test-nginx-fast:
         NGINX_VERSION: ["1.31.3"]
         WAF: ["ON", "OFF"]
       - ARCH: ["amd64", "arm64"]
+        BASE_IMAGE: ["nginx:1.31.4", "nginx:1.31.4-alpine"]
+        NGINX_VERSION: ["1.31.4"]
+        WAF: ["ON", "OFF"]
+      - ARCH: ["amd64", "arm64"]
         BASE_IMAGE: ["amazonlinux:2023.11.20260427.1"]
         NGINX_VERSION: ["1.28.3"]
         WAF: ["ON", "OFF"]
@@ -195,7 +200,7 @@ test-nginx-asan-fast:
     - build-nginx-asan-fast
   variables:
     ARCH: "amd64"
-    NGINX_VERSION: "1.31.3"
+    NGINX_VERSION: "1.31.4"
     WAF: "ON"
 
 test-nginx-msan-fast:
@@ -206,7 +211,7 @@ test-nginx-msan-fast:
     - build-nginx-msan-fast
   variables:
     ARCH: "amd64"
-    NGINX_VERSION: "1.31.3"
+    NGINX_VERSION: "1.31.4"
     WAF: "ON"
 
 test-ingress-nginx-fast:
@@ -268,8 +273,8 @@ test-nginx-rum-fast:
         NGINX_VERSION: ["1.30.4"]
         WAF: ["OFF"]
       - ARCH: ["amd64", "arm64"]
-        BASE_IMAGE: ["nginx:1.31.3"]
-        NGINX_VERSION: ["1.31.3"]
+        BASE_IMAGE: ["nginx:1.31.4"]
+        NGINX_VERSION: ["1.31.4"]
         WAF: ["OFF"]
 
 coverage:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 cmake_policy(SET CMP0068 NEW)
 cmake_policy(SET CMP0135 NEW)
 
-set(NGINX_DATADOG_VERSION 1.21.0)
+set(NGINX_DATADOG_VERSION 1.22.0)
 project(ngx_http_datadog_module VERSION ${NGINX_DATADOG_VERSION})
 
 option(NGINX_DATADOG_ASM_ENABLED "Build with libddwaf" ON)


### PR DESCRIPTION
Add support for [Nginx 1.31.4](https://github.com/nginx/nginx/releases#release-release-1.31.4).

By the way, remove support for Nginx 1.25.1 and 1.25.2 (because [Nginx Plus R30 reached end of technical support on August 14, 2025](https://docs.nginx.com/nginx/releases#end-of-life-eol-releases)).