### PR TITLE
feat(telemetry): report AppSec state at startup

### DIFF
--- a/src/security/library.cpp
+++ b/src/security/library.cpp
@@ -715,6 +715,7 @@ std::optional<ddwaf_owned_map> Library::initialize_security_library(
 
   if (conf.enable_status() ==
       FinalizedConfigSettings::enable_status::DISABLED) {
+    Library::set_active(false);
     ngx_log_error(NGX_LOG_INFO, ngx_cycle->log, 0,
                   "datadog security library is explicitly disabled");
     return std::nullopt;

--- a/src/tracing_library.cpp
+++ b/src/tracing_library.cpp
@@ -5,6 +5,7 @@
 #include <datadog/error.h>
 #include <datadog/expected.h>
 #include <datadog/span.h>
+#include <datadog/telemetry/product.h>
 #include <datadog/tracer.h>
 #include <datadog/tracer_config.h>
 #include <rapidjson/document.h>
@@ -29,6 +30,7 @@ extern "C" {
 #endif
 #include "nginx_flavors.h"
 #include "string_util.h"
+#include "version.h"
 
 namespace datadog {
 namespace nginx {
@@ -120,6 +122,14 @@ dd::Expected<dd::Tracer> TracingLibrary::make_tracer(
   }
 
 #ifdef WITH_WAF
+  config.telemetry.products.emplace_back(
+      datadog::telemetry::Product{datadog::telemetry::Product::Name::appsec,
+                                  security::Library::active(),
+                                  datadog_semver_nginx_mod,
+                                  {},
+                                  {},
+                                  {}});
+
   const bool appsec_fully_disabled = (nginx_conf.appsec_enabled == 0);
   if (!appsec_fully_disabled) {
     const bool has_custom_ruleset = (nginx_conf.appsec_ruleset_file.len > 0);


### PR DESCRIPTION
## Summary

- register the AppSec product in `app-started` telemetry for WAF-enabled builds
- report the state owned by `security::Library` and the nginx module version
- clear stale active state when AppSec is explicitly disabled

## Dependency

Depends on DataDog/dd-trace-cpp#365, which fixes serialization of registered telemetry products.

## Validation

- WAF-enabled CMake build of the changed objects
- `unit_tests`: passed
- native NGINX telemetry capture with AppSec disabled: `enabled=false`, `version=1.22.0`
- native NGINX telemetry capture with AppSec enabled: `enabled=true`, `version=1.22.0`
- clangd diagnostics: clean