### PR TITLE
Move to the public musl-build-env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,27 +52,22 @@ IN_DOCKER_OR_CI := $(shell if [ "$(IN_DOCKER)" = "true" ] || \
 
 # ----- Docker Images
 
-BUILD_IMAGE := nginx_musl_toolchain
+BUILD_IMAGE_DIGEST := sha256:6fbb23a5089853eea7cd26dfaeded4e6541027927016fb1ccdaf2d6713da5c26
 CI_REGISTRY := registry.ddbuild.io/ci/nginx-datadog
-CI_BUILD_IMAGE := $(CI_REGISTRY)/$(BUILD_IMAGE)
 CI_TEST_IMAGE := $(CI_REGISTRY)/test
 UWSGI_TEST_IMAGE := $(CI_REGISTRY)/uwsgi
 
 FORMATTER_IMAGE ?= nginx-datadog-formatter
 
 # On GitLab, we get the Docker images from registry.ddbuild.io.
-# Locally, we build them before using them in some targets via $(TOOLCHAIN_DEPENDENCY) and $(TEST_DEPENDENCY).
+# Locally, we build them before using them in some targets via $(TEST_DEPENDENCY).
 ifdef GITLAB_CI
-	TOOLCHAIN_DEPENDENCY :=
+	BUILD_IMAGE := registry.ddbuild.io/ci/musl-toolchain-glibc-support/musl-build-env@$(BUILD_IMAGE_DIGEST)
 	TEST_DEPENDENCY :=
 else
-	TOOLCHAIN_DEPENDENCY := build-local-musl-toolchain
+	BUILD_IMAGE := docker.io/datadog/musl-build-env@$(BUILD_IMAGE_DIGEST)
 	TEST_DEPENDENCY := build-local-uwsgi-test-image
 endif
-
-.PHONY: build-local-musl-toolchain
-build-local-musl-toolchain:
-	docker build --progress=plain --platform $(DOCKER_PLATFORM) --build-arg ARCH=$(ARCH) $(if $(filter environment command,$(origin MIRROR_REGISTRY)),--build-arg MIRROR_REGISTRY=$(MIRROR_REGISTRY),) -t $(BUILD_IMAGE) build_env
 
 .PHONY: build-local-uwsgi-test-image
 build-local-uwsgi-test-image:
@@ -81,11 +76,7 @@ build-local-uwsgi-test-image:
 # build-push-images-for-CI must be run, once, from a developer machine, to put in registry.ddbuild.io the needed Docker images.
 # Once done, update the sha256 digest in .gitlab/common.yml.
 .PHONY: build-push-images-for-CI
-build-push-images-for-CI: build-push-musl-toolchain build-push-test-image build-push-uwsgi-test-image
-
-.PHONY: build-push-musl-toolchain
-build-push-musl-toolchain:
-	$(call build-push-multiarch,$(CI_BUILD_IMAGE),build_env)
+build-push-images-for-CI: build-push-test-image build-push-uwsgi-test-image
 
 .PHONY: build-push-test-image
 build-push-test-image:
@@ -178,7 +169,7 @@ build: dd-trace-cpp-deps
 	@echo 'build successful 👍'
 
 .PHONY: build-musl build-musl-cov
-build-musl build-musl-cov: $(TOOLCHAIN_DEPENDENCY)
+build-musl build-musl-cov:
 ifndef NGINX_VERSION
 	$(error NGINX_VERSION is not set. Please set the NGINX_VERSION environment variable)
 endif
@@ -222,7 +213,7 @@ build-musl-aux build-musl-cov-aux:
 NGINX_VERSION ?= $(if $(RESTY_VERSION),$(shell echo $(RESTY_VERSION) | awk -F. '{print $$1"."$$2"."$$3}'))
 BUILD_OPENRESTY_COMMAND := ./bin/openresty/build_openresty.sh && make build-openresty-aux
 .PHONY: build-openresty
-build-openresty: $(TOOLCHAIN_DEPENDENCY)
+build-openresty:
 ifndef RESTY_VERSION
 	$(error RESTY_VERSION is not set. Please set the RESTY_VERSION environment variable)
 endif
@@ -255,7 +246,7 @@ build-openresty-aux:
 # --- Ingress Nginx
 
 .PHONY: build-ingress-nginx
-build-ingress-nginx: $(TOOLCHAIN_DEPENDENCY)
+build-ingress-nginx:
 ifndef INGRESS_NGINX_VERSION
 	$(error INGRESS_NGINX_VERSION is not set. Please set the INGRESS_NGINX_VERSION environment variable)
 endif


### PR DESCRIPTION
With https://hub.docker.com/r/datadog/musl-build-env/tags now public, we can move to it.