### PR TITLE
Add support for Nginx 1.31.5

### DIFF
--- a/.gitlab/build-and-test-all.yml
+++ b/.gitlab/build-and-test-all.yml
@@ -63,6 +63,7 @@ build-nginx-all:
           - "1.31.2"
           - "1.31.3"
           - "1.31.4"
+          - "1.31.5"
         WAF: ["ON", "OFF"]
 
 build-nginx-rum-all:
@@ -109,6 +110,7 @@ build-nginx-rum-all:
           - "1.31.2"
           - "1.31.3"
           - "1.31.4"
+          - "1.31.5"
         WAF: ["OFF"]
 
 build-ingress-nginx-all:
@@ -344,6 +346,10 @@ test-nginx-all-bis:
         BASE_IMAGE: ["nginx:1.31.4", "nginx:1.31.4-alpine"]
         NGINX_VERSION: ["1.31.4"]
         WAF: ["ON", "OFF"]
+      - ARCH: ["amd64", "arm64"]
+        BASE_IMAGE: ["nginx:1.31.5", "nginx:1.31.5-alpine"]
+        NGINX_VERSION: ["1.31.5"]
+        WAF: ["ON", "OFF"]
 
 test-nginx-rum-all:
   extends:
@@ -494,6 +500,10 @@ test-nginx-rum-all:
       - ARCH: ["amd64", "arm64"]
         BASE_IMAGE: ["nginx:1.31.4"]
         NGINX_VERSION: ["1.31.4"]
+        WAF: ["OFF"]
+      - ARCH: ["amd64", "arm64"]
+        BASE_IMAGE: ["nginx:1.31.5"]
+        NGINX_VERSION: ["1.31.5"]
         WAF: ["OFF"]
 
 test-ingress-nginx-all:

--- a/.gitlab/build-and-test-fast.yml
+++ b/.gitlab/build-and-test-fast.yml
@@ -85,7 +85,7 @@ build-nginx-fast:
           - "1.29.8"
           - "1.30.4"
           - "1.31.3"
-          - "1.31.4"
+          - "1.31.5"
         WAF: ["ON", "OFF"]
 
 build-nginx-asan-fast:
@@ -94,7 +94,7 @@ build-nginx-asan-fast:
     - .build-nginx-asan
   variables:
     ARCH: "amd64"
-    NGINX_VERSION: "1.31.4"
+    NGINX_VERSION: "1.31.5"
     WAF: "ON"
 
 build-nginx-msan-fast:
@@ -103,7 +103,7 @@ build-nginx-msan-fast:
     - .build-nginx-msan
   variables:
     ARCH: "amd64"
-    NGINX_VERSION: "1.31.4"
+    NGINX_VERSION: "1.31.5"
     WAF: "ON"
 
 build-ingress-nginx-fast:
@@ -145,7 +145,7 @@ build-nginx-rum-fast:
           - "1.28.3"
           - "1.29.8"
           - "1.30.4"
-          - "1.31.4"
+          - "1.31.5"
         WAF: ["OFF"]
 
 test-nginx-fast:
@@ -184,8 +184,8 @@ test-nginx-fast:
         NGINX_VERSION: ["1.31.3"]
         WAF: ["ON", "OFF"]
       - ARCH: ["amd64", "arm64"]
-        BASE_IMAGE: ["nginx:1.31.4", "nginx:1.31.4-alpine"]
-        NGINX_VERSION: ["1.31.4"]
+        BASE_IMAGE: ["nginx:1.31.5", "nginx:1.31.5-alpine"]
+        NGINX_VERSION: ["1.31.5"]
         WAF: ["ON", "OFF"]
       - ARCH: ["amd64", "arm64"]
         BASE_IMAGE: ["amazonlinux:2023.11.20260427.1"]
@@ -200,7 +200,7 @@ test-nginx-asan-fast:
     - build-nginx-asan-fast
   variables:
     ARCH: "amd64"
-    NGINX_VERSION: "1.31.4"
+    NGINX_VERSION: "1.31.5"
     WAF: "ON"
 
 test-nginx-msan-fast:
@@ -211,7 +211,7 @@ test-nginx-msan-fast:
     - build-nginx-msan-fast
   variables:
     ARCH: "amd64"
-    NGINX_VERSION: "1.31.4"
+    NGINX_VERSION: "1.31.5"
     WAF: "ON"
 
 test-ingress-nginx-fast:
@@ -273,8 +273,8 @@ test-nginx-rum-fast:
         NGINX_VERSION: ["1.30.4"]
         WAF: ["OFF"]
       - ARCH: ["amd64", "arm64"]
-        BASE_IMAGE: ["nginx:1.31.4"]
-        NGINX_VERSION: ["1.31.4"]
+        BASE_IMAGE: ["nginx:1.31.5"]
+        NGINX_VERSION: ["1.31.5"]
         WAF: ["OFF"]
 
 coverage:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 cmake_policy(SET CMP0068 NEW)
 cmake_policy(SET CMP0135 NEW)
 
-set(NGINX_DATADOG_VERSION 1.22.0)
+set(NGINX_DATADOG_VERSION 1.23.0)
 project(ngx_http_datadog_module VERSION ${NGINX_DATADOG_VERSION})
 
 option(NGINX_DATADOG_ASM_ENABLED "Build with libddwaf" ON)

--- a/doc/ingress-nginx.md
+++ b/doc/ingress-nginx.md
@@ -1,4 +1,4 @@
-# Ingress-nginx Rupport for Datadog
+# Ingress-nginx Support for Datadog
 
 [Ingress-nginx](https://github.com/kubernetes/ingress-nginx) is one of the [Kubernetes ingress
 controller](https://kubernetes.io/docs/concepts/services-networking/ingress/) that uses Nginx as a


### PR DESCRIPTION
- Add support for [Nginx 1.31.5](https://github.com/nginx/nginx/releases#release-release-1.31.5).
- Bump version to `1.23.0` to prepare delivery.