### PR TITLE
Disable code using ngx_http_request_s.terminated for Nginx < 1.25.4

### DIFF
--- a/.gitlab/build-and-test-all.yml
+++ b/.gitlab/build-and-test-all.yml
@@ -9,8 +9,7 @@ include:
   rules:
     - if: $CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+/
       when: always
-    - when: manual
-      allow_failure: true
+    - when: never
 
 .build-all:
   extends: .build-and-test-all

--- a/.gitlab/build-and-test-all.yml
+++ b/.gitlab/build-and-test-all.yml
@@ -9,7 +9,8 @@ include:
   rules:
     - if: $CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+/
       when: always
-    - when: never
+    - when: manual
+      allow_failure: true
 
 .build-all:
   extends: .build-and-test-all

--- a/src/security/context.cpp
+++ b/src/security/context.cpp
@@ -304,20 +304,22 @@ class PolTaskCtx {
     std::memcpy(self_copy_storage, this, sizeof(Self));
     Self *self_copy = reinterpret_cast<Self *>(self_copy_storage);
 
+#if nginx_version >= 1025004
+    // The ngx_http_request_s.terminated flag was introduced in Nginx 1.25.4.
+    // TODO: remove this pre-compilation test when dropping support for 1.25.3.
     if (req_.main->terminated) {
       ngx_log_debug(NGX_LOG_DEBUG_HTTP, req_log(), 0,
                     "request was terminated while task %p was active; "
                     "running the connection write handler",
                     &get_task());
-
       req_.main->count--;
       ngx_event_t *write_event = req_.connection->write;
       write_event->handler(write_event);
-
       // The request pool may have been destroyed by the write handler.
       self_copy->~Self();
       return;
     }
+#endif
 
     if (count > 1) {
       // ngx_del_event(connection->read, NGX_READ_EVENT, 0) may've been called


### PR DESCRIPTION
https://github.com/DataDog/nginx-datadog/pull/410 introduced a usage of the `ngx_http_request_s.terminated` flag. But this flag was introduced in Nginx 1.25.4. So this code does not compile with Nginx 1.25.3:
```
/go/src/github.com/DataDog/apm-reliability/nginx-datadog/src/security/context.cpp:307:20: error: no member named 'terminated' in 'ngx_http_request_s'
  307 |     if (req_.main->terminated) {
      |         ~~~~~~~~~  ^
```

Since the bug this recent code fixes is rare, and since [we will drop the support of Nginx 1.25.3 in December 2026
](https://docs.nginx.com/nginx/releases#end-of-life-eol-releases), the simplest solution applied is to disable this code for Nginx < 1.25.4.

Successful build and test jobs validating the fix:
- [build-nginx-all: [amd64, 1.25.3, ON]](https://gitlab.ddbuild.io/DataDog/apm-reliability/nginx-datadog/-/jobs/1971995842)
- [build-nginx-all: [arm64, 1.25.3, ON]](https://gitlab.ddbuild.io/DataDog/apm-reliability/nginx-datadog/-/jobs/1971995932)
- [build-openresty-all: [amd64, 1.25.3.1, ON]](https://gitlab.ddbuild.io/DataDog/apm-reliability/nginx-datadog/-/jobs/1971996220)
- [build-openresty-all: [arm64, 1.25.3.1, ON]](https://gitlab.ddbuild.io/DataDog/apm-reliability/nginx-datadog/-/jobs/1971996245)
- [build-openresty-all: [amd64, 1.25.3.2, ON]](https://gitlab.ddbuild.io/DataDog/apm-reliability/nginx-datadog/-/jobs/1971996222)
- [build-openresty-all: [arm64, 1.25.3.2, ON]](https://gitlab.ddbuild.io/DataDog/apm-reliability/nginx-datadog/-/jobs/1971996249)
- [test-nginx-all: [amd64, nginx:1.25.3, 1.25.3, ON]](https://gitlab.ddbuild.io/DataDog/apm-reliability/nginx-datadog/-/jobs/1971996316)
- [test-nginx-all: [arm64, nginx:1.25.3, 1.25.3, ON]](https://gitlab.ddbuild.io/DataDog/apm-reliability/nginx-datadog/-/jobs/1971996327)
- [test-nginx-all: [amd64, nginx:1.25.3-alpine, 1.25.3, ON]](https://gitlab.ddbuild.io/DataDog/apm-reliability/nginx-datadog/-/jobs/1971996322)
- [test-nginx-all: [arm64, nginx:1.25.3-alpine, 1.25.3, ON]](https://gitlab.ddbuild.io/DataDog/apm-reliability/nginx-datadog/-/jobs/1971996332)
- [test-openresty-all: [amd64, 1.25.3.1, ON]](https://gitlab.ddbuild.io/DataDog/apm-reliability/nginx-datadog/-/jobs/1971997082)
- [test-openresty-all: [amd64, 1.25.3.2, ON]](https://gitlab.ddbuild.io/DataDog/apm-reliability/nginx-datadog/-/jobs/1971997086)

Jira ticket: [IDMPL-816 [Nginx] WAF not compiling anymore with Nginx 1.25.3](https://datadoghq.atlassian.net/browse/IDMPL-816)