### PR TITLE
Increase SLO following baseline degradation

### DIFF
--- a/.gitlab/bp-runner.fail-on-breach.yml
+++ b/.gitlab/bp-runner.fail-on-breach.yml
@@ -13,5 +13,5 @@ experiments:
               - throughput > 3700 op/s
           - name: normal_operation/only-tracing
             thresholds:
-              - threshold: agg_http_req_duration_p50 < 0.119 ms
+              - threshold: agg_http_req_duration_p50 < 0.122 ms
                 warning_range: 2


### PR DESCRIPTION
Since August 28th, the baseline p50 latency got a 4% degradation. The tracing p50 latency got the same degradation. See [Benchmarking Platform | C++](https://ddstaging.datadoghq.com/dashboard/uc8-pup-pkt?fromUser=true&refresh_mode=paused&from_ts=1787356800000&to_ts=1788652799999&live=false):
- p50 latency baseline was 95 μs; it is now 99 μs.
- p50 latency with tracing was 114 μs; it is now 118 μs.
<img width="481" height="276" alt="image" src="https://github.com/user-attachments/assets/767b280d-9bb1-455a-adc4-4a1b594430ca" />

Thus, this PR updates accordingly the SLO threshold.

Jira ticket: [IDMPL-919 [Nginx] Performance benchmarks: update SLO following baseline degradation](https://datadoghq.atlassian.net/browse/IDMPL-919).